### PR TITLE
test/docs: CachingGraphOperations 테스트 추가 및 README/KDoc 강화

### DIFF
--- a/graph/graph-age/README.ko.md
+++ b/graph/graph-age/README.ko.md
@@ -792,6 +792,43 @@ GraphVertex(
 )
 ```
 
+## 캐싱 데코레이터
+
+`CachingAgeGraphOperations`는 `AgeGraphOperations`를 `ConcurrentHashMap` 기반 캐시로 감싸는 데코레이터입니다.
+읽기 결과를 메모이제이션하여 캐시 히트 시 DB 호출을 ~5 ns 조회로 대체합니다.
+반복 읽기가 많은 벤치마크 및 워크로드에 적합합니다.
+
+### 캐시 동작
+
+| 연산 | 효과 |
+|------|------|
+| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | 첫 번째 호출 시 DB 조회 후 캐시 저장, 이후 호출은 캐시 히트 |
+| `createVertex`, `createEdge` | 동일 인자 반복 호출 시 이전 결과 반환 (쓰기 메모이제이션). 읽기 캐시는 무효화, 쓰기 캐시는 보존 |
+| `updateVertex`, `deleteVertex`, `deleteEdge` | 읽기·쓰기 캐시 전체 무효화 |
+
+> **프로덕션 주의**: 쓰기 메모이제이션으로 인해 동일 인자로 `createVertex`를 반복 호출해도 DB 레코드가 추가 생성되지 않습니다.
+> 트랜잭션 기반 insert 의미가 필요한 경우 `AgeGraphOperations`를 직접 사용하세요.
+
+### 사용 예제
+
+```kotlin
+Database.connect(dataSource)
+val baseOps = AgeGraphOperations("my_graph")
+
+// 캐싱 데코레이터로 감싸기
+val ops = CachingAgeGraphOperations(baseOps)
+
+// 첫 번째 조회: DB 호출 (JDBC 라운드트립)
+val alice = ops.findVertexById("Person", aliceId)
+
+// 두 번째 조회: 캐시 히트 (~5 ns)
+val aliceCached = ops.findVertexById("Person", aliceId)
+
+// 쓰기 후 자동 캐시 무효화
+ops.deleteVertex("Person", aliceId)
+val afterDelete = ops.findVertexById("Person", aliceId)  // null (캐시 미스 → DB 재조회)
+```
+
 ## 주의사항
 
 ### ID 타입

--- a/graph/graph-age/README.md
+++ b/graph/graph-age/README.md
@@ -33,6 +33,7 @@ graph TD
 |-------|-------------|
 | `AgeGraphOperations` | Synchronous `GraphOperations` implementation backed by Exposed + JDBC |
 | `AgeGraphSuspendOperations` | Coroutine-based `GraphSuspendOperations` implementation |
+| `CachingAgeGraphOperations` | `ConcurrentHashMap`-backed caching decorator over `AgeGraphOperations` |
 | `AgeSql` | Produces SQL strings that wrap Cypher queries for Apache AGE |
 | `AgePropertySerializer` | Serializes Kotlin values into AGE-compatible literals |
 | `AgeTypeParser` | Parses `agtype` results into `GraphVertex`, `GraphEdge`, and `GraphPath` |
@@ -93,6 +94,40 @@ val path = ops.shortestPath(alice.id, bob.id, edgeLabel = "KNOWS", maxDepth = 5)
 
 // Neighbors
 val neighbors = ops.neighbors(alice.id, edgeLabel = "KNOWS", direction = Direction.OUTGOING)
+```
+
+## Caching Decorator
+
+`CachingAgeGraphOperations` wraps an `AgeGraphOperations` instance and memoizes all read results using `ConcurrentHashMap` (~5 ns lookup). It is designed for read-heavy workloads such as benchmarks or repeated graph traversals.
+
+### Cache Behaviour
+
+| Operation | Effect |
+|-----------|--------|
+| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | Results cached on first call; subsequent calls return the cached value without hitting the DB |
+| `createVertex`, `createEdge` | Write-result memoization: same arguments return the same object. Read caches are invalidated; write caches are preserved |
+| `updateVertex`, `deleteVertex`, `deleteEdge` | All caches (read + write) invalidated |
+
+> **Production note**: write-result memoization means repeated `createVertex` calls with the same arguments do not create additional DB records. Use `AgeGraphOperations` directly when transactional insert semantics are required.
+
+### Usage Example
+
+```kotlin
+Database.connect(dataSource)
+val baseOps = AgeGraphOperations("my_graph")
+
+// Wrap with caching decorator
+val ops = CachingAgeGraphOperations(baseOps)
+
+// First call: DB query (JDBC round-trip)
+val alice = ops.findVertexById("Person", aliceId)
+
+// Second call: cache hit (~5 ns), no DB round-trip
+val aliceCached = ops.findVertexById("Person", aliceId)
+
+// Any write invalidates all read caches automatically
+ops.deleteVertex("Person", aliceId)
+val afterDelete = ops.findVertexById("Person", aliceId)  // null (cache miss → DB)
 ```
 
 ## Notes

--- a/graph/graph-age/build.gradle.kts
+++ b/graph/graph-age/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     testImplementation(Libs.bluetape4k_testcontainers)
     testImplementation(Libs.testcontainers_postgresql)
     testImplementation(Libs.hikaricp)
+    testImplementation(Libs.mockk)
 }

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperations.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperations.kt
@@ -25,9 +25,36 @@ import java.util.concurrent.ConcurrentHashMap
  * 그대로 반환한다. 이는 벤치마크/테스트용 편의 기능이며, 트랜잭션 기반 insert 의미가 필요한
  * 프로덕션 코드는 [AgeGraphOperations]를 직접 사용해야 한다.
  *
- * Round 8 변경사항: 모든 읽기 캐시를 Caffeine → ConcurrentHashMap 으로 교체.
- * TinyLFU 북키핑 비용을 제거하여 lookup latency 를 ~13-15 ns → ~5 ns 로 단축.
- * TTL/maxSize 기반 축출은 제거되었고, 쓰기 시 명시적 clear() 로 일관성을 유지한다.
+ * 모든 읽기 캐시는 Caffeine → ConcurrentHashMap 으로 구현되어 TinyLFU 북키핑 비용을 제거하고
+ * lookup latency 를 ~13-15 ns → ~5 ns 로 단축한다. TTL/maxSize 기반 축출은 제거되었고,
+ * 쓰기 시 명시적 clear() 로 일관성을 유지한다.
+ *
+ * ### 사용 예제
+ * ```kotlin
+ * val dataSource = HikariDataSource(HikariConfig().apply {
+ *     jdbcUrl = "jdbc:postgresql://localhost:5432/postgres"
+ *     username = "postgres"
+ *     password = "postgres"
+ *     connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+ * })
+ * Database.connect(dataSource)
+ * val baseOps = AgeGraphOperations("my_graph")
+ *
+ * // 캐싱 래퍼로 감싸기 (벤치마크/반복 읽기가 많은 워크로드에 적합)
+ * val ops = CachingAgeGraphOperations(baseOps)
+ *
+ * // 첫 번째 조회: DB 호출 발생
+ * val alice = ops.findVertexById("Person", aliceId)
+ *
+ * // 두 번째 조회: 캐시 히트 (~5 ns), DB 호출 없음
+ * val aliceCached = ops.findVertexById("Person", aliceId)
+ *
+ * // 정점 삭제: 모든 캐시 자동 무효화
+ * ops.deleteVertex("Person", aliceId)
+ *
+ * // 삭제 후 조회: 캐시 미스 → DB 재조회
+ * val afterDelete = ops.findVertexById("Person", aliceId)  // null
+ * ```
  */
 class CachingAgeGraphOperations(
     private val delegate: AgeGraphOperations,

--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperationsTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperationsTest.kt
@@ -1,0 +1,282 @@
+package io.bluetape4k.graph.age
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.model.PathStep
+import io.bluetape4k.logging.KLogging
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [CachingAgeGraphOperations] 의 캐시 히트·무효화·Write 메모이제이션 동작을 검증한다.
+ *
+ * MockK 로 delegate 를 모킹하여 delegate 호출 횟수를 정확히 검증한다.
+ * 실제 PostgreSQL AGE 서버 없이 순수 캐시 레이어만 테스트한다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CachingAgeGraphOperationsTest {
+
+    companion object : KLogging()
+
+    private lateinit var delegate: AgeGraphOperations
+    private lateinit var caching: CachingAgeGraphOperations
+
+    private val aliceId = GraphElementId.of("alice-1")
+    private val bobId = GraphElementId.of("bob-1")
+    private val edgeId = GraphElementId.of("edge-1")
+
+    private val alice = GraphVertex(aliceId, "Person", mapOf("name" to "Alice"))
+    private val bob = GraphVertex(bobId, "Person", mapOf("name" to "Bob"))
+    private val edge = GraphEdge(edgeId, "KNOWS", aliceId, bobId)
+    private val path = GraphPath(
+        listOf(
+            PathStep.VertexStep(alice),
+            PathStep.EdgeStep(edge),
+            PathStep.VertexStep(bob),
+        )
+    )
+
+    @BeforeEach
+    fun setup() {
+        delegate = mockk(relaxed = true)
+        caching = CachingAgeGraphOperations(delegate)
+    }
+
+    // ───── findVertexById 캐싱 ─────
+
+    @Test
+    fun `findVertexById는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns alice
+
+        val first = caching.findVertexById("Person", aliceId)
+        val second = caching.findVertexById("Person", aliceId)
+
+        first shouldBeEqualTo alice
+        second shouldBeEqualTo alice
+        verify(exactly = 1) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `findVertexById는 null 결과도 캐시하여 delegate를 1회만 호출한다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns null
+
+        val first = caching.findVertexById("Person", aliceId)
+        val second = caching.findVertexById("Person", aliceId)
+
+        first.shouldBeNull()
+        second.shouldBeNull()
+        verify(exactly = 1) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    // ───── findVerticesByLabel 캐싱 ─────
+
+    @Test
+    fun `findVerticesByLabel는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val vertices = listOf(alice, bob)
+        every { delegate.findVerticesByLabel("Person", emptyMap()) } returns vertices
+
+        val first = caching.findVerticesByLabel("Person")
+        val second = caching.findVerticesByLabel("Person")
+
+        first shouldBeEqualTo vertices
+        second shouldBeEqualTo vertices
+        verify(exactly = 1) { delegate.findVerticesByLabel("Person", emptyMap()) }
+    }
+
+    @Test
+    fun `findVerticesByLabel는 filter 포함 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val filter = mapOf("name" to "Alice")
+        every { delegate.findVerticesByLabel("Person", filter) } returns listOf(alice)
+
+        val first = caching.findVerticesByLabel("Person", filter)
+        val second = caching.findVerticesByLabel("Person", filter)
+
+        first shouldBeEqualTo listOf(alice)
+        second shouldBeEqualTo listOf(alice)
+        verify(exactly = 1) { delegate.findVerticesByLabel("Person", filter) }
+    }
+
+    // ───── neighbors 캐싱 ─────
+
+    @Test
+    fun `neighbors는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = NeighborOptions.Default
+        every { delegate.neighbors(aliceId, opts) } returns listOf(bob)
+
+        val first = caching.neighbors(aliceId, opts)
+        val second = caching.neighbors(aliceId, opts)
+
+        first shouldBeEqualTo listOf(bob)
+        second shouldBeEqualTo listOf(bob)
+        verify(exactly = 1) { delegate.neighbors(aliceId, opts) }
+    }
+
+    // ───── shortestPath 캐싱 ─────
+
+    @Test
+    fun `shortestPath는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.shortestPath(aliceId, bobId, opts) } returns path
+
+        val first = caching.shortestPath(aliceId, bobId, opts)
+        val second = caching.shortestPath(aliceId, bobId, opts)
+
+        first shouldBeEqualTo path
+        second shouldBeEqualTo path
+        verify(exactly = 1) { delegate.shortestPath(aliceId, bobId, opts) }
+    }
+
+    @Test
+    fun `shortestPath는 null 결과도 캐시하여 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.shortestPath(aliceId, bobId, opts) } returns null
+
+        val first = caching.shortestPath(aliceId, bobId, opts)
+        val second = caching.shortestPath(aliceId, bobId, opts)
+
+        first.shouldBeNull()
+        second.shouldBeNull()
+        verify(exactly = 1) { delegate.shortestPath(aliceId, bobId, opts) }
+    }
+
+    // ───── allPaths 캐싱 ─────
+
+    @Test
+    fun `allPaths는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.allPaths(aliceId, bobId, opts) } returns listOf(path)
+
+        val first = caching.allPaths(aliceId, bobId, opts)
+        val second = caching.allPaths(aliceId, bobId, opts)
+
+        first shouldBeEqualTo listOf(path)
+        second shouldBeEqualTo listOf(path)
+        verify(exactly = 1) { delegate.allPaths(aliceId, bobId, opts) }
+    }
+
+    // ───── findEdgesByLabel 캐싱 ─────
+
+    @Test
+    fun `findEdgesByLabel는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        every { delegate.findEdgesByLabel("KNOWS", emptyMap()) } returns listOf(edge)
+
+        val first = caching.findEdgesByLabel("KNOWS")
+        val second = caching.findEdgesByLabel("KNOWS")
+
+        first shouldBeEqualTo listOf(edge)
+        second shouldBeEqualTo listOf(edge)
+        verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
+    }
+
+    // ───── 쓰기 시 읽기 캐시 무효화 ─────
+
+    @Test
+    fun `deleteVertex 후 읽기 캐시가 무효화된다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns alice andThen null
+        every { delegate.deleteVertex("Person", aliceId) } returns true
+
+        caching.findVertexById("Person", aliceId)   // 캐시 적재
+        caching.deleteVertex("Person", aliceId)     // 전체 캐시 무효화
+        val after = caching.findVertexById("Person", aliceId)  // delegate 재호출
+
+        after.shouldBeNull()
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `updateVertex 후 읽기 캐시가 무효화된다`() {
+        val updated = alice.copy(properties = mapOf("name" to "Alice Updated"))
+        every { delegate.findVertexById("Person", aliceId) } returns alice andThen updated
+        every { delegate.updateVertex("Person", aliceId, any()) } returns updated
+
+        caching.findVertexById("Person", aliceId)   // 캐시 적재
+        caching.updateVertex("Person", aliceId, mapOf("name" to "Alice Updated"))
+        val after = caching.findVertexById("Person", aliceId)  // delegate 재호출
+
+        after shouldBeEqualTo updated
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `deleteEdge 후 모든 캐시가 무효화된다`() {
+        every { delegate.findVerticesByLabel("Person", emptyMap()) } returns listOf(alice) andThen emptyList()
+        every { delegate.deleteEdge("KNOWS", edgeId) } returns true
+
+        caching.findVerticesByLabel("Person")   // 캐시 적재
+        caching.deleteEdge("KNOWS", edgeId)     // 전체 캐시 무효화
+        val after = caching.findVerticesByLabel("Person")  // delegate 재호출
+
+        after shouldBeEqualTo emptyList()
+        verify(exactly = 2) { delegate.findVerticesByLabel("Person", emptyMap()) }
+    }
+
+    // ───── 쓰기 메모이제이션 ─────
+
+    @Test
+    fun `createVertex는 동일 인자 반복 호출 시 메모이제이션된 결과를 반환한다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice
+
+        val first = caching.createVertex("Person", props)
+        val second = caching.createVertex("Person", props)
+
+        first shouldBeEqualTo alice
+        second shouldBeEqualTo alice
+        verify(exactly = 1) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
+    fun `createEdge는 동일 인자 반복 호출 시 메모이제이션된 결과를 반환한다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+
+        val first = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+        val second = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+
+        first shouldBeEqualTo edge
+        second shouldBeEqualTo edge
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+    }
+
+    @Test
+    fun `createVertex는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice
+        every { delegate.findVertexById("Person", aliceId) } returns alice
+
+        caching.findVertexById("Person", aliceId)   // 읽기 캐시 적재
+        caching.createVertex("Person", props)        // 읽기 캐시만 무효화, 쓰기 캐시는 유지
+        caching.findVertexById("Person", aliceId)   // 읽기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 1) { delegate.createVertex("Person", props) }
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+
+        // 두 번째 createVertex 호출 → 메모이제이션 캐시 히트
+        caching.createVertex("Person", props)
+        verify(exactly = 1) { delegate.createVertex("Person", props) }  // delegate 추가 호출 없음
+    }
+
+    @Test
+    fun `deleteVertex 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))
+        every { delegate.deleteVertex("Person", aliceId) } returns true
+
+        caching.createVertex("Person", props)       // 쓰기 캐시 적재
+        val deleted = caching.deleteVertex("Person", aliceId)  // 전체 캐시 무효화
+        caching.createVertex("Person", props)       // 쓰기 캐시 미스 → delegate 재호출
+
+        deleted.shouldBeTrue()
+        verify(exactly = 2) { delegate.createVertex("Person", props) }
+    }
+}

--- a/graph/graph-neo4j/README.ko.md
+++ b/graph/graph-neo4j/README.ko.md
@@ -931,6 +931,43 @@ graphOps.shortestPath(fromId, toId, edgeLabel = "KNOWS", maxDepth = 10)
 // maxDepth 없이 호출하면 안 됨
 ```
 
+## 캐싱 데코레이터
+
+`CachingNeo4jGraphOperations`는 `Neo4jGraphOperations`를 `ConcurrentHashMap` 기반 캐시로 감싸는 데코레이터입니다.
+읽기 결과를 메모이제이션하여 캐시 히트 시 DB 호출을 ~5 ns 조회로 대체합니다.
+반복 읽기가 많은 벤치마크 및 워크로드에 적합합니다.
+
+### 캐시 동작
+
+| 연산 | 효과 |
+|------|------|
+| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | 첫 번째 호출 시 DB 조회 후 캐시 저장, 이후 호출은 캐시 히트 |
+| `createVertex`, `createEdge` | 동일 인자 반복 호출 시 이전 결과 반환 (쓰기 메모이제이션). 읽기 캐시는 무효화, 쓰기 캐시는 보존 |
+| `updateVertex`, `deleteVertex`, `deleteEdge` | 읽기·쓰기 캐시 전체 무효화 |
+
+> **프로덕션 주의**: 쓰기 메모이제이션으로 인해 동일 인자로 `createVertex`를 반복 호출해도 DB 레코드가 추가 생성되지 않습니다.
+> 트랜잭션 기반 insert 의미가 필요한 경우 `Neo4jGraphOperations`를 직접 사용하세요.
+
+### 사용 예제
+
+```kotlin
+val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
+val baseOps = Neo4jGraphOperations(driver)
+
+// 캐싱 데코레이터로 감싸기
+val ops = CachingNeo4jGraphOperations(baseOps)
+
+// 첫 번째 조회: DB 호출
+val alice = ops.findVertexById("Person", aliceId)
+
+// 두 번째 조회: 캐시 히트 (~5 ns)
+val aliceCached = ops.findVertexById("Person", aliceId)
+
+// 쓰기 후 자동 캐시 무효화
+ops.deleteVertex("Person", aliceId)
+val afterDelete = ops.findVertexById("Person", aliceId)  // null (캐시 미스 → DB 재조회)
+```
+
 ## 성능 팁
 
 ### 인덱스 활용

--- a/graph/graph-neo4j/README.md
+++ b/graph/graph-neo4j/README.md
@@ -38,6 +38,7 @@ graph TD
 |-------|-------------|
 | `Neo4jGraphOperations` | Synchronous `GraphOperations` implementation over the Neo4j driver |
 | `Neo4jGraphSuspendOperations` | Coroutine-based `GraphSuspendOperations` implementation |
+| `CachingNeo4jGraphOperations` | `ConcurrentHashMap`-backed caching decorator over `Neo4jGraphOperations` |
 | `Neo4jCoroutineSession` | Bridges `ReactiveSession` and Kotlin Coroutines |
 | `Neo4jRecordMapper` | Converts Neo4j `Record`, `Node`, `Relationship`, and `Path` to graph-core domain types |
 
@@ -186,6 +187,40 @@ All queries use Neo4j driver parameter binding. Never concatenate user-supplied 
 
 ### Depth Limits
 `shortestPath` and `allPaths` enforce a `maxDepth` to prevent runaway traversals.
+
+## Caching Decorator
+
+`CachingNeo4jGraphOperations` wraps a `Neo4jGraphOperations` instance and memoizes all read results using `ConcurrentHashMap` (~5 ns lookup). It is designed for read-heavy workloads such as benchmarks or repeated graph traversals.
+
+### Cache Behaviour
+
+| Operation | Effect |
+|-----------|--------|
+| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | Results cached on first call; subsequent calls return the cached value without hitting the DB |
+| `createVertex`, `createEdge` | Write-result memoization: same arguments return the same object. Read caches are invalidated; write caches are preserved |
+| `updateVertex`, `deleteVertex`, `deleteEdge` | All caches (read + write) invalidated |
+
+> **Production note**: write-result memoization means repeated `createVertex` calls with the same arguments do not create additional DB records. Use `Neo4jGraphOperations` directly when transactional insert semantics are required.
+
+### Usage Example
+
+```kotlin
+val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
+val baseOps = Neo4jGraphOperations(driver)
+
+// Wrap with caching decorator
+val ops = CachingNeo4jGraphOperations(baseOps)
+
+// First call: DB query
+val alice = ops.findVertexById("Person", aliceId)
+
+// Second call: cache hit (~5 ns), no DB round-trip
+val aliceCached = ops.findVertexById("Person", aliceId)
+
+// Any write invalidates all read caches automatically
+ops.deleteVertex("Person", aliceId)
+val afterDelete = ops.findVertexById("Person", aliceId)  // null (cache miss → DB)
+```
 
 ## Performance Tips
 

--- a/graph/graph-neo4j/build.gradle.kts
+++ b/graph/graph-neo4j/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     testImplementation(Libs.bluetape4k_testcontainers)
     testImplementation(Libs.testcontainers_neo4j)
     testImplementation(Libs.kotlinx_coroutines_test)
+    testImplementation(Libs.mockk)
 }

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperations.kt
@@ -25,9 +25,30 @@ import java.util.concurrent.ConcurrentHashMap
  * 그대로 반환한다. 이는 벤치마크/테스트용 편의 기능이며, 트랜잭션 기반 insert 의미가 필요한
  * 프로덕션 코드는 [Neo4jGraphOperations]를 직접 사용해야 한다.
  *
- * Round 8 변경사항: 모든 읽기 캐시를 Caffeine → ConcurrentHashMap 으로 교체.
- * TinyLFU 북키핑 비용을 제거하여 lookup latency 를 ~13-15 ns → ~5 ns 로 단축.
- * TTL/maxSize 기반 축출은 제거되었고, 쓰기 시 명시적 clear() 로 일관성을 유지한다.
+ * 모든 읽기 캐시는 Caffeine → ConcurrentHashMap 으로 구현되어 TinyLFU 북키핑 비용을 제거하고
+ * lookup latency 를 ~13-15 ns → ~5 ns 로 단축한다. TTL/maxSize 기반 축출은 제거되었고,
+ * 쓰기 시 명시적 clear() 로 일관성을 유지한다.
+ *
+ * ### 사용 예제
+ * ```kotlin
+ * val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
+ * val baseOps = Neo4jGraphOperations(driver)
+ *
+ * // 캐싱 래퍼로 감싸기 (벤치마크/반복 읽기가 많은 워크로드에 적합)
+ * val ops = CachingNeo4jGraphOperations(baseOps)
+ *
+ * // 첫 번째 조회: DB 호출 발생
+ * val alice = ops.findVertexById("Person", aliceId)
+ *
+ * // 두 번째 조회: 캐시 히트 (~5 ns), DB 호출 없음
+ * val aliceCached = ops.findVertexById("Person", aliceId)
+ *
+ * // 정점 삭제: 모든 캐시 자동 무효화
+ * ops.deleteVertex("Person", aliceId)
+ *
+ * // 삭제 후 조회: 캐시 미스 → DB 재조회
+ * val afterDelete = ops.findVertexById("Person", aliceId)  // null
+ * ```
  */
 class CachingNeo4jGraphOperations(
     private val delegate: Neo4jGraphOperations,

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperationsTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperationsTest.kt
@@ -1,0 +1,282 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.model.PathStep
+import io.bluetape4k.logging.KLogging
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [CachingNeo4jGraphOperations] 의 캐시 히트·무효화·Write 메모이제이션 동작을 검증한다.
+ *
+ * MockK 로 delegate 를 모킹하여 delegate 호출 횟수를 정확히 검증한다.
+ * 실제 Neo4j 서버 없이 순수 캐시 레이어만 테스트한다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CachingNeo4jGraphOperationsTest {
+
+    companion object : KLogging()
+
+    private lateinit var delegate: Neo4jGraphOperations
+    private lateinit var caching: CachingNeo4jGraphOperations
+
+    private val aliceId = GraphElementId.of("alice-1")
+    private val bobId = GraphElementId.of("bob-1")
+    private val edgeId = GraphElementId.of("edge-1")
+
+    private val alice = GraphVertex(aliceId, "Person", mapOf("name" to "Alice"))
+    private val bob = GraphVertex(bobId, "Person", mapOf("name" to "Bob"))
+    private val edge = GraphEdge(edgeId, "KNOWS", aliceId, bobId)
+    private val path = GraphPath(
+        listOf(
+            PathStep.VertexStep(alice),
+            PathStep.EdgeStep(edge),
+            PathStep.VertexStep(bob),
+        )
+    )
+
+    @BeforeEach
+    fun setup() {
+        delegate = mockk(relaxed = true)
+        caching = CachingNeo4jGraphOperations(delegate)
+    }
+
+    // ───── findVertexById 캐싱 ─────
+
+    @Test
+    fun `findVertexById는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns alice
+
+        val first = caching.findVertexById("Person", aliceId)
+        val second = caching.findVertexById("Person", aliceId)
+
+        first shouldBeEqualTo alice
+        second shouldBeEqualTo alice
+        verify(exactly = 1) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `findVertexById는 null 결과도 캐시하여 delegate를 1회만 호출한다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns null
+
+        val first = caching.findVertexById("Person", aliceId)
+        val second = caching.findVertexById("Person", aliceId)
+
+        first.shouldBeNull()
+        second.shouldBeNull()
+        verify(exactly = 1) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    // ───── findVerticesByLabel 캐싱 ─────
+
+    @Test
+    fun `findVerticesByLabel는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val vertices = listOf(alice, bob)
+        every { delegate.findVerticesByLabel("Person", emptyMap()) } returns vertices
+
+        val first = caching.findVerticesByLabel("Person")
+        val second = caching.findVerticesByLabel("Person")
+
+        first shouldBeEqualTo vertices
+        second shouldBeEqualTo vertices
+        verify(exactly = 1) { delegate.findVerticesByLabel("Person", emptyMap()) }
+    }
+
+    @Test
+    fun `findVerticesByLabel는 filter 포함 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val filter = mapOf("name" to "Alice")
+        every { delegate.findVerticesByLabel("Person", filter) } returns listOf(alice)
+
+        val first = caching.findVerticesByLabel("Person", filter)
+        val second = caching.findVerticesByLabel("Person", filter)
+
+        first shouldBeEqualTo listOf(alice)
+        second shouldBeEqualTo listOf(alice)
+        verify(exactly = 1) { delegate.findVerticesByLabel("Person", filter) }
+    }
+
+    // ───── neighbors 캐싱 ─────
+
+    @Test
+    fun `neighbors는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = NeighborOptions.Default
+        every { delegate.neighbors(aliceId, opts) } returns listOf(bob)
+
+        val first = caching.neighbors(aliceId, opts)
+        val second = caching.neighbors(aliceId, opts)
+
+        first shouldBeEqualTo listOf(bob)
+        second shouldBeEqualTo listOf(bob)
+        verify(exactly = 1) { delegate.neighbors(aliceId, opts) }
+    }
+
+    // ───── shortestPath 캐싱 ─────
+
+    @Test
+    fun `shortestPath는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.shortestPath(aliceId, bobId, opts) } returns path
+
+        val first = caching.shortestPath(aliceId, bobId, opts)
+        val second = caching.shortestPath(aliceId, bobId, opts)
+
+        first shouldBeEqualTo path
+        second shouldBeEqualTo path
+        verify(exactly = 1) { delegate.shortestPath(aliceId, bobId, opts) }
+    }
+
+    @Test
+    fun `shortestPath는 null 결과도 캐시하여 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.shortestPath(aliceId, bobId, opts) } returns null
+
+        val first = caching.shortestPath(aliceId, bobId, opts)
+        val second = caching.shortestPath(aliceId, bobId, opts)
+
+        first.shouldBeNull()
+        second.shouldBeNull()
+        verify(exactly = 1) { delegate.shortestPath(aliceId, bobId, opts) }
+    }
+
+    // ───── allPaths 캐싱 ─────
+
+    @Test
+    fun `allPaths는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.allPaths(aliceId, bobId, opts) } returns listOf(path)
+
+        val first = caching.allPaths(aliceId, bobId, opts)
+        val second = caching.allPaths(aliceId, bobId, opts)
+
+        first shouldBeEqualTo listOf(path)
+        second shouldBeEqualTo listOf(path)
+        verify(exactly = 1) { delegate.allPaths(aliceId, bobId, opts) }
+    }
+
+    // ───── findEdgesByLabel 캐싱 ─────
+
+    @Test
+    fun `findEdgesByLabel는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        every { delegate.findEdgesByLabel("KNOWS", emptyMap()) } returns listOf(edge)
+
+        val first = caching.findEdgesByLabel("KNOWS")
+        val second = caching.findEdgesByLabel("KNOWS")
+
+        first shouldBeEqualTo listOf(edge)
+        second shouldBeEqualTo listOf(edge)
+        verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
+    }
+
+    // ───── 쓰기 시 읽기 캐시 무효화 ─────
+
+    @Test
+    fun `deleteVertex 후 읽기 캐시가 무효화된다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns alice andThen null
+        every { delegate.deleteVertex("Person", aliceId) } returns true
+
+        caching.findVertexById("Person", aliceId)   // 캐시 적재
+        caching.deleteVertex("Person", aliceId)     // 전체 캐시 무효화
+        val after = caching.findVertexById("Person", aliceId)  // delegate 재호출
+
+        after.shouldBeNull()
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `updateVertex 후 읽기 캐시가 무효화된다`() {
+        val updated = alice.copy(properties = mapOf("name" to "Alice Updated"))
+        every { delegate.findVertexById("Person", aliceId) } returns alice andThen updated
+        every { delegate.updateVertex("Person", aliceId, any()) } returns updated
+
+        caching.findVertexById("Person", aliceId)   // 캐시 적재
+        caching.updateVertex("Person", aliceId, mapOf("name" to "Alice Updated"))
+        val after = caching.findVertexById("Person", aliceId)  // delegate 재호출
+
+        after shouldBeEqualTo updated
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `deleteEdge 후 모든 캐시가 무효화된다`() {
+        every { delegate.findVerticesByLabel("Person", emptyMap()) } returns listOf(alice) andThen emptyList()
+        every { delegate.deleteEdge("KNOWS", edgeId) } returns true
+
+        caching.findVerticesByLabel("Person")   // 캐시 적재
+        caching.deleteEdge("KNOWS", edgeId)     // 전체 캐시 무효화
+        val after = caching.findVerticesByLabel("Person")  // delegate 재호출
+
+        after shouldBeEqualTo emptyList()
+        verify(exactly = 2) { delegate.findVerticesByLabel("Person", emptyMap()) }
+    }
+
+    // ───── 쓰기 메모이제이션 ─────
+
+    @Test
+    fun `createVertex는 동일 인자 반복 호출 시 메모이제이션된 결과를 반환한다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice
+
+        val first = caching.createVertex("Person", props)
+        val second = caching.createVertex("Person", props)
+
+        first shouldBeEqualTo alice
+        second shouldBeEqualTo alice
+        verify(exactly = 1) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
+    fun `createEdge는 동일 인자 반복 호출 시 메모이제이션된 결과를 반환한다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+
+        val first = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+        val second = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+
+        first shouldBeEqualTo edge
+        second shouldBeEqualTo edge
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+    }
+
+    @Test
+    fun `createVertex는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice
+        every { delegate.findVertexById("Person", aliceId) } returns alice
+
+        caching.findVertexById("Person", aliceId)   // 읽기 캐시 적재
+        caching.createVertex("Person", props)        // 읽기 캐시만 무효화, 쓰기 캐시는 유지
+        caching.findVertexById("Person", aliceId)   // 읽기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 1) { delegate.createVertex("Person", props) }
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+
+        // 두 번째 createVertex 호출 → 메모이제이션 캐시 히트
+        caching.createVertex("Person", props)
+        verify(exactly = 1) { delegate.createVertex("Person", props) }  // delegate 추가 호출 없음
+    }
+
+    @Test
+    fun `deleteVertex 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))
+        every { delegate.deleteVertex("Person", aliceId) } returns true
+
+        caching.createVertex("Person", props)       // 쓰기 캐시 적재
+        val deleted = caching.deleteVertex("Person", aliceId)  // 전체 캐시 무효화
+        caching.createVertex("Person", props)       // 쓰기 캐시 미스 → delegate 재호출
+
+        deleted.shouldBeTrue()
+        verify(exactly = 2) { delegate.createVertex("Person", props) }
+    }
+}


### PR DESCRIPTION
## 변경 요약

CachingNeo4jGraphOperations / CachingAgeGraphOperations 에 누락된 단위 테스트를 추가하고, KDoc 예제 및 README를 최신화합니다.

## 변경 내용

### 테스트 추가
- `CachingNeo4jGraphOperationsTest`: MockK 기반 16개 테스트 (캐시 히트, null 캐싱, 읽기 캐시 무효화, 쓰기 메모이제이션)
- `CachingAgeGraphOperationsTest`: 동일 패턴 16개 테스트

### 테스트 커버리지
- 캐시 히트: `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel`
- null 결과 캐싱 (Optional 래핑 검증)
- 쓰기 시 캐시 무효화: `deleteVertex`, `updateVertex`, `deleteEdge`
- 쓰기 메모이제이션: `createVertex`, `createEdge`
- `createVertex` 호출 시 읽기 캐시만 무효화, 쓰기 캐시 보존 검증
- `deleteVertex` 후 쓰기 메모이제이션 캐시도 무효화 검증

### KDoc 개선
- `CachingNeo4jGraphOperations`: 사용 예제 추가 (캐싱 생성, 히트, 무효화)
- `CachingAgeGraphOperations`: 동일 패턴 사용 예제 추가

### README 업데이트
- `graph-neo4j/README.md`, `README.ko.md`: Caching Decorator 섹션 추가
- `graph-age/README.md`, `README.ko.md`: Caching Decorator 섹션 추가

### 빌드 의존성
- `graph-neo4j/build.gradle.kts`: `testImplementation(Libs.mockk)` 추가
- `graph-age/build.gradle.kts`: `testImplementation(Libs.mockk)` 추가

## 테스트 결과
- `CachingNeo4jGraphOperationsTest`: 16/16 통과 (1.9s)
- `CachingAgeGraphOperationsTest`: 16/16 통과 (1.8s)