### PR TITLE
test: add missing cache tests for CachingAge/Neo4jGraphOperations

### DIFF
--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperationsTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperationsTest.kt
@@ -179,6 +179,20 @@ class CachingAgeGraphOperationsTest {
         verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
     }
 
+    @Test
+    fun `findEdgesByLabel는 filter 포함 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val filter = mapOf("since" to 2020)
+        val filteredEdge = GraphEdge(edgeId, "KNOWS", aliceId, bobId, filter)
+        every { delegate.findEdgesByLabel("KNOWS", filter) } returns listOf(filteredEdge)
+
+        val first = caching.findEdgesByLabel("KNOWS", filter)
+        val second = caching.findEdgesByLabel("KNOWS", filter)
+
+        first shouldBeEqualTo listOf(filteredEdge)
+        second shouldBeEqualTo listOf(filteredEdge)
+        verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", filter) }
+    }
+
     // ───── 쓰기 시 읽기 캐시 무효화 ─────
 
     @Test
@@ -249,6 +263,23 @@ class CachingAgeGraphOperationsTest {
     }
 
     @Test
+    fun `createEdge는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+        every { delegate.findEdgesByLabel("KNOWS", emptyMap()) } returns listOf(edge)
+
+        caching.findEdgesByLabel("KNOWS")              // 읽기 캐시 적재
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 읽기 캐시만 무효화, 쓰기 캐시는 유지
+        caching.findEdgesByLabel("KNOWS")              // 읽기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+        verify(exactly = 2) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
+
+        // 두 번째 createEdge 호출 → 메모이제이션 캐시 히트
+        caching.createEdge(aliceId, bobId, "KNOWS")
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }  // delegate 추가 호출 없음
+    }
+
+    @Test
     fun `createVertex는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
         val props = mapOf("name" to "Alice")
         every { delegate.createVertex("Person", props) } returns alice
@@ -294,6 +325,20 @@ class CachingAgeGraphOperationsTest {
         r2 shouldBeEqualTo bob
         verify(exactly = 1) { delegate.createVertex("Person", propsAlice) }
         verify(exactly = 1) { delegate.createVertex("Person", propsBob) }
+    }
+
+    @Test
+    fun `deleteEdge 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge andThen
+            GraphEdge(GraphElementId.of("edge-2"), "KNOWS", aliceId, bobId)
+        every { delegate.deleteEdge("KNOWS", edgeId) } returns true
+
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 쓰기 캐시 적재
+        val deleted = caching.deleteEdge("KNOWS", edgeId)  // 전체 캐시 무효화
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 쓰기 캐시 미스 → delegate 재호출
+
+        deleted.shouldBeTrue()
+        verify(exactly = 2) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
     }
 
     @Test

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperationsTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperationsTest.kt
@@ -179,6 +179,20 @@ class CachingNeo4jGraphOperationsTest {
         verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
     }
 
+    @Test
+    fun `findEdgesByLabel는 filter 포함 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val filter = mapOf("since" to 2020)
+        val filteredEdge = GraphEdge(edgeId, "KNOWS", aliceId, bobId, filter)
+        every { delegate.findEdgesByLabel("KNOWS", filter) } returns listOf(filteredEdge)
+
+        val first = caching.findEdgesByLabel("KNOWS", filter)
+        val second = caching.findEdgesByLabel("KNOWS", filter)
+
+        first shouldBeEqualTo listOf(filteredEdge)
+        second shouldBeEqualTo listOf(filteredEdge)
+        verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", filter) }
+    }
+
     // ───── 쓰기 시 읽기 캐시 무효화 ─────
 
     @Test
@@ -249,6 +263,23 @@ class CachingNeo4jGraphOperationsTest {
     }
 
     @Test
+    fun `createEdge는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+        every { delegate.findEdgesByLabel("KNOWS", emptyMap()) } returns listOf(edge)
+
+        caching.findEdgesByLabel("KNOWS")              // 읽기 캐시 적재
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 읽기 캐시만 무효화, 쓰기 캐시는 유지
+        caching.findEdgesByLabel("KNOWS")              // 읽기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+        verify(exactly = 2) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
+
+        // 두 번째 createEdge 호출 → 메모이제이션 캐시 히트
+        caching.createEdge(aliceId, bobId, "KNOWS")
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }  // delegate 추가 호출 없음
+    }
+
+    @Test
     fun `createVertex는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
         val props = mapOf("name" to "Alice")
         every { delegate.createVertex("Person", props) } returns alice
@@ -294,6 +325,20 @@ class CachingNeo4jGraphOperationsTest {
         r2 shouldBeEqualTo bob
         verify(exactly = 1) { delegate.createVertex("Person", propsAlice) }
         verify(exactly = 1) { delegate.createVertex("Person", propsBob) }
+    }
+
+    @Test
+    fun `deleteEdge 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge andThen
+            GraphEdge(GraphElementId.of("edge-2"), "KNOWS", aliceId, bobId)
+        every { delegate.deleteEdge("KNOWS", edgeId) } returns true
+
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 쓰기 캐시 적재
+        val deleted = caching.deleteEdge("KNOWS", edgeId)  // 전체 캐시 무효화
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 쓰기 캐시 미스 → delegate 재호출
+
+        deleted.shouldBeTrue()
+        verify(exactly = 2) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

누락된 단위 테스트 3종을 CachingAgeGraphOperationsTest와 CachingNeo4jGraphOperationsTest 양쪽에 추가.

### 추가된 테스트

- findEdgesByLabel filter 포함 캐시 히트 테스트 (findVerticesByLabel filter 테스트와 대칭)
- createEdge 읽기 캐시만 무효화, 쓰기 메모이제이션 보존 테스트 (createVertex 대칭)
- deleteEdge 후 쓰기 메모이제이션 캐시(createEdgeMap/createVertexMap)도 무효화 검증

### 결과
- CachingAgeGraphOperationsTest: 21/21 통과
- CachingNeo4jGraphOperationsTest: 21/21 통과

이전 커밋 4cb4476 (fix: replace propertiesHash with full Map key) 에 대한 테스트 보완.