### PR TITLE
test: add updateVertex write-cache invalidation test to Caching*GraphOperationsTest

### DIFF
--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperationsTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/CachingAgeGraphOperationsTest.kt
@@ -312,6 +312,19 @@ class CachingAgeGraphOperationsTest {
     }
 
     @Test
+    fun `updateVertex 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))
+        every { delegate.updateVertex("Person", aliceId, any()) } returns alice.copy(properties = mapOf("name" to "Alice Updated"))
+
+        caching.createVertex("Person", props)       // 쓰기 캐시 적재
+        caching.updateVertex("Person", aliceId, mapOf("name" to "Alice Updated"))  // 전체 캐시 무효화
+        caching.createVertex("Person", props)       // 쓰기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 2) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
     fun `createVertex는 다른 속성 맵으로 호출 시 delegate를 각각 호출한다`() {
         val propsAlice = mapOf("name" to "Alice")
         val propsBob = mapOf("name" to "Bob")

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperationsTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperationsTest.kt
@@ -312,6 +312,19 @@ class CachingNeo4jGraphOperationsTest {
     }
 
     @Test
+    fun `updateVertex 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))
+        every { delegate.updateVertex("Person", aliceId, any()) } returns alice.copy(properties = mapOf("name" to "Alice Updated"))
+
+        caching.createVertex("Person", props)       // 쓰기 캐시 적재
+        caching.updateVertex("Person", aliceId, mapOf("name" to "Alice Updated"))  // 전체 캐시 무효화
+        caching.createVertex("Person", props)       // 쓰기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 2) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
     fun `createVertex는 다른 속성 맵으로 호출 시 delegate를 각각 호출한다`() {
         val propsAlice = mapOf("name" to "Alice")
         val propsBob = mapOf("name" to "Bob")


### PR DESCRIPTION
## Summary

`updateVertex` calls `invalidateAll()` which clears **both** read caches and write-memoization caches. The existing test only verified read cache invalidation. This PR adds the missing write-memoization invalidation test, matching the symmetry already present for `deleteVertex` and `deleteEdge`.

## Changes

- **`CachingAgeGraphOperationsTest`**: add `updateVertex 후 쓰기 메모이제이션 캐시도 무효화된다`
- **`CachingNeo4jGraphOperationsTest`**: add `updateVertex 후 쓰기 메모이제이션 캐시도 무효화된다`

## Test Results

All 20 tests pass in each module (graph-age, graph-neo4j).

## Context

Automated review of changes from the last 24 hours (KDoc additions to `CachingAgeGraphOperations` and `CachingNeo4jGraphOperations` via PR #6). No functional changes — test-only.