### PR TITLE
feat: 태그 push 시 Maven Central Portal 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,245 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to publish (e.g. 0.2.0). Must match an existing tag.'
+        required: true
+        type: string
+      diagnoseSigning:
+        description: 'Run signing diagnostics before publishing'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
+env:
+  JAVA_VERSION: '25'
+  JAVA_DISTRIBUTION: 'temurin'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  resolve-version:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            VERSION="$TAG_NAME"
+          else
+            VERSION="$INPUT_VERSION"
+          fi
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=$VERSION"
+
+  publish:
+    name: Publish RELEASE to Maven Central Portal
+    needs: resolve-version
+    runs-on: ubuntu-latest
+    environment: maven-central-release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Verify gradle.properties matches tag
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE=$(grep -E '^baseVersion=' gradle.properties | cut -d= -f2)
+          SNAP=$(grep -E '^snapshotVersion=' gradle.properties | cut -d= -f2 || echo "")
+          echo "tag=$VERSION baseVersion=$BASE snapshotVersion='$SNAP'"
+          if [[ "$BASE" != "$VERSION" ]]; then
+            echo "::error::gradle.properties baseVersion ($BASE) does not match tag ($VERSION)"
+            exit 1
+          fi
+          if [[ -n "$SNAP" ]]; then
+            echo "::error::snapshotVersion must be empty for release. Got: '$SNAP'"
+            exit 1
+          fi
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Diagnose signing inputs
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.diagnoseSigning }}
+        shell: bash
+        env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: |
+          python <<'PY'
+          import base64, os
+
+          raw_key = os.environ.get("SIGNING_KEY", "")
+          key_id = os.environ.get("SIGNING_KEY_ID", "")
+          password = os.environ.get("SIGNING_PASSWORD", "")
+
+          print(f"SIGNING_KEY_ID set={bool(key_id)} length={len(key_id)}")
+          print(f"SIGNING_PASSWORD set={bool(password)} length={len(password)}")
+          print(f"SIGNING_KEY set={bool(raw_key)} length={len(raw_key)}")
+
+          if raw_key.lstrip().startswith("-----BEGIN"):
+              normalized_key = raw_key.replace("\\n", "\n")
+              source = "armored"
+          elif "\\n" in raw_key:
+              normalized_key = raw_key.replace("\\n", "\n")
+              source = "escaped_newlines"
+          else:
+              try:
+                  normalized_key = base64.b64decode(raw_key.strip()).decode("utf-8")
+                  source = "base64"
+              except Exception:
+                  normalized_key = raw_key
+                  source = "raw"
+
+          print(f"SIGNING_KEY source={source} normalized_length={len(normalized_key)}")
+          print(f"SIGNING_KEY armored={'BEGIN PGP PRIVATE KEY BLOCK' in normalized_key}")
+          PY
+
+      - name: Publish to Central Portal
+        run: >
+          ./gradlew publishAggregationToCentralPortal
+          --no-daemon
+          --no-configuration-cache
+          --no-build-cache
+          --stacktrace
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+  github-release:
+    name: Create GitHub Release
+    needs: [resolve-version, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Resolve previous tag
+        id: prev_tag
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          PREV=$(git tag --list --sort=-v:refname \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$' \
+            | grep -vx "$VERSION" \
+            | head -1 || true)
+          echo "previous=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV:-(none)}"
+
+      - name: Compose release notes
+        id: notes
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.previous }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          NOTES_FILE="$(mktemp)"
+
+          awk -v ver="$VERSION" '
+            BEGIN { inblock=0 }
+            /^## \[/ {
+              if (inblock) exit
+              if (index($0, "[" ver "]") > 0) { inblock=1; next }
+            }
+            inblock { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+
+          if [[ ! -s "$NOTES_FILE" ]]; then
+            echo "::warning::No CHANGELOG section found for $VERSION. Using fallback notes."
+            printf "Release %s\n\nSee [CHANGELOG.md](./CHANGELOG.md) for details.\n\n" "$VERSION" > "$NOTES_FILE"
+          fi
+
+          if [[ -n "$PREV_TAG" ]]; then
+            CONTRIBUTORS=$(git shortlog -sne "${PREV_TAG}..${VERSION}" \
+              | sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//' \
+              | sort -u || true)
+            if [[ -n "$CONTRIBUTORS" ]]; then
+              {
+                printf '\n## Contributors\n\n'
+                printf 'Thanks to everyone who contributed to this release.\n\n'
+                while IFS= read -r line; do
+                  printf -- '- %s\n' "$line"
+                done <<< "$CONTRIBUTORS"
+              } >> "$NOTES_FILE"
+            fi
+
+            printf '\n**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+              "$REPO" "$PREV_TAG" "$VERSION" >> "$NOTES_FILE"
+          else
+            printf '\n**Full Changelog**: https://github.com/%s/commits/%s\n' \
+              "$REPO" "$VERSION" >> "$NOTES_FILE"
+          fi
+
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+          echo "--- Release notes preview (head 60 lines) ---"
+          head -60 "$NOTES_FILE"
+          echo "--- tail 20 lines ---"
+          tail -20 "$NOTES_FILE"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          NOTES_FILE: ${{ steps.notes.outputs.notes_file }}
+        run: |
+          set -euo pipefail
+          PRERELEASE_FLAG=""
+          if [[ "$VERSION" =~ -(RC|Beta|Alpha|M) ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file "$NOTES_FILE" \
+            $PRERELEASE_FLAG


### PR DESCRIPTION
## 배경

bluetape4k-projects와 동일한 RELEASE 배포 자동화를 bluetape4k-graph 에도 적용합니다. `git push origin <version>` 한 번으로 Maven Central Portal 배포 + GitHub Release 생성이 완결됩니다.

## 주요 변경

### `.github/workflows/release.yml` (신규)

| Job | 동작 |
|-----|------|
| `resolve-version` | 태그 또는 workflow_dispatch input에서 버전 추출 + semver 정규식 검증 |
| `publish` | `gradle.properties`의 `baseVersion`이 태그와 일치 · `snapshotVersion` 비어있음 검증 → `./gradlew publishAggregationToCentralPortal` (nmcp AUTOMATIC 모드) |
| `github-release` | CHANGELOG [버전] 섹션 추출 → Contributors(`git shortlog -sne PREV..CUR`) + Full Changelog compare 링크 합성 → `gh release create` |

### 트리거

- `push: tags: ['[0-9]+.[0-9]+.[0-9]+', '[0-9]+.[0-9]+.[0-9]+-*']` — `0.2.0`, `0.2.0-RC1` 등
- `workflow_dispatch` — 수동 실행 (version input 필수, diagnoseSigning 옵션)
- **v prefix 없는 태그 규약** 적용 (기존 `v0.1.0` → 앞으로 `0.2.0`)

### 환경

- Java 25 / temurin
- Environment: `maven-central-release` (저장소에 생성 완료)

### Secrets (기존 snapshot 워크플로우와 동일)

- `CENTRAL_USERNAME`, `CENTRAL_PASSWORD`
- `SIGNING_KEY_ID`, `SIGNING_KEY`, `SIGNING_PASSWORD`

### 보안

- 모든 `${{ github.* }}` / `${{ inputs.* }}` 값은 env 변수로 전달 후 shell 변수 참조 (command injection 차단)
- 버전 문자열 정규식 검증
- Previous tag 탐지 시 v-prefix 레거시 태그(`v0.1.0`)도 compare 링크 생성을 위해 고려

## 동작 시나리오 (향후 0.2.0 릴리즈 시)

1. release 브랜치(워크트리)에서 `gradle.properties` 에서 `snapshotVersion=` 비우고 CHANGELOG `[Unreleased]` → `[0.2.0]` 확정
2. main 으로 `--no-ff` merge + annotated tag `0.2.0`
3. main → develop back-merge
4. develop 에서 다음 개발 버전 (`baseVersion=0.3.0`) 으로 bump
5. `git push origin main develop 0.2.0` → **워크플로우가 Central Portal 배포 + GitHub Release 생성 자동 수행**

## 검증

- `yq`로 YAML 유효성 OK
- Gradle 태스크 존재 확인: `publishAggregationToCentralPortal` ✅ (로컬 dry-run)

## 후속 작업

이 PR 은 **워크플로우 인프라만 선적용**. 실제 0.2.0 릴리즈는 별도 브랜치에서 CHANGELOG 정리 및 버전 확정을 거쳐 진행합니다.