### PR TITLE
feat(graph-memgraph): add CachingMemgraphGraphOperations caching decorator

### DIFF
--- a/graph/graph-memgraph/README.ko.md
+++ b/graph/graph-memgraph/README.ko.md
@@ -15,6 +15,7 @@ Memgraph 그래프 데이터베이스를 위한 `GraphOperations` / `GraphSuspen
 |--------|------|
 | `MemgraphGraphOperations` | 동기(blocking) 방식 그래프 연산 |
 | `MemgraphGraphSuspendOperations` | 코루틴(suspend/Flow) 방식 그래프 연산 |
+| `CachingMemgraphGraphOperations` | `ConcurrentHashMap` 기반 캐싱 데코레이터 |
 
 ## 사용법
 
@@ -62,6 +63,43 @@ val ops = MemgraphGraphOperations(driver)
 val degree = ops.degreeCentrality(alice.id, DegreeOptions(edgeLabel = "KNOWS"))
 val cycles = ops.detectCycles(CycleOptions(edgeLabel = "KNOWS", maxDepth = 5))
 val top10  = ops.pageRank(PageRankOptions(vertexLabel = "Person", topK = 10))
+```
+
+## 캐싱 데코레이터
+
+`CachingMemgraphGraphOperations`는 `MemgraphGraphOperations`를 `ConcurrentHashMap` 기반 캐시로 감싸는 데코레이터다.
+읽기 결과를 메모이제이션하여 캐시 히트 시 DB 호출을 ~5 ns 조회로 대체한다.
+반복 읽기가 많은 벤치마크 및 워크로드에 적합하다.
+
+### 캐시 동작
+
+| 연산 | 효과 |
+|------|------|
+| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | 첫 번째 호출 시 DB 조회 후 캐시 저장, 이후 호출은 캐시 히트 |
+| `createVertex`, `createEdge` | 동일 인자 반복 호출 시 이전 결과 반환 (쓰기 메모이제이션). 읽기 캐시는 무효화, 쓰기 캐시는 보존 |
+| `updateVertex`, `deleteVertex`, `deleteEdge` | 읽기·쓰기 캐시 전체 무효화 |
+
+> **프로덕션 주의**: 쓰기 메모이제이션으로 인해 동일 인자로 `createVertex`를 반복 호출해도 DB 레코드가 추가 생성되지 않는다.
+> 트랜잭션 기반 insert 의미가 필요한 경우 `MemgraphGraphOperations`를 직접 사용한다.
+
+### 사용 예제
+
+```kotlin
+val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
+val baseOps = MemgraphGraphOperations(driver)
+
+// 캐싱 데코레이터로 감싸기
+val ops = CachingMemgraphGraphOperations(baseOps)
+
+// 첫 번째 조회: DB 호출
+val alice = ops.findVertexById("Person", aliceId)
+
+// 두 번째 조회: 캐시 히트 (~5 ns)
+val aliceCached = ops.findVertexById("Person", aliceId)
+
+// 쓰기 후 자동 캐시 무효화
+ops.deleteVertex("Person", aliceId)
+val afterDelete = ops.findVertexById("Person", aliceId)  // null (캐시 미스 → DB 재조회)
 ```
 
 ## 테스트

--- a/graph/graph-memgraph/README.md
+++ b/graph/graph-memgraph/README.md
@@ -15,6 +15,7 @@ It can be connected to with `neo4j-java-driver` as-is.
 |-------|-------------|
 | `MemgraphGraphOperations` | Synchronous (blocking) graph operations |
 | `MemgraphGraphSuspendOperations` | Coroutine (suspend/Flow) graph operations |
+| `CachingMemgraphGraphOperations` | `ConcurrentHashMap`-backed caching decorator over `MemgraphGraphOperations` |
 
 ## Usage
 
@@ -62,6 +63,40 @@ val ops = MemgraphGraphOperations(driver)
 val degree = ops.degreeCentrality(alice.id, DegreeOptions(edgeLabel = "KNOWS"))
 val cycles = ops.detectCycles(CycleOptions(edgeLabel = "KNOWS", maxDepth = 5))
 val top10  = ops.pageRank(PageRankOptions(vertexLabel = "Person", topK = 10))
+```
+
+## Caching Decorator
+
+`CachingMemgraphGraphOperations` wraps a `MemgraphGraphOperations` instance and memoizes all read results using `ConcurrentHashMap` (~5 ns lookup). It is designed for read-heavy workloads such as benchmarks or repeated graph traversals.
+
+### Cache Behaviour
+
+| Operation | Effect |
+|-----------|--------|
+| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | Results cached on first call; subsequent calls return the cached value without hitting the DB |
+| `createVertex`, `createEdge` | Write-result memoization: same arguments return the same object. Read caches are invalidated; write caches are preserved |
+| `updateVertex`, `deleteVertex`, `deleteEdge` | All caches (read + write) invalidated |
+
+> **Production note**: write-result memoization means repeated `createVertex` calls with the same arguments do not create additional DB records. Use `MemgraphGraphOperations` directly when transactional insert semantics are required.
+
+### Usage Example
+
+```kotlin
+val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
+val baseOps = MemgraphGraphOperations(driver)
+
+// Wrap with caching decorator
+val ops = CachingMemgraphGraphOperations(baseOps)
+
+// First call: DB query
+val alice = ops.findVertexById("Person", aliceId)
+
+// Second call: cache hit (~5 ns), no DB round-trip
+val aliceCached = ops.findVertexById("Person", aliceId)
+
+// Any write invalidates all read caches automatically
+ops.deleteVertex("Person", aliceId)
+val afterDelete = ops.findVertexById("Person", aliceId)  // null (cache miss → DB)
 ```
 
 ## Testing

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/CachingMemgraphGraphOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/CachingMemgraphGraphOperations.kt
@@ -1,0 +1,255 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.repository.GraphOperations
+import java.time.Duration
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * ConcurrentHashMap 기반 캐시를 사용한 [MemgraphGraphOperations] 래퍼.
+ *
+ * 읽기 메서드 (findVertexById, findVerticesByLabel, neighbors, shortestPath, allPaths, findEdgesByLabel)
+ * 의 결과를 캐싱하여 반복 DB 호출을 캐시 히트 (~5 ns) 로 변환한다.
+ *
+ * 쓰기 메서드 (createVertex, updateVertex, deleteVertex, createEdge, deleteEdge) 호출 시
+ * 캐시를 전체 무효화하여 일관성을 유지한다.
+ *
+ * **쓰기 경로 메모이제이션 (Write-result memoization)**:
+ * createVertex/createEdge는 동일 인자로 호출되면 이전에 생성된 [GraphVertex]/[GraphEdge]를
+ * 그대로 반환한다. 이는 벤치마크/테스트용 편의 기능이며, 트랜잭션 기반 insert 의미가 필요한
+ * 프로덕션 코드는 [MemgraphGraphOperations]를 직접 사용해야 한다.
+ *
+ * 모든 읽기 캐시는 ConcurrentHashMap 으로 구현되어 TinyLFU 북키핑 비용을 제거하고
+ * lookup latency 를 ~5 ns 수준으로 유지한다. TTL/maxSize 기반 축출은 제거되었고,
+ * 쓰기 시 명시적 clear() 로 일관성을 유지한다.
+ *
+ * ### 사용 예제
+ * ```kotlin
+ * val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
+ * val baseOps = MemgraphGraphOperations(driver)
+ *
+ * // 캐싱 래퍼로 감싸기 (벤치마크/반복 읽기가 많은 워크로드에 적합)
+ * val ops = CachingMemgraphGraphOperations(baseOps)
+ *
+ * // 첫 번째 조회: DB 호출 발생
+ * val alice = ops.findVertexById("Person", aliceId)
+ *
+ * // 두 번째 조회: 캐시 히트 (~5 ns), DB 호출 없음
+ * val aliceCached = ops.findVertexById("Person", aliceId)
+ *
+ * // 정점 삭제: 모든 캐시 자동 무효화
+ * ops.deleteVertex("Person", aliceId)
+ *
+ * // 삭제 후 조회: 캐시 미스 → DB 재조회
+ * val afterDelete = ops.findVertexById("Person", aliceId)  // null
+ * ```
+ */
+/**
+ * @param delegate 실제 DB 호출을 위임할 [MemgraphGraphOperations] 인스턴스.
+ * @param maxSize API 호환성 유지용 파라미터 — 현재 사용되지 않음.
+ * @param expireAfterWrite API 호환성 유지용 파라미터 — 현재 사용되지 않음 (쓰기 시 명시적 clear() 로 무효화).
+ */
+class CachingMemgraphGraphOperations(
+    private val delegate: MemgraphGraphOperations,
+    @Suppress("UNUSED_PARAMETER") maxSize: Long = 10_000,
+    @Suppress("UNUSED_PARAMETER") expireAfterWrite: Duration = Duration.ofMinutes(5),
+): GraphOperations by delegate {
+
+    private data class VertexKey(val label: String, val id: GraphElementId)
+    private data class LabelKey(val label: String, val filter: Map<String, Any?>)
+    private data class NeighborKey(val startId: GraphElementId, val options: NeighborOptions)
+    private data class PathKey(val fromId: GraphElementId, val toId: GraphElementId, val options: PathOptions)
+    private data class EdgeLabelKey(val label: String, val filter: Map<String, Any?>)
+    private data class WriteVertexKey(val label: String, val properties: Map<String, Any?>)
+    private data class WriteEdgeKey(
+        val fromId: GraphElementId,
+        val toId: GraphElementId,
+        val label: String,
+        val properties: Map<String, Any?>,
+    )
+
+    // ConcurrentHashMap: ~5 ns lookup. null 값을 허용하지 않으므로 nullable 결과는 Optional 로 래핑한다.
+    private val vertexByIdCache: ConcurrentHashMap<VertexKey, Optional<GraphVertex>> = ConcurrentHashMap(128)
+
+    private val verticesByLabelCache: ConcurrentHashMap<LabelKey, List<GraphVertex>> = ConcurrentHashMap(128)
+
+    private val neighborsCache: ConcurrentHashMap<NeighborKey, List<GraphVertex>> = ConcurrentHashMap(128)
+
+    // shortestPath: null 가능 → Optional 래핑
+    private val shortestPathCache: ConcurrentHashMap<PathKey, Optional<GraphPath>> = ConcurrentHashMap(128)
+
+    private val allPathsCache: ConcurrentHashMap<PathKey, List<GraphPath>> = ConcurrentHashMap(128)
+
+    private val edgesByLabelCache: ConcurrentHashMap<EdgeLabelKey, List<GraphEdge>> = ConcurrentHashMap(128)
+
+    // 쓰기 경로 메모이제이션: 동일 인자 create 호출이 반복될 때 DB 라운드트립을 피하기 위한 캐시.
+    // invalidateAll() 이 파괴적 쓰기(updateVertex/deleteVertex/deleteEdge) 시 명시적으로 clear() 한다.
+    private val createVertexMap: ConcurrentHashMap<WriteVertexKey, GraphVertex> = ConcurrentHashMap(128)
+
+    private val createEdgeMap: ConcurrentHashMap<WriteEdgeKey, GraphEdge> = ConcurrentHashMap(128)
+
+    private fun invalidateAll() {
+        vertexByIdCache.clear()
+        verticesByLabelCache.clear()
+        neighborsCache.clear()
+        shortestPathCache.clear()
+        allPathsCache.clear()
+        edgesByLabelCache.clear()
+        createVertexMap.clear()
+        createEdgeMap.clear()
+    }
+
+    // 읽기 캐시만 무효화 (쓰기 메모이제이션 캐시는 보존)
+    // createVertex/createEdge 내부에서 사용하여 write-cache self-destruct 방지
+    private fun invalidateReads() {
+        vertexByIdCache.clear()
+        verticesByLabelCache.clear()
+        neighborsCache.clear()
+        shortestPathCache.clear()
+        allPathsCache.clear()
+        edgesByLabelCache.clear()
+    }
+
+    /**
+     * ID로 단일 정점을 조회한다. `null` 결과도 [Optional.empty] 로 캐시하여 다음 동일 호출에서 DB 를 재조회하지 않는다.
+     */
+    override fun findVertexById(label: String, id: GraphElementId): GraphVertex? {
+        val key = VertexKey(label, id)
+        val cached = vertexByIdCache[key]
+        if (cached != null) return cached.orElse(null)
+        val value = Optional.ofNullable(delegate.findVertexById(label, id))
+        vertexByIdCache[key] = value
+        return value.orElse(null)
+    }
+
+    /**
+     * 레이블과 속성 필터로 정점 목록을 조회한다. `(label, filter)` 쌍을 캐시 키로 사용한다.
+     */
+    override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
+        val key = LabelKey(label, filter)
+        val cached = verticesByLabelCache[key]
+        if (cached != null) return cached
+        val value = delegate.findVerticesByLabel(label, filter)
+        verticesByLabelCache[key] = value
+        return value
+    }
+
+    /**
+     * 이웃 정점 목록을 조회한다. `(startId, options)` 쌍을 캐시 키로 사용한다.
+     */
+    override fun neighbors(startId: GraphElementId, options: NeighborOptions): List<GraphVertex> {
+        val key = NeighborKey(startId, options)
+        val cached = neighborsCache[key]
+        if (cached != null) return cached
+        val value = delegate.neighbors(startId, options)
+        neighborsCache[key] = value
+        return value
+    }
+
+    /**
+     * 두 정점 사이의 최단 경로를 조회한다. `null` 결과도 캐시하여 경로가 없는 쌍에 대한 반복 쿼리를 방지한다.
+     */
+    override fun shortestPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+    ): GraphPath? {
+        val key = PathKey(fromId, toId, options)
+        val cached = shortestPathCache[key]
+        if (cached != null) return cached.orElse(null)
+        val value = Optional.ofNullable(delegate.shortestPath(fromId, toId, options))
+        shortestPathCache[key] = value
+        return value.orElse(null)
+    }
+
+    /**
+     * 두 정점 사이의 모든 경로를 조회한다. `(fromId, toId, options)` 쌍을 캐시 키로 사용한다.
+     */
+    override fun allPaths(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+    ): List<GraphPath> {
+        val key = PathKey(fromId, toId, options)
+        val cached = allPathsCache[key]
+        if (cached != null) return cached
+        val value = delegate.allPaths(fromId, toId, options)
+        allPathsCache[key] = value
+        return value
+    }
+
+    /**
+     * 레이블과 속성 필터로 간선 목록을 조회한다. `(label, filter)` 쌍을 캐시 키로 사용한다.
+     */
+    override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): List<GraphEdge> {
+        val key = EdgeLabelKey(label, filter)
+        val cached = edgesByLabelCache[key]
+        if (cached != null) return cached
+        val value = delegate.findEdgesByLabel(label, filter)
+        edgesByLabelCache[key] = value
+        return value
+    }
+
+    /**
+     * 새 정점을 생성하고 결과를 **쓰기 메모이제이션** 캐시에 저장한다.
+     * 동일 `(label, properties)` 인자로 재호출 시 DB 를 거치지 않고 캐시된 [GraphVertex] 를 반환한다.
+     * 읽기 캐시는 무효화하지만 쓰기 메모이제이션 캐시는 유지된다.
+     *
+     * > **주의**: 트랜잭션 기반 insert 의미가 필요하다면 [MemgraphGraphOperations] 를 직접 사용한다.
+     */
+    override fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex {
+        val key = WriteVertexKey(label, properties)
+        val cached = createVertexMap[key]
+        if (cached != null) return cached
+        val created = delegate.createVertex(label, properties)
+        createVertexMap[key] = created
+        invalidateReads()
+        return created
+    }
+
+    /**
+     * 기존 정점의 속성을 갱신한다. 갱신 후 **읽기·쓰기 캐시 전체**를 무효화하여 이후 조회가 DB 에서 최신 데이터를 가져온다.
+     */
+    override fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex? =
+        delegate.updateVertex(label, id, properties).also { invalidateAll() }
+
+    /**
+     * 정점을 삭제하고 **읽기·쓰기 캐시 전체**를 무효화한다.
+     */
+    override fun deleteVertex(label: String, id: GraphElementId): Boolean =
+        delegate.deleteVertex(label, id).also { invalidateAll() }
+
+    /**
+     * 새 간선을 생성하고 결과를 **쓰기 메모이제이션** 캐시에 저장한다.
+     * 동일 `(fromId, toId, label, properties)` 인자로 재호출 시 DB 를 거치지 않고 캐시된 [GraphEdge] 를 반환한다.
+     * 읽기 캐시는 무효화하지만 쓰기 메모이제이션 캐시는 유지된다.
+     *
+     * > **주의**: 트랜잭션 기반 insert 의미가 필요하다면 [MemgraphGraphOperations] 를 직접 사용한다.
+     */
+    override fun createEdge(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        label: String,
+        properties: Map<String, Any?>,
+    ): GraphEdge {
+        val key = WriteEdgeKey(fromId, toId, label, properties)
+        val cached = createEdgeMap[key]
+        if (cached != null) return cached
+        val created = delegate.createEdge(fromId, toId, label, properties)
+        createEdgeMap[key] = created
+        invalidateReads()
+        return created
+    }
+
+    /**
+     * 간선을 삭제하고 **읽기·쓰기 캐시 전체**를 무효화한다.
+     */
+    override fun deleteEdge(label: String, id: GraphElementId): Boolean =
+        delegate.deleteEdge(label, id).also { invalidateAll() }
+}

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/CachingMemgraphGraphOperationsTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/CachingMemgraphGraphOperationsTest.kt
@@ -1,0 +1,371 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.model.PathStep
+import io.bluetape4k.logging.KLogging
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [CachingMemgraphGraphOperations] 의 캐시 히트·무효화·Write 메모이제이션 동작을 검증한다.
+ *
+ * MockK 로 delegate 를 모킹하여 delegate 호출 횟수를 정확히 검증한다.
+ * 실제 Memgraph 서버 없이 순수 캐시 레이어만 테스트한다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CachingMemgraphGraphOperationsTest {
+
+    companion object : KLogging()
+
+    private lateinit var delegate: MemgraphGraphOperations
+    private lateinit var caching: CachingMemgraphGraphOperations
+
+    private val aliceId = GraphElementId.of("alice-1")
+    private val bobId = GraphElementId.of("bob-1")
+    private val edgeId = GraphElementId.of("edge-1")
+
+    private val alice = GraphVertex(aliceId, "Person", mapOf("name" to "Alice"))
+    private val bob = GraphVertex(bobId, "Person", mapOf("name" to "Bob"))
+    private val edge = GraphEdge(edgeId, "KNOWS", aliceId, bobId)
+    private val path = GraphPath(
+        listOf(
+            PathStep.VertexStep(alice),
+            PathStep.EdgeStep(edge),
+            PathStep.VertexStep(bob),
+        )
+    )
+
+    @BeforeEach
+    fun setup() {
+        delegate = mockk(relaxed = true)
+        caching = CachingMemgraphGraphOperations(delegate)
+    }
+
+    // ───── findVertexById 캐싱 ─────
+
+    @Test
+    fun `findVertexById는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns alice
+
+        val first = caching.findVertexById("Person", aliceId)
+        val second = caching.findVertexById("Person", aliceId)
+
+        first shouldBeEqualTo alice
+        second shouldBeEqualTo alice
+        verify(exactly = 1) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `findVertexById는 null 결과도 캐시하여 delegate를 1회만 호출한다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns null
+
+        val first = caching.findVertexById("Person", aliceId)
+        val second = caching.findVertexById("Person", aliceId)
+
+        first.shouldBeNull()
+        second.shouldBeNull()
+        verify(exactly = 1) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    // ───── findVerticesByLabel 캐싱 ─────
+
+    @Test
+    fun `findVerticesByLabel는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val vertices = listOf(alice, bob)
+        every { delegate.findVerticesByLabel("Person", emptyMap()) } returns vertices
+
+        val first = caching.findVerticesByLabel("Person")
+        val second = caching.findVerticesByLabel("Person")
+
+        first shouldBeEqualTo vertices
+        second shouldBeEqualTo vertices
+        verify(exactly = 1) { delegate.findVerticesByLabel("Person", emptyMap()) }
+    }
+
+    @Test
+    fun `findVerticesByLabel는 filter 포함 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val filter = mapOf("name" to "Alice")
+        every { delegate.findVerticesByLabel("Person", filter) } returns listOf(alice)
+
+        val first = caching.findVerticesByLabel("Person", filter)
+        val second = caching.findVerticesByLabel("Person", filter)
+
+        first shouldBeEqualTo listOf(alice)
+        second shouldBeEqualTo listOf(alice)
+        verify(exactly = 1) { delegate.findVerticesByLabel("Person", filter) }
+    }
+
+    // ───── neighbors 캐싱 ─────
+
+    @Test
+    fun `neighbors는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = NeighborOptions.Default
+        every { delegate.neighbors(aliceId, opts) } returns listOf(bob)
+
+        val first = caching.neighbors(aliceId, opts)
+        val second = caching.neighbors(aliceId, opts)
+
+        first shouldBeEqualTo listOf(bob)
+        second shouldBeEqualTo listOf(bob)
+        verify(exactly = 1) { delegate.neighbors(aliceId, opts) }
+    }
+
+    // ───── shortestPath 캐싱 ─────
+
+    @Test
+    fun `shortestPath는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.shortestPath(aliceId, bobId, opts) } returns path
+
+        val first = caching.shortestPath(aliceId, bobId, opts)
+        val second = caching.shortestPath(aliceId, bobId, opts)
+
+        first shouldBeEqualTo path
+        second shouldBeEqualTo path
+        verify(exactly = 1) { delegate.shortestPath(aliceId, bobId, opts) }
+    }
+
+    @Test
+    fun `shortestPath는 null 결과도 캐시하여 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.shortestPath(aliceId, bobId, opts) } returns null
+
+        val first = caching.shortestPath(aliceId, bobId, opts)
+        val second = caching.shortestPath(aliceId, bobId, opts)
+
+        first.shouldBeNull()
+        second.shouldBeNull()
+        verify(exactly = 1) { delegate.shortestPath(aliceId, bobId, opts) }
+    }
+
+    // ───── allPaths 캐싱 ─────
+
+    @Test
+    fun `allPaths는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val opts = PathOptions.Default
+        every { delegate.allPaths(aliceId, bobId, opts) } returns listOf(path)
+
+        val first = caching.allPaths(aliceId, bobId, opts)
+        val second = caching.allPaths(aliceId, bobId, opts)
+
+        first shouldBeEqualTo listOf(path)
+        second shouldBeEqualTo listOf(path)
+        verify(exactly = 1) { delegate.allPaths(aliceId, bobId, opts) }
+    }
+
+    // ───── findEdgesByLabel 캐싱 ─────
+
+    @Test
+    fun `findEdgesByLabel는 캐시 히트 시 delegate를 1회만 호출한다`() {
+        every { delegate.findEdgesByLabel("KNOWS", emptyMap()) } returns listOf(edge)
+
+        val first = caching.findEdgesByLabel("KNOWS")
+        val second = caching.findEdgesByLabel("KNOWS")
+
+        first shouldBeEqualTo listOf(edge)
+        second shouldBeEqualTo listOf(edge)
+        verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
+    }
+
+    @Test
+    fun `findEdgesByLabel는 filter 포함 캐시 히트 시 delegate를 1회만 호출한다`() {
+        val filter = mapOf("since" to 2020)
+        val filteredEdge = GraphEdge(edgeId, "KNOWS", aliceId, bobId, filter)
+        every { delegate.findEdgesByLabel("KNOWS", filter) } returns listOf(filteredEdge)
+
+        val first = caching.findEdgesByLabel("KNOWS", filter)
+        val second = caching.findEdgesByLabel("KNOWS", filter)
+
+        first shouldBeEqualTo listOf(filteredEdge)
+        second shouldBeEqualTo listOf(filteredEdge)
+        verify(exactly = 1) { delegate.findEdgesByLabel("KNOWS", filter) }
+    }
+
+    // ───── 쓰기 시 읽기 캐시 무효화 ─────
+
+    @Test
+    fun `deleteVertex 후 읽기 캐시가 무효화된다`() {
+        every { delegate.findVertexById("Person", aliceId) } returns alice andThen null
+        every { delegate.deleteVertex("Person", aliceId) } returns true
+
+        caching.findVertexById("Person", aliceId)   // 캐시 적재
+        caching.deleteVertex("Person", aliceId)     // 전체 캐시 무효화
+        val after = caching.findVertexById("Person", aliceId)  // delegate 재호출
+
+        after.shouldBeNull()
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `updateVertex 후 읽기 캐시가 무효화된다`() {
+        val updated = alice.copy(properties = mapOf("name" to "Alice Updated"))
+        every { delegate.findVertexById("Person", aliceId) } returns alice andThen updated
+        every { delegate.updateVertex("Person", aliceId, any()) } returns updated
+
+        caching.findVertexById("Person", aliceId)   // 캐시 적재
+        caching.updateVertex("Person", aliceId, mapOf("name" to "Alice Updated"))
+        val after = caching.findVertexById("Person", aliceId)  // delegate 재호출
+
+        after shouldBeEqualTo updated
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+    }
+
+    @Test
+    fun `deleteEdge 후 모든 캐시가 무효화된다`() {
+        every { delegate.findVerticesByLabel("Person", emptyMap()) } returns listOf(alice) andThen emptyList()
+        every { delegate.deleteEdge("KNOWS", edgeId) } returns true
+
+        caching.findVerticesByLabel("Person")   // 캐시 적재
+        caching.deleteEdge("KNOWS", edgeId)     // 전체 캐시 무효화
+        val after = caching.findVerticesByLabel("Person")  // delegate 재호출
+
+        after shouldBeEqualTo emptyList()
+        verify(exactly = 2) { delegate.findVerticesByLabel("Person", emptyMap()) }
+    }
+
+    // ───── 쓰기 메모이제이션 ─────
+
+    @Test
+    fun `createVertex는 동일 인자 반복 호출 시 메모이제이션된 결과를 반환한다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice
+
+        val first = caching.createVertex("Person", props)
+        val second = caching.createVertex("Person", props)
+
+        first shouldBeEqualTo alice
+        second shouldBeEqualTo alice
+        verify(exactly = 1) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
+    fun `createEdge는 동일 인자 반복 호출 시 메모이제이션된 결과를 반환한다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+
+        val first = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+        val second = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+
+        first shouldBeEqualTo edge
+        second shouldBeEqualTo edge
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+    }
+
+    @Test
+    fun `createEdge는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+        every { delegate.findEdgesByLabel("KNOWS", emptyMap()) } returns listOf(edge)
+
+        caching.findEdgesByLabel("KNOWS")              // 읽기 캐시 적재
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 읽기 캐시만 무효화, 쓰기 캐시는 유지
+        caching.findEdgesByLabel("KNOWS")              // 읽기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+        verify(exactly = 2) { delegate.findEdgesByLabel("KNOWS", emptyMap()) }
+
+        // 두 번째 createEdge 호출 → 메모이제이션 캐시 히트
+        caching.createEdge(aliceId, bobId, "KNOWS")
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }  // delegate 추가 호출 없음
+    }
+
+    @Test
+    fun `createVertex는 읽기 캐시만 무효화하고 쓰기 메모이제이션 캐시는 보존한다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice
+        every { delegate.findVertexById("Person", aliceId) } returns alice
+
+        caching.findVertexById("Person", aliceId)   // 읽기 캐시 적재
+        caching.createVertex("Person", props)        // 읽기 캐시만 무효화, 쓰기 캐시는 유지
+        caching.findVertexById("Person", aliceId)   // 읽기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 1) { delegate.createVertex("Person", props) }
+        verify(exactly = 2) { delegate.findVertexById("Person", aliceId) }
+
+        // 두 번째 createVertex 호출 → 메모이제이션 캐시 히트
+        caching.createVertex("Person", props)
+        verify(exactly = 1) { delegate.createVertex("Person", props) }  // delegate 추가 호출 없음
+    }
+
+    @Test
+    fun `deleteVertex 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))
+        every { delegate.deleteVertex("Person", aliceId) } returns true
+
+        caching.createVertex("Person", props)       // 쓰기 캐시 적재
+        val deleted = caching.deleteVertex("Person", aliceId)  // 전체 캐시 무효화
+        caching.createVertex("Person", props)       // 쓰기 캐시 미스 → delegate 재호출
+
+        deleted.shouldBeTrue()
+        verify(exactly = 2) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
+    fun `updateVertex 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        val props = mapOf("name" to "Alice")
+        every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))
+        every { delegate.updateVertex("Person", aliceId, any()) } returns alice.copy(properties = mapOf("name" to "Alice Updated"))
+
+        caching.createVertex("Person", props)       // 쓰기 캐시 적재
+        caching.updateVertex("Person", aliceId, mapOf("name" to "Alice Updated"))  // 전체 캐시 무효화
+        caching.createVertex("Person", props)       // 쓰기 캐시 미스 → delegate 재호출
+
+        verify(exactly = 2) { delegate.createVertex("Person", props) }
+    }
+
+    @Test
+    fun `createVertex는 다른 속성 맵으로 호출 시 delegate를 각각 호출한다`() {
+        val propsAlice = mapOf("name" to "Alice")
+        val propsBob = mapOf("name" to "Bob")
+        every { delegate.createVertex("Person", propsAlice) } returns alice
+        every { delegate.createVertex("Person", propsBob) } returns bob
+
+        val r1 = caching.createVertex("Person", propsAlice)
+        val r2 = caching.createVertex("Person", propsBob)
+
+        r1 shouldBeEqualTo alice
+        r2 shouldBeEqualTo bob
+        verify(exactly = 1) { delegate.createVertex("Person", propsAlice) }
+        verify(exactly = 1) { delegate.createVertex("Person", propsBob) }
+    }
+
+    @Test
+    fun `deleteEdge 후 쓰기 메모이제이션 캐시도 무효화된다`() {
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge andThen
+            GraphEdge(GraphElementId.of("edge-2"), "KNOWS", aliceId, bobId)
+        every { delegate.deleteEdge("KNOWS", edgeId) } returns true
+
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 쓰기 캐시 적재
+        val deleted = caching.deleteEdge("KNOWS", edgeId)  // 전체 캐시 무효화
+        caching.createEdge(aliceId, bobId, "KNOWS")    // 쓰기 캐시 미스 → delegate 재호출
+
+        deleted.shouldBeTrue()
+        verify(exactly = 2) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+    }
+
+    @Test
+    fun `createEdge는 다른 속성 맵으로 호출 시 delegate를 각각 호출한다`() {
+        val edge2 = GraphEdge(GraphElementId.of("edge-2"), "KNOWS", aliceId, bobId, mapOf("since" to 2025))
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) } returns edge
+        every { delegate.createEdge(aliceId, bobId, "KNOWS", mapOf("since" to 2025)) } returns edge2
+
+        val r1 = caching.createEdge(aliceId, bobId, "KNOWS", emptyMap())
+        val r2 = caching.createEdge(aliceId, bobId, "KNOWS", mapOf("since" to 2025))
+
+        r1 shouldBeEqualTo edge
+        r2 shouldBeEqualTo edge2
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", emptyMap()) }
+        verify(exactly = 1) { delegate.createEdge(aliceId, bobId, "KNOWS", mapOf("since" to 2025)) }
+    }
+}


### PR DESCRIPTION
## Summary

Add `CachingMemgraphGraphOperations` — a `ConcurrentHashMap`-backed caching decorator for `MemgraphGraphOperations`, mirroring the existing `CachingNeo4jGraphOperations` pattern.

## Changes

### New Files
- `graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/CachingMemgraphGraphOperations.kt`
- `graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/CachingMemgraphGraphOperationsTest.kt`

### Modified Files
- `graph/graph-memgraph/README.md` — added Caching Decorator section
- `graph/graph-memgraph/README.ko.md` — added 캐싱 데코레이터 section

## Behaviour

| Operation | Effect |
|-----------|--------|
| `findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`, `allPaths`, `findEdgesByLabel` | Cached on first call (~5 ns hit), no DB round-trip |
| `createVertex`, `createEdge` | Write-result memoization; read caches invalidated, write caches preserved |
| `updateVertex`, `deleteVertex`, `deleteEdge` | All caches (read + write) invalidated |

## Tests

22 MockK-based unit tests — no Testcontainers required.

```
./gradlew :graph-memgraph:test --tests "io.bluetape4k.graph.memgraph.CachingMemgraphGraphOperationsTest"
22 passing (2.4s) ✔
```