### PR TITLE
docs/test: graph-io-csv KDoc 강화 + 임포트 에러 테스트 + README 임포트 섹션

### DIFF
--- a/graph-io/csv/README.md
+++ b/graph-io/csv/README.md
@@ -122,6 +122,102 @@ val report = runBlocking {
 println("Exported ${report.verticesWritten} vertices and ${report.edgesWritten} edges")
 ```
 
+## Import
+
+CSV 파일에서 그래프를 임포트합니다. 정점과 간선 CSV 파일은 각각 별도의 파일로 제공해야 합니다.
+
+### Synchronous Import
+
+```kotlin
+import io.bluetape4k.graph.io.csv.CsvGraphBulkImporter
+import io.bluetape4k.graph.io.csv.CsvGraphImportSource
+import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
+import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.options.MissingEndpointPolicy
+import io.bluetape4k.graph.io.source.GraphImportSource
+import java.nio.file.Paths
+
+val importer = CsvGraphBulkImporter()
+
+val source = CsvGraphImportSource(
+    vertices = GraphImportSource.PathSource(Paths.get("vertices.csv")),
+    edges    = GraphImportSource.PathSource(Paths.get("edges.csv")),
+)
+
+val options = GraphImportOptions(
+    defaultVertexLabel    = "Node",
+    onDuplicateVertexId   = DuplicateVertexPolicy.SKIP,   // 중복 정점 건너뜀
+    onMissingEdgeEndpoint = MissingEndpointPolicy.SKIP_EDGE, // 끝점 없는 간선 건너뜀
+)
+
+val report = importer.importGraph(source, graphOps, options)
+println("Imported ${report.verticesCreated}/${report.verticesRead} vertices, " +
+        "${report.edgesCreated}/${report.edgesRead} edges — ${report.status}")
+```
+
+### Import CSV File Format
+
+정점 CSV 파일:
+
+```csv
+id,label,prop.name,prop.age
+v1,Person,Alice,30
+v2,Person,Bob,25
+```
+
+간선 CSV 파일:
+
+```csv
+id,label,from,to,prop.since
+,KNOWS,v1,v2,2024
+```
+
+### Import Options
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `defaultVertexLabel` | `String` | `"Vertex"` | `label` 컬럼이 비어있을 때 사용하는 기본 레이블 |
+| `defaultEdgeLabel` | `String` | `"Edge"` | `label` 컬럼이 비어있을 때 사용하는 기본 레이블 |
+| `onDuplicateVertexId` | `DuplicateVertexPolicy` | `FAIL` | 중복 정점 ID 처리: `FAIL` (즉시 실패) 또는 `SKIP` (건너뜀) |
+| `onMissingEdgeEndpoint` | `MissingEndpointPolicy` | `FAIL` | 끝점 없는 간선 처리: `FAIL` (즉시 실패) 또는 `SKIP_EDGE` (건너뜀) |
+| `preserveExternalIdProperty` | `String?` | `null` | 외부 ID를 속성으로 보존할 키 이름 (예: `"_externalId"`) |
+
+### Import Report
+
+임포트 결과에서 통계와 실패 목록을 확인할 수 있습니다:
+
+```kotlin
+val report = importer.importGraph(source, graphOps, options)
+
+println("Status: ${report.status}")              // COMPLETED, PARTIAL, FAILED
+println("Vertices: ${report.verticesCreated}/${report.verticesRead}")
+println("Edges: ${report.edgesCreated}/${report.edgesRead}")
+println("Skipped vertices: ${report.skippedVertices}")
+println("Skipped edges: ${report.skippedEdges}")
+println("Duration: ${report.elapsed.toMillis()}ms")
+
+report.failures.forEach { failure ->
+    println("[${failure.severity}][${failure.phase}] ${failure.message}")
+}
+```
+
+### Virtual Thread Import
+
+```kotlin
+val importer = CsvGraphVirtualThreadBulkImporter()
+val future = importer.importGraphAsync(source, graphOps, options)
+val report = future.get()
+```
+
+### Coroutine-Based Import (Suspend)
+
+```kotlin
+val importer = SuspendCsvGraphBulkImporter()
+val report = coroutineScope {
+    importer.importGraphSuspending(source, suspendGraphOps, options)
+}
+```
+
 ## Configuration
 
 ### Property Modes

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphBulkExporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphBulkExporter.kt
@@ -18,7 +18,23 @@ import io.bluetape4k.logging.debug
 
 /**
  * CSV 동기 벌크 익스포터.
- * 정점 파일과 간선 파일을 별도로 작성한다. 정점 헤더는 전체 레코드를 스캔하여 유니온 헤더를 생성한다.
+ *
+ * 정점 파일과 간선 파일을 별도로 작성한다.
+ * 정점 헤더는 전체 레코드를 스캔하여 모든 속성 키의 유니온 헤더를 자동 생성한다.
+ *
+ * ```kotlin
+ * val exporter = CsvGraphBulkExporter()
+ * val sink = CsvGraphExportSink(
+ *     vertices = GraphExportSink.PathSink(Paths.get("vertices.csv")),
+ *     edges    = GraphExportSink.PathSink(Paths.get("edges.csv")),
+ * )
+ * val options = GraphExportOptions(
+ *     vertexLabels = setOf("Person", "Company"),
+ *     edgeLabels   = setOf("KNOWS", "WORKS_FOR"),
+ * )
+ * val report = exporter.exportGraph(sink, graphOps, options)
+ * println("exported ${report.verticesWritten} vertices in ${report.elapsed.toMillis()}ms")
+ * ```
  */
 class CsvGraphBulkExporter : GraphBulkExporter<CsvGraphExportSink> {
 

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphBulkImporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphBulkImporter.kt
@@ -22,7 +22,23 @@ import io.bluetape4k.logging.warn
 
 /**
  * CSV 동기 벌크 임포터.
- * 정점 파일을 모두 읽어 외부ID-백엔드ID 맵을 구축한 뒤, 엣지 파일을 처리한다.
+ *
+ * 정점 CSV 파일을 전부 읽어 외부ID→백엔드ID 맵을 구축한 뒤, 간선 CSV 파일을 처리하는 2-패스 방식으로 동작한다.
+ * 중복 정점 ID 및 누락된 간선 끝점 처리 정책은 [GraphImportOptions]로 제어한다.
+ *
+ * ```kotlin
+ * val importer = CsvGraphBulkImporter()
+ * val source = CsvGraphImportSource(
+ *     vertices = GraphImportSource.PathSource(Paths.get("vertices.csv")),
+ *     edges    = GraphImportSource.PathSource(Paths.get("edges.csv")),
+ * )
+ * val options = GraphImportOptions(
+ *     onDuplicateVertexId   = DuplicateVertexPolicy.SKIP,
+ *     onMissingEdgeEndpoint = MissingEndpointPolicy.SKIP_EDGE,
+ * )
+ * val report = importer.importGraph(source, graphOps, options)
+ * println("imported ${report.verticesCreated} vertices, ${report.edgesCreated} edges — ${report.status}")
+ * ```
  */
 class CsvGraphBulkImporter : GraphBulkImporter<CsvGraphImportSource> {
 

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphIoOptions.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphIoOptions.kt
@@ -2,7 +2,20 @@ package io.bluetape4k.graph.io.csv
 
 import java.io.Serializable
 
-/** CSV 형식별 I/O 옵션. 기본값은 `"prop."` 접두사 방식. */
+/**
+ * CSV 형식별 I/O 옵션. 기본값은 `"prop."` 접두사 방식([CsvPropertyMode.PrefixedColumns]).
+ *
+ * ```kotlin
+ * // 기본: 속성을 "prop." 접두사 컬럼으로 저장 → id, label, prop.name, prop.age
+ * val defaults = CsvGraphIoOptions()
+ *
+ * // JSON 단일 컬럼: id, label, attributes
+ * val jsonMode = CsvGraphIoOptions(propertyMode = CsvPropertyMode.RawJsonColumn("attributes"))
+ *
+ * // 속성 제외: id, label 만 저장
+ * val noProps = CsvGraphIoOptions(propertyMode = CsvPropertyMode.None)
+ * ```
+ */
 data class CsvGraphIoOptions(
     val propertyMode: CsvPropertyMode = CsvPropertyMode.PrefixedColumns(),
 ) : Serializable {

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphVirtualThreadBulkExporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphVirtualThreadBulkExporter.kt
@@ -9,7 +9,23 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
-/** CSV Virtual Thread 기반 익스포터. Sync 익스포터를 VT Future로 감싼다. */
+/**
+ * CSV Virtual Thread 기반 익스포터.
+ *
+ * [CsvGraphBulkExporter]를 Java Virtual Thread 위에서 비동기로 실행한다.
+ * `CompletableFuture`를 통해 논블로킹 방식으로 결과를 받을 수 있다.
+ *
+ * ```kotlin
+ * val exporter = CsvGraphVirtualThreadBulkExporter()
+ * val sink = CsvGraphExportSink(
+ *     vertices = GraphExportSink.PathSink(Paths.get("vertices.csv")),
+ *     edges    = GraphExportSink.PathSink(Paths.get("edges.csv")),
+ * )
+ * val future = exporter.exportGraphAsync(sink, graphOps, GraphExportOptions(vertexLabels = setOf("Person")))
+ * val report = future.get()  // 완료 대기
+ * println("exported ${report.verticesWritten} vertices — ${report.status}")
+ * ```
+ */
 class CsvGraphVirtualThreadBulkExporter(
     private val sync: CsvGraphBulkExporter = CsvGraphBulkExporter(),
 ) : GraphVirtualThreadBulkExporter<CsvGraphExportSink> {

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphVirtualThreadBulkImporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvGraphVirtualThreadBulkImporter.kt
@@ -9,7 +9,23 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
-/** CSV Virtual Thread 기반 임포터. Sync 임포터를 VT Future로 감싼다. */
+/**
+ * CSV Virtual Thread 기반 임포터.
+ *
+ * [CsvGraphBulkImporter]를 Java Virtual Thread 위에서 비동기로 실행한다.
+ * `CompletableFuture`를 통해 논블로킹 방식으로 결과를 받을 수 있다.
+ *
+ * ```kotlin
+ * val importer = CsvGraphVirtualThreadBulkImporter()
+ * val source = CsvGraphImportSource(
+ *     vertices = GraphImportSource.PathSource(Paths.get("vertices.csv")),
+ *     edges    = GraphImportSource.PathSource(Paths.get("edges.csv")),
+ * )
+ * val future = importer.importGraphAsync(source, graphOps, GraphImportOptions())
+ * val report = future.get()  // 완료 대기
+ * println("imported ${report.verticesCreated} vertices — ${report.status}")
+ * ```
+ */
 class CsvGraphVirtualThreadBulkImporter(
     private val sync: CsvGraphBulkImporter = CsvGraphBulkImporter(),
 ) : GraphVirtualThreadBulkImporter<CsvGraphImportSource> {

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvPropertyMode.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/CsvPropertyMode.kt
@@ -3,10 +3,18 @@ package io.bluetape4k.graph.io.csv
 import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 
-/** CSV 속성 컬럼 표현 방식을 지정하는 sealed 인터페이스. */
+/**
+ * CSV 속성 컬럼 표현 방식을 지정하는 sealed 인터페이스.
+ *
+ * | 구현체 | 컬럼 구조 예시 |
+ * |---|---|
+ * | [PrefixedColumns] | `id, label, prop.name, prop.age` |
+ * | [RawJsonColumn] | `id, label, properties` (JSON 문자열) |
+ * | [None] | `id, label` (속성 없음) |
+ */
 sealed interface CsvPropertyMode {
 
-    /** 속성 컬럼을 아예 포함하지 않는다. */
+    /** 속성 컬럼을 아예 포함하지 않는다. `id, label` 컬럼만 생성된다. */
     data object None : CsvPropertyMode, Serializable {
         private const val serialVersionUID: Long = 1L
     }

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkExporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkExporter.kt
@@ -21,7 +21,21 @@ import kotlinx.coroutines.withContext
 
 /**
  * CSV 코루틴(suspend) 벌크 익스포터.
+ *
  * suspend 방식으로 정점과 간선을 Flow로 수집하여 CSV 파일로 저장한다.
+ * `Dispatchers.IO`에서 실행되며 Kotlin 코루틴 구조적 동시성을 활용한다.
+ *
+ * ```kotlin
+ * val exporter = SuspendCsvGraphBulkExporter()
+ * val sink = CsvGraphExportSink(
+ *     vertices = GraphExportSink.PathSink(Paths.get("vertices.csv")),
+ *     edges    = GraphExportSink.PathSink(Paths.get("edges.csv")),
+ * )
+ * val report = coroutineScope {
+ *     exporter.exportGraphSuspending(sink, suspendOps, GraphExportOptions(vertexLabels = setOf("Person")))
+ * }
+ * println("exported ${report.verticesWritten} vertices — ${report.status}")
+ * ```
  */
 class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink> {
 

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkImporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkImporter.kt
@@ -26,7 +26,19 @@ import kotlinx.coroutines.withContext
 
 /**
  * CSV 코루틴(suspend) 벌크 임포터.
- * SuspendCsvRecordReader로 정점과 엣지를 Flow로 스트리밍하여 처리한다.
+ *
+ * [SuspendCsvRecordReader]로 정점과 간선을 Flow로 스트리밍하여 처리하는 2-패스 방식이다.
+ * Kotlin 코루틴 구조적 동시성을 활용하며 `Dispatchers.IO`에서 실행된다.
+ *
+ * ```kotlin
+ * val importer = SuspendCsvGraphBulkImporter()
+ * val source = CsvGraphImportSource(
+ *     vertices = GraphImportSource.PathSource(Paths.get("vertices.csv")),
+ *     edges    = GraphImportSource.PathSource(Paths.get("edges.csv")),
+ * )
+ * val report = importer.importGraphSuspending(source, suspendOps, GraphImportOptions())
+ * println("imported ${report.verticesCreated} vertices — ${report.status}")
+ * ```
  */
 class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSource> {
 

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvImportErrorTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvImportErrorTest.kt
@@ -1,0 +1,118 @@
+package io.bluetape4k.graph.io.csv
+
+import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
+import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.options.MissingEndpointPolicy
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class CsvImportErrorTest {
+
+    companion object : KLogging()
+
+    private fun importer() = CsvGraphBulkImporter()
+    private fun ops() = TinkerGraphOperations()
+
+    private fun source(dir: Path, vCsv: String, eCsv: String): CsvGraphImportSource {
+        val vFile = dir.resolve("v.csv").also { it.writeText(vCsv) }
+        val eFile = dir.resolve("e.csv").also { it.writeText(eCsv) }
+        return CsvGraphImportSource(GraphImportSource.PathSource(vFile), GraphImportSource.PathSource(eFile))
+    }
+
+    @Test
+    fun `blank vertex id causes FAILED status`(@TempDir dir: Path) {
+        val src = source(
+            dir,
+            vCsv = "id,label\n,Person\n",
+            eCsv = "id,label,from,to\n",
+        )
+        val report = importer().importGraph(src, ops(), GraphImportOptions())
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.verticesCreated shouldBeEqualTo 0L
+        report.failures shouldHaveSize 1
+    }
+
+    @Test
+    fun `duplicate vertex id with SKIP policy gives PARTIAL status`(@TempDir dir: Path) {
+        val src = source(
+            dir,
+            vCsv = "id,label\nv1,Person\nv1,Person\n",
+            eCsv = "id,label,from,to\n",
+        )
+        val report = importer().importGraph(
+            src,
+            ops(),
+            GraphImportOptions(onDuplicateVertexId = DuplicateVertexPolicy.SKIP),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.PARTIAL
+        report.verticesCreated shouldBeEqualTo 1L
+        report.skippedVertices shouldBeEqualTo 1L
+        report.failures shouldHaveSize 1
+    }
+
+    @Test
+    fun `missing edge endpoint with SKIP_EDGE policy gives PARTIAL status`(@TempDir dir: Path) {
+        val src = source(
+            dir,
+            vCsv = "id,label\nv1,Person\n",
+            eCsv = "id,label,from,to\n,KNOWS,v1,v999\n",
+        )
+        val report = importer().importGraph(
+            src,
+            ops(),
+            GraphImportOptions(onMissingEdgeEndpoint = MissingEndpointPolicy.SKIP_EDGE),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.PARTIAL
+        report.verticesCreated shouldBeEqualTo 1L
+        report.edgesCreated shouldBeEqualTo 0L
+        report.skippedEdges shouldBeEqualTo 1L
+        report.failures shouldHaveSize 1
+    }
+
+    @Test
+    fun `missing edge endpoint with FAIL policy gives FAILED status`(@TempDir dir: Path) {
+        val src = source(
+            dir,
+            vCsv = "id,label\nv1,Person\n",
+            eCsv = "id,label,from,to\n,KNOWS,v1,v999\n",
+        )
+        val report = importer().importGraph(
+            src,
+            ops(),
+            GraphImportOptions(onMissingEdgeEndpoint = MissingEndpointPolicy.FAIL),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.edgesCreated shouldBeEqualTo 0L
+        report.failures shouldHaveSize 1
+    }
+
+    @Test
+    fun `import with multiple vertices and edges sets correct counts`(@TempDir dir: Path) {
+        val src = source(
+            dir,
+            vCsv = "id,label,prop.name\nv1,Person,Alice\nv2,Person,Bob\nv3,Person,Carol\n",
+            eCsv = "id,label,from,to\n,KNOWS,v1,v2\n,KNOWS,v2,v3\n",
+        )
+        val report = importer().importGraph(src, ops(), GraphImportOptions())
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesRead shouldBeEqualTo 3L
+        report.verticesCreated shouldBeEqualTo 3L
+        report.edgesRead shouldBeEqualTo 2L
+        report.edgesCreated shouldBeEqualTo 2L
+        report.elapsed.toMillis() shouldBeGreaterThan 0L
+    }
+}


### PR DESCRIPTION
## 변경 요약

24시간 내 변경 사항(PR #36 — RecordExtensions KDoc + 테스트) 연속 개선 작업.

## 변경 내용

### 테스트 추가 (5개 신규 케이스)

`CsvImportErrorTest` 추가:
- **blank vertex id** → `FAILED` 상태 즉시 중단 검증
- **중복 정점 ID** + `DuplicateVertexPolicy.SKIP` → `PARTIAL` 상태 + skippedVertices 카운터 검증
- **누락 간선 끝점** + `MissingEndpointPolicy.SKIP_EDGE` → `PARTIAL` 상태 + skippedEdges 카운터 검증
- **누락 간선 끝점** + `MissingEndpointPolicy.FAIL` → `FAILED` 상태 검증
- **정상 임포트** 다중 정점/간선 카운터 검증

### KDoc 강화 (코드 예제 포함)

공개 API 8개 클래스에 코드 예제 포함 KDoc 추가:
- `CsvGraphBulkImporter` / `CsvGraphBulkExporter`
- `SuspendCsvGraphBulkImporter` / `SuspendCsvGraphBulkExporter`
- `CsvGraphVirtualThreadBulkImporter` / `CsvGraphVirtualThreadBulkExporter`
- `CsvGraphIoOptions` — 3가지 propertyMode 예시 포함
- `CsvPropertyMode` — 모드별 컬럼 구조 표 추가

### README 업데이트

임포트 섹션 신규 추가:
- CSV 파일 포맷 예시 (정점/간선)
- `GraphImportOptions` 파라미터 설명 표
- 임포트 보고서 사용 예시
- Virtual Thread / Suspend 임포트 예시

## 테스트 결과

`18 passing` (기존 13 + 신규 5)

## 관련 이슈

- PR #36 (RecordExtensions KDoc + 테스트) 후속 작업