### PR TITLE
feat: weighted graph support — Dijkstra/A* shortest path (#31)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-weighted-graph-plan.md
+++ b/docs/superpowers/plans/2026-04-28-weighted-graph-plan.md
@@ -1,0 +1,292 @@
+# 가중치 그래프 지원 구현 계획
+
+- **Issue**: #31 가중치 그래프 지원 — weighted edge + Dijkstra / A\* 최단경로
+- **Spec**: [`docs/superpowers/specs/2026-04-28-weighted-graph-design.md`](../specs/2026-04-28-weighted-graph-design.md)
+- **Status**: Plan (Ready)
+- **Author**: bluetape4k-graph maintainers
+- **Date**: 2026-04-28
+- **관련 모듈**: `graph-core`, `graph-neo4j`, `graph-memgraph`, `graph-age`, `graph-tinkerpop`, `graph-falkordb`, `examples/*`, `benchmark/graph-benchmark`
+
+---
+
+## 개요
+
+본 계획은 Spec(2026-04-28)에서 채택된 **안 B (JVM 폴백 단일 구현)** 와 **A\* 별도 메서드** 결정을 구현 가능한 단위로 분해한다.
+
+설계 핵심 5가지:
+
+1. **JVM fallback 단일 구현** — 모든 백엔드(neo4j/memgraph/age/tinkerpop/falkordb)가 `graph-core`의 `DijkstraRunner`/`AStarRunner`에 위임. 결과 결정성과 코드 중복 제거를 동시에 달성.
+2. **`PathOptions` 비파괴 확장** — `weightProperty`, `missingWeightPolicy`, `direction`, `maxVisited` 모두 default 값. 기존 호출 사이트는 컴파일 변경 없음.
+3. **`GraphPath.totalWeight` 저장 필드** — 가중치 모드 결과를 메타데이터로 보존. unweighted 경로는 length 와 동일한 Double.
+4. **신규 레포지토리 메서드** — `findVertexById(id)` (label-only), `findEdgesByStartId(id, label?)`, `findEdgesByEndId(id, label?)` (sync + suspend). `ShortestPathFallback`이 이 API 를 사용해 백엔드 무관하게 adjacency 를 lazy 로 가져온다.
+5. **`aStarPath` 직접 override** — interface default method 가 `GraphOperations` 합성 타입을 요구하기 때문에, `GraphTraversalRepository`에서는 시그니처만 추가하고 default 본체는 제공하지 않는다. 각 백엔드 `*GraphOperations` 가 직접 `override` 하여 `ShortestPathFallback.aStar(this, ...)` 를 호출한다.
+
+작업 분해 전략: graph-core 기반(모델/옵션/예외 → 레포 인터페이스 → 알고리즘 내부) → 각 백엔드(인터페이스 구현 → shortestPath 분기 → aStarPath override → suspend 변형 → caching 위임) → 테스트(unit → abstract base → backend별) → 벤치마크 → 문서. 백엔드 5개의 작업은 동일 패턴이므로 그룹 task 로 묶고, 백엔드별로 sync/suspend/caching 3변형을 병렬 작업한다.
+
+---
+
+## Task List
+
+### T1 — `MissingWeightPolicy` + `MissingWeightException` 신규 작성
+
+- **complexity**: low
+- **scope**: 1 file (graph-core, ~50 LOC)
+- **설명**: `graph-core/.../model/MissingWeightPolicy.kt` 파일을 생성한다. `sealed class MissingWeightPolicy : Serializable` 와 `data object Fail`, `data object Skip`, `data class UseDefault(value: Double)` 구현. `UseDefault.init { require(value > 0.0 && value.isFinite()) }`. 같은 파일에 `class MissingWeightException(edgeId, key) : IllegalStateException(...)` 정의. 모든 sealed 분기와 companion 에 `serialVersionUID = 1L`.
+- **완료 기준**: 빌드 통과. `MissingWeightPolicy.UseDefault(0.0)` / `UseDefault(Double.NaN)` / `UseDefault(Double.POSITIVE_INFINITY)` 가 IllegalArgumentException 으로 거부되는 단위 테스트 작성.
+
+### T2 — `GraphPath` 에 `totalWeight: Double` 필드 추가
+
+- **complexity**: medium
+- **scope**: 1 file (graph-core) + 회귀 검증
+- **설명**: `data class GraphPath(steps, totalWeight: Double = ...)` 두 번째 파라미터 추가. 기본값은 `steps.filterIsInstance<PathStep.EdgeStep>().size.toDouble()`. `EMPTY = GraphPath(emptyList(), 0.0)` 와 `of(vararg vertices)` 도 갱신(`totalWeight = 0.0`). `serialVersionUID` 유지. 아래 5개 생산 코드 call site 를 명시적으로 확인 후 업데이트:
+  - `AgeGraphOperations.kt:397`
+  - `AgeTypeParser.kt:92`
+  - `FalkorDBGraphOperations.kt:586`
+  - `FalkorDBGraphSuspendOperations.kt:640`
+  - `GraphPath.kt:87, 102` (companion `EMPTY`/`of`)
+  코드베이스 전체에서 `val (` 또는 `componentN` 으로 destructuring 사용처도 grep 확인.
+- **완료 기준**: destructuring 사용처 0 확인. 5개 call site 모두 업데이트 완료. `GraphPath.equals`/`hashCode` 변경으로 기존 단언 실패 여부 확인. 직렬화 라운드트립 테스트 통과.
+
+### T3 — `PathOptions` 4개 신규 필드 추가
+
+- **complexity**: medium
+- **scope**: 1 file (graph-core) + Direction enum 위치 확인
+- **설명**: `data class PathOptions(...)` 에 `weightProperty: String? = null`, `missingWeightPolicy: MissingWeightPolicy = MissingWeightPolicy.Fail`, `direction: Direction = Direction.BOTH`, `maxVisited: Int = 100_000` 추가. `init` 블록에 `require(maxDepth >= 0)`, `require(maxVisited > 0)` 추가. companion `Default = PathOptions()`. `Direction` 이 graph-core 에 없으면 `model/Direction.kt` 신규 작성(`enum class Direction { OUTGOING, INCOMING, BOTH }`).
+- **완료 기준**: 기존 호출(`PathOptions(edgeLabel="...")`) 모두 컴파일 통과. destructuring 사용처 0 확인. 단위 테스트로 음수 maxDepth/0 maxVisited 거부 검증.
+
+### T4 — `GraphVertexRepository` / `GraphSuspendVertexRepository` 에 `findVertexById(id)` overload 추가
+
+- **complexity**: medium
+- **scope**: 2 interface files + impact 분석
+- **설명**: 기존 `findVertexById(label, id)` 옆에 label 없이 ID 만으로 조회하는 `fun findVertexById(id: GraphElementId): GraphVertex?` 추가. suspend 버전 동일. interface default 구현이 가능한지 검토 — 가능하면 default 로 모든 라벨 검색, 불가능하면 abstract 로 두고 백엔드별 구현. (백엔드들이 cypher/gremlin 으로 자연스럽게 ID 단독 매칭이 가능하므로 abstract 권장.)
+- **완료 기준**: `graph-core` 빌드 통과. 모든 백엔드는 후속 task 에서 구현 (T9 ~ T13).
+
+### T5 — `GraphEdgeRepository` / `GraphSuspendEdgeRepository` 에 `findEdgesByStartId` / `findEdgesByEndId` 추가
+
+- **complexity**: medium
+- **scope**: 2 interface files
+- **설명**: 두 메서드 모두 `(id: GraphElementId, edgeLabel: String? = null): List<GraphEdge>` 시그니처. suspend 버전은 `Flow<GraphEdge>` 또는 `List<GraphEdge>` — 기존 EdgeRepository 패턴 따름(현재 패턴 확인 후 일관성 유지). KDoc 에 "결과 순서는 startId/endId 의 lexicographic 오름차순 정렬되어야 한다 — Dijkstra 결정성 보장 위해" 명시.
+- **완료 기준**: 인터페이스 빌드 통과. 결정성 요구사항이 KDoc 으로 명시됨.
+
+### T6 — `GraphTraversalRepository` 변형 3종에 `aStarPath` 시그니처 추가
+
+- **complexity**: medium
+- **scope**: 3 interface files (sync/suspend/VT)
+- **설명**:
+  - `GraphTraversalRepository.aStarPath(fromId, toId, heuristic: (GraphVertex) -> Double, options: PathOptions): GraphPath?` — default 구현 없음, abstract.
+  - `GraphSuspendTraversalRepository.aStarPath(...)` 동일 (suspend) — heuristic 은 동기 함수만 허용 (KDoc 에 명시).
+  - `GraphVirtualThreadTraversalRepository.aStarPathAsync(...): CompletableFuture<GraphPath?>` — 기존 `*Async` 명명 패턴 준수.
+  - `VirtualThreadTraversalAdapter` 구현부에서 `aStarPathAsync` 를 `supplyAsync(virtualExecutor) { underlying.aStarPath(...) }` 로 위임.
+  - **주의**: graph-core 내 `GraphTraversalRepository` 구현체(test double/fake 등)가 있으면 `aStarPath` stub 을 추가해 컴파일 유지. `grep -r "GraphTraversalRepository" graph-core/src/test` 로 확인.
+- **완료 기준**: 시그니처만 추가. 백엔드 구현 미완 상태에서는 컴파일 에러 발생 — 후속 backend tasks 에서 해소. graph-core test fake 가 있으면 stub 추가.
+
+### T7 — `WeightExtractor` 작성
+
+- **complexity**: high
+- **scope**: 1 file (graph-core, ~120 LOC) + 단위 테스트
+- **설명**: `internal object WeightExtractor` 의 `extract(edge, key, policy): Double?` 구현. 검증 순서 엄수: 결측→정책 적용 / Number 타입 / BigDecimal/BigInteger overflow / `toDouble()` / NaN 거부 / `isFinite()` 거부 / `>= 0.0` 검증. `Fail` 정책 결측 시 `MissingWeightException`, 그 외 위반 시 `IllegalArgumentException` (메시지에 edge id, key, raw value 포함). `Skip` 결측 시 null 반환.
+- **완료 기준**: Int/Long/Double/Float/BigDecimal/BigInteger 변환 단위 테스트, NaN/+Infinity/-Infinity/음수 거부, BigDecimal `Double.MAX_VALUE` 초과 거부, BigInteger `Long.MAX_VALUE` 초과 거부, Skip/Fail/UseDefault 분기 모두 통과. 커버리지 95% 이상.
+
+### T8 — `PathReconstructor` 헬퍼 작성
+
+- **complexity**: low
+- **scope**: 1 file (graph-core, ~40 LOC)
+- **설명**: 두 러너가 공유할 경로 복원 로직. `reconstruct(parent: Map<GraphElementId, Pair<GraphEdge, GraphElementId>>, fromId, toId, vertices: Map<GraphElementId, GraphVertex>): List<PathStep>` — to 에서 from 까지 역추적 후 reverse, `[V, E, V, E, V]` 형태로 반환. fromId 자체가 toId 인 경우 `[VertexStep(from)]` 단일 vertex 경로.
+- **완료 기준**: 단위 테스트로 1-hop / multi-hop / self path 검증.
+
+### T9 — `DijkstraRunner` 작성
+
+- **complexity**: high
+- **scope**: 1 file (graph-core, ~150 LOC) + 단위 테스트
+- **설명**: `internal object DijkstraRunner` + `KLogging companion`. `data class Result(path: GraphPath?, visitedCount: Int, truncated: Boolean = false)`. `run(fromId, toId, maxDepth, maxVisited, fetchIncident, weightOf, startVertex): Result`.
+  - `java.util.PriorityQueue` 사용, `Comparator.comparingDouble { it.cost }.thenComparing { it.vertexId }` (이중 보장).
+  - `settled: HashSet<GraphElementId>`, `parent: HashMap<...>`, `vertexCache: HashMap<GraphElementId, GraphVertex>` (PathReconstructor 에 전달).
+  - `fetchIncident(v).sortedBy { it.second.id.value }` 후 PQ push (cross-backend 결정성).
+  - `weightOf(edge)` 가 null (Skip 결측) → 해당 간선 건너뜀.
+  - `settled.size > maxVisited` → WARN 로그 후 `Result(null, settled.size, truncated=true)`.
+  - `depth >= maxDepth` → WARN 로그 후 더 이상 확장하지 않음 (continue).
+  - to 도달 시 break, PathReconstructor 호출, `totalWeight = dist[to]`.
+  - DEBUG 로그: 시작/완료 정보 (from, to, visited, totalWeight).
+- **완료 기준**: 단위 테스트 — 직선 / 분기 / 동등비용 결정성 / self-loop 무시 / 도달불가 null / maxDepth 초과 / maxVisited 초과(truncated=true) / 결측+Fail/Skip/UseDefault. 커버리지 95%+.
+
+### T10 — `AStarRunner` 작성
+
+- **complexity**: high
+- **scope**: 1 file (graph-core, ~150 LOC) + 단위 테스트
+- **설명**: `internal object AStarRunner` + `KLogging`. Dijkstra 와 동일한 시그니처에 `heuristic: (GraphVertex) -> Double` 파라미터 추가. PQ 키는 `f = g + h(v)`, `g[v]` 별도 관리, `closed` 집합 관리. heuristic 은 이미 `safeHeuristic` (NaN/Infinity/음수 검증 래핑) 으로 들어온다고 가정. PathReconstructor 공유 사용.
+- **완료 기준**: 단위 테스트 — admissible heuristic(h=0)이 Dijkstra 와 동일 결과 / admissible(직선거리)이 visited 감소 / non-admissible 도 종료 보장 / maxDepth & maxVisited / 잘못된 heuristic 입력은 ShortestPathFallback 단계에서 거부됨 (러너 자체는 안전한 입력 가정).
+
+### T11 — `ShortestPathFallback` 작성
+
+- **complexity**: high
+- **scope**: 1 file (graph-core, ~150 LOC)
+- **설명**: `internal object ShortestPathFallback` + `KLogging`. 두 public 함수.
+  - `dijkstra(ops: GraphOperations, fromId, toId, options): GraphPath?` — `requireNotNull(options.weightProperty)`, `ops.findVertexById(fromId/toId)` 검증, `buildFetchIncident(ops, options)` (private), `weightOf = { WeightExtractor.extract(it, weightKey, policy) }`, `DijkstraRunner.run(...)` 호출.
+  - `aStar(ops, fromId, toId, heuristic, options): GraphPath?` — 동일 + `safeHeuristic` 래핑 (`require(h.isFinite() && h >= 0.0)`) 후 `AStarRunner.run(...)` 호출.
+  - `private fun buildFetchIncident(ops, options): (GraphElementId) -> Sequence<Pair<GraphEdge, GraphVertex>>` — `direction` 분기 (OUTGOING/INCOMING/BOTH) 로 `findEdgesByStartId` / `findEdgesByEndId` 호출, vertex 미조회 시 해당 쌍 제외, BOTH 일 때 dedup 은 DijkstraRunner의 settled 가 흡수하므로 단순 concat.
+- **완료 기준**: graph-core 빌드 통과. 통합 테스트는 백엔드별 task 에서 검증.
+
+### T11.5 — `ShortestPathFallbackTest` 단위 테스트 (fake GraphOperations)
+
+- **complexity**: medium
+- **scope**: 1 test file (graph-core)
+- **설명**: fake `GraphOperations` (in-memory adjacency map) 으로 `ShortestPathFallback` 직접 테스트. direction 분기 (OUTGOING/INCOMING/BOTH), `from` 미존재 → null, `to` 미존재 → null, `weightProperty = null` → IllegalArgumentException, 정상 가중치 경로 등 시나리오. PathReconstructor 통합 검증도 겸함.
+- **완료 기준**: OUTGOING/INCOMING/BOTH 각 방향 테스트 통과. early-exit null 케이스 통과.
+
+### T12 — Neo4j 백엔드 구현 (sync/suspend/caching)
+
+- **complexity**: high
+- **scope**: 3 files (`Neo4jGraphOperations.kt`, `Neo4jGraphSuspendOperations.kt`, `CachingNeo4jGraphOperations.kt`)
+- **설명**:
+  - sync `Neo4jGraphOperations`: `findVertexById(id)` (label 없는 cypher: `MATCH (n) WHERE elementId(n) = $id RETURN n`), `findEdgesByStartId(id, edgeLabel?)`, `findEdgesByEndId(id, edgeLabel?)` 구현 (정렬: `ORDER BY elementId(neighbor)`). `shortestPath` 에 `when (options.weightProperty) { null -> 기존 / else -> ShortestPathFallback.dijkstra(this, ...) }` 분기. `aStarPath` override → `ShortestPathFallback.aStar(this, ...)`.
+  - suspend 버전: `withContext(Dispatchers.IO) { underlyingSync.* }` 로 위임 또는 native Driver Async 사용 (현재 패턴 확인 후 일관성).
+  - caching 버전: 신규 메서드도 upstream 위임만, 캐시는 후속 이슈로 유보.
+- **완료 기준**: graph-neo4j 모듈 빌드 통과. 통합 테스트 (`Neo4jWeightedShortestPathTest`) 통과.
+
+### T13 — Memgraph 백엔드 구현 (sync/suspend/caching)
+
+- **complexity**: high
+- **scope**: 3 files
+- **설명**: T12 와 동일 패턴. Memgraph 는 Neo4j 드라이버 호환이지만 `elementId()` 미지원 → `id(n)` 사용. cypher 쿼리는 Memgraph 방언 점검 필수. caching 변형 동일 위임.
+- **완료 기준**: graph-memgraph 빌드 + 통합 테스트 통과.
+
+### T14 — AGE 백엔드 구현 (sync/suspend/caching)
+
+- **complexity**: high
+- **scope**: 3 files (`AgeGraphOperations.kt` 등)
+- **설명**: T12 와 동일 패턴. AGE 는 Cypher-over-SQL 이므로 `findVertexById` / `findEdges*` 의 SQL 래퍼 작성 (기존 BFS 구현체 참조). properties JSON 추출 시 weight 가 jsonb number 로 들어오므로 `WeightExtractor` 가 받아들일 수 있는 `Number` 타입으로 변환되도록 매퍼 점검.
+- **완료 기준**: graph-age 빌드 + 통합 테스트 통과.
+
+### T15 — TinkerPop 백엔드 구현 (sync/suspend)
+
+- **complexity**: high
+- **scope**: 2 files (TinkerPop 은 Caching 변형 없음)
+- **설명**: T12 와 동일 패턴. Gremlin `g.V(id)` / `g.V(id).outE(label).order().by(inV().id())` 등으로 결정적 정렬 보장. 인메모리 TinkerGraph 라서 라이프사이클 단순. 체크리스트:
+  - `findVertexById(id: GraphElementId)` 구현
+  - `findEdgesByStartId(id, edgeLabel?)` 구현 (정렬 보장)
+  - `findEdgesByEndId(id, edgeLabel?)` 구현 (정렬 보장)
+  - `shortestPath` 분기 (`weightProperty != null → ShortestPathFallback.dijkstra`)
+  - `aStarPath` override → `ShortestPathFallback.aStar`
+  - suspend 미러 (5개 메서드 전부)
+- **완료 기준**: graph-tinkerpop 빌드 + 통합 테스트 통과.
+
+### T16 — FalkorDB 백엔드 구현 (sync/suspend)
+
+- **complexity**: high
+- **scope**: 2 files (FalkorDB 는 Caching 변형 없음)
+- **설명**: T12 와 동일 패턴. FalkorDB 는 openCypher 부분집합. `MATCH (n) WHERE id(n) = $id` 로 ID 단독 매칭. jfalkordb 결과 매핑에서 properties Number 타입 보존 점검. 체크리스트:
+  - `findVertexById(id: GraphElementId)` 구현
+  - `findEdgesByStartId(id, edgeLabel?)` 구현 (정렬 보장)
+  - `findEdgesByEndId(id, edgeLabel?)` 구현 (정렬 보장)
+  - `shortestPath` 분기
+  - `aStarPath` override
+  - suspend 미러
+- **완료 기준**: graph-falkordb 빌드 + 통합 테스트 통과.
+
+### T17 — graph-core 단위 테스트 보강 (DijkstraRunner / AStarRunner / WeightExtractor / GraphPath 직렬화 / PathReconstructor)
+
+- **complexity**: medium
+- **scope**: 5 test files
+- **설명**: T1, T7, T8, T9, T10 에서 작성한 테스트를 한 곳에 모아 누락된 시나리오 보강 — `DijkstraRunnerTest`, `AStarRunnerTest`, `WeightExtractorTest`, `GraphPathSerializationTest`, `PathReconstructorTest`. `PathReconstructorTest` 는 T8 완료 기준에 나온 1-hop / multi-hop / self path 시나리오. 각 테스트는 AAA 패턴 + 결정성 (vertex id lexicographic tie-break) 검증 포함. `kluent` + JUnit 5 사용.
+- **완료 기준**: graph-core test 커버리지 신규 코드 95%+. 모든 시나리오(Spec 6.1) 커버.
+
+### T18 — `Abstract*WeightedShortestPathTest` 추상 베이스 + 백엔드별 구체 테스트 5종 (sync)
+
+- **complexity**: high
+- **scope**: 1 abstract + 5 concrete test files (`graph-{neo4j,memgraph,age,tinkerpop,falkordb}` 의 src/test)
+- **설명**: 추상 클래스에 Spec 6.2 그래프 (`A→B→D, A→C→D, A→E dead-end`) 적재 로직 + 시나리오. `shortestPath(weighted) == A→B→D` (totalWeight=3), `aStarPath(admissible) == 동일`, 결측 정책 3종, maxDepth/maxVisited 한도, cross-backend equality (totalWeight + vertex id 순서). 구체 클래스는 백엔드 driver/ops 셋업만 제공. `@TestInstance(PER_CLASS)` + `@BeforeAll` 컨테이너 라이프사이클.
+- **완료 기준**: 5개 백엔드 모두 동일 시나리오에서 동일 결과 반환 (cross-backend assertion 헬퍼로 검증).
+
+### T19 — Suspend 변형 통합 테스트 (`Abstract*WeightedShortestPathSuspendTest` + 5 backend)
+
+- **complexity**: medium
+- **scope**: 1 abstract + 5 concrete test files
+- **설명**: T18 의 suspend 거울. `kotlinx-coroutines-test` `runTest` 사용, `Dispatchers.IO` 컨텍스트에서 동작 검증. heuristic 은 동기 람다.
+- **완료 기준**: suspend 변형이 sync 와 동일 결과 반환.
+
+### T20 — 회귀 테스트 — 기존 unweighted `shortestPath` 동작 보존
+
+- **complexity**: low
+- **scope**: 추가 테스트 케이스 1~2 개 (각 백엔드 기존 테스트 클래스에 추가 또는 abstract 추가)
+- **설명**: `PathOptions()` (default, weightProperty=null) 호출이 기존 hop 수 기준 결과를 그대로 반환하는지 검증. `GraphPath.totalWeight == length.toDouble()` 보장. `GraphPath` 직렬화 라운드트립 (totalWeight 포함). `GraphPath.equals`/`hashCode` 회귀 — 동일 steps 의 두 path 에서 totalWeight 차이가 있으면 equals == false 임을 명시적으로 단언(기존 테스트 조정 필요 여부 확인).
+- **완료 기준**: 기존 회귀 테스트 + 신규 회귀 단언 모두 통과. `./gradlew test` 그린.
+
+### T21 — `WeightedShortestPathBench` JMH 벤치마크 + 결과 기록
+
+- **complexity**: medium
+- **scope**: 1 bench file (benchmark/graph-benchmark) + `docs/benchmark/weighted-shortest-path.md`
+- **설명**: V=1000, E=avg 5 무작위 그래프 (가중치는 1.0~10.0 uniform). Dijkstra (weighted) vs BFS (unweighted) p50/p95 latency. 축: Sync / VirtualThread / Suspend (3축). JMH `@Setup(Trial)` 에서 그래프 한 번 적재, `@Benchmark` 메서드는 무작위 from/to 페어 호출. 결과를 `docs/benchmark/` 에 마크다운 표로 기록. 백엔드는 TinkerGraph(인메모리) + Neo4j(컨테이너) 2종으로 한정 (시간 제약).
+- **완료 기준**: 벤치마크 실행 후 결과 파일 commit. memory 시드 기준 결과 재현 가능.
+
+### T22 — README / CHANGELOG / KDoc 업데이트
+
+- **complexity**: low
+- **scope**: README.md / README.ko.md / CHANGELOG.md + 모든 신규 public 심볼 KDoc 보강
+- **설명**:
+  - README 에 "가중치 최단 경로" 섹션 추가 (Dijkstra + A\* 사용 예시).
+  - CHANGELOG 에 "0.x.y — Weighted shortest path (Dijkstra/A\*) 추가" 항목.
+  - `aStarPath` / `PathOptions` 신규 필드 / `MissingWeightPolicy` / `findVertexById(id)` / `findEdgesByStartId/EndId` 모두 KDoc 보강 (`@param`, `@throws`, `@since`).
+  - 선택적: `docs/superpowers/wiki/weighted-graph-usage.md` 사용 가이드 (별도 PR 가능).
+- **완료 기준**: 빌드 시 dokka 경고 0. README 코드 블록이 실제로 컴파일/실행 가능한 형태.
+
+### T22.5 — bluetape4k-patterns 체크리스트 검증
+
+- **complexity**: low
+- **scope**: 모든 신규/수정 파일 검토
+- **설명**: `bluetape4k-patterns` skill 실행. 신규 파일 전체에 대해:
+  - 모든 `internal object` / `class` 에 `companion object : KLogging()` 또는 `KLoggingChannel()` 존재 확인
+  - public API 에 `@param` / `@throws` / `@since` KDoc 완비
+  - magic number 미존재 (named constant 사용)
+  - AtomicFU 적용 필요 부분 없는지 확인
+  - immutability 위반 없음
+- **완료 기준**: 패턴 위반 0. detekt/ktlint 경고 0.
+
+### T23 — Definition of Done 최종 게이트 (전체 빌드/테스트/벤치마크 검증)
+
+- **complexity**: medium
+- **scope**: 작업이 아닌 게이트 — 전체 검증
+- **설명**:
+  - `./gradlew clean build` 통과 (모든 모듈).
+  - `./gradlew test` 통과.
+  - 신규 코드 커버리지 ≥ 80% (graph-core 러너/추출기 95%+).
+  - ktlint / detekt 통과.
+  - 벤치마크 결과 기록 완료.
+  - 기존 unweighted 테스트 회귀 0.
+  - PR 생성 (commit-push-pr 플로우, conventional commits, 이슈 #31 close 라벨).
+- **완료 기준**: PR open + 모든 CI 통과 + code-reviewer 에이전트 최종 검토 완료.
+
+---
+
+## 작업 순서 / 의존성
+
+```
+T1, T2, T3 (model)            ─┐
+T4, T5, T6 (interface)         ├─→ T7, T8 (utils) ─→ T9, T10 (runners) ─→ T11 (fallback) ─→ T11.5 (fallback unit test)
+                                                                              │
+                                                                              ▼
+                                       T12, T13, T14, T15, T16 (backends, parallel)
+                                                                              │
+                                                                              ▼
+                 T17 (core unit, +PathReconstructor) ─→ T18, T19 (integration) ─→ T20 (regression)
+                                                                              │
+                                                                              ▼
+                                         T21 (bench) ─→ T22 (docs) ─→ T22.5 (patterns) ─→ T23 (DoD gate)
+```
+
+- T12~T16 은 백엔드별 독립이므로 병렬 가능.
+- T17 은 T9/T10/T7/T2 직후 즉시 진행.
+- T20 은 T18/T19 와 병렬 가능 (기존 테스트 수정 없는 한 회귀 단언만 추가).
+- T21 은 T16 까지 완료 후 진행 (백엔드 안정 후 측정 의미 있음).
+
+## 리스크 트래킹 (Spec §2.2 매핑)
+
+| 리스크 | Task |
+|--------|------|
+| R1 음수 weight | T7 (WeightExtractor), T17 |
+| R2 NaN/Infinity | T7, T17 |
+| R3 결측 weight | T1, T7, T17, T18 |
+| R4 거대 그래프 OOM | T3 (maxVisited), T9 (truncated), T17 |
+| R5 부동소수점 비결정성 | T9 (PQ 이중 키), T11 (vertex id 정렬), T18 (cross-backend assertion) |
+| R6 self loop | T9 (settled 흡수) + T17 단위 테스트 |
+| R7 non-admissible heuristic | T10 (종료 보장), T22 (KDoc 경고) |
+| R8 동시성 | 기존 GraphSession 패턴 재사용 (변경 없음) — 회귀 테스트 T20 으로 가시성 |

--- a/docs/superpowers/specs/2026-04-28-weighted-graph-design.md
+++ b/docs/superpowers/specs/2026-04-28-weighted-graph-design.md
@@ -1,0 +1,804 @@
+# 가중치 그래프 지원 — Weighted Edge + Dijkstra / A\* Shortest Path 설계
+
+- **Issue**: #31 가중치 그래프 지원 — weighted edge + Dijkstra / A\* 최단경로
+- **Status**: Draft (Spec)
+- **Author**: bluetape4k-graph maintainers
+- **Date**: 2026-04-28
+- **관련 모듈**: `graph-core`, `graph-neo4j`, `graph-memgraph`, `graph-age`, `graph-tinkerpop`, `graph-falkordb`, `examples/*`, `benchmark/graph-benchmark`
+
+---
+
+## 1. 개요 및 목표
+
+### 1.1 배경
+
+`bluetape4k-graph`는 현재 모든 백엔드(Neo4j / Memgraph / AGE / TinkerPop / FalkorDB)에서 `GraphTraversalRepository.shortestPath` 를 **간선 수(hops) 기준 최단 경로**로 정의한다. 즉, 모든 간선의 비용을 1로 가정한 **unweighted shortest path** 만 지원한다.
+
+실제 그래프 응용(도로망, 라우팅, LinkedIn 1‑hop 친밀도, 코드 의존성 가중치 등)에서는 간선마다 비용(거리, 지연, 신뢰도, 비용)이 다른 **가중치 최단 경로** 가 필수다. 본 설계는 다음을 추가한다.
+
+1. **Edge weight** : `GraphEdge.properties` 에 저장된 숫자 속성을 비용으로 사용하는 표준화된 방식.
+2. **Dijkstra 최단 경로** : `PathOptions.weightProperty` 가 지정되면 가중치 기반으로 동작.
+3. **A\* 최단 경로** : 사용자가 제공하는 휴리스틱 함수로 가속.
+4. **`GraphPath.totalWeight`** : 경로의 총 비용 (가중치 미사용 시 hops 와 동일).
+
+### 1.2 목표
+
+- 기존 `shortestPath` 의 **시그니처를 유지** 하되, `PathOptions.weightProperty` 가 `null` 일 때만 기존 unweighted 동작을 보장한다(완전한 backward compatibility).
+- 가중치 모드일 때 **모든 백엔드에서 동일한 결과**(같은 총 비용·동치 경로 후보 중 결정적 선택)를 보장한다.
+- 백엔드별 native 가중치 알고리즘의 **부재** 를 받아들이고, 첫 단계는 **JVM 폴백 단일 구현** 으로 통일한다.
+- A\* 는 별도 메서드 `aStarPath(...)` 로 추가 — 휴리스틱 함수가 그래프 외부 도메인 지식이라서 옵션 객체에 함수 타입을 두는 것보다 별도 메서드가 더 명확하다.
+- `GraphSuspendOperations`, `VirtualThreadAdapter` 의 이중 API 패턴을 유지한다.
+- 음수 가중치는 **거부(예외)** — Dijkstra 가정 위반이며, Bellman‑Ford 는 본 이슈 범위를 벗어난다.
+
+### 1.3 비목표 (out of scope)
+
+- Bellman‑Ford / Floyd‑Warshall / Johnson 등 음수 가중치 또는 all‑pairs 최단 경로.
+- Native GDS/APOC 호출(Neo4j Graph Data Science). 추후 별도 이슈로.
+- Yen's k‑shortest paths, weighted `allPaths`. (`allPaths` 는 단순 경로 enumeration 정의 유지)
+- 동적 가중치(쿼리 실행 시 평가되는 람다 가중치) — 단순 property 키 기반만 지원.
+
+---
+
+## 2. 브레인스토밍
+
+### 2.1 문제 재정의
+
+> "동일한 출발/도착 사이에서 간선 수가 적은 경로보다 비용 합이 작은 경로가 답이 되어야 한다. 이를 백엔드 추상화를 깨지 않으면서, 다섯 가지 그래프 백엔드에 일관되게, 그리고 결정적인 결과로 제공한다."
+
+**입력 조건**
+
+- `GraphEdge.properties` 의 임의 키(`weight`, `distance`, `cost` 등)가 비용으로 지정될 수 있다.
+- 비용 값 타입은 `Number` (`Int`, `Long`, `Double`, `Float`, `BigDecimal`). 내부적으로 `Double` 로 정규화한다.
+- 일부 간선이 weight 속성을 갖지 않을 수 있다 → 결측 정책 필요.
+
+**제약**
+
+- 백엔드 native 가중 최단경로 미지원(Cypher native, Gremlin core, AGE, FalkorDB 모두).
+- 결과는 결정적이어야 한다(테스트 검증을 위해).
+- 메모리 사용량은 graph-core BFS 구현과 비슷한 수준을 목표 — adjacency map 기반.
+- 코루틴/Flow 호환, 가상 스레드 어댑터 호환.
+
+**불확실성**
+
+- Neo4j 5+에서 `apoc.algo.dijkstra` 호출 가능 여부 — APOC 플러그인 의존이라서 보장 불가.
+- AGE 의 가중치 cypher 지원 — 미지원으로 확인됨.
+- `Number → Double` 변환에서 `BigDecimal` overflow 가능성 — 가능성 있으나 일반적 응용에서는 무시 가능.
+
+### 2.2 설계 위험 / 실패 모드
+
+| # | 위험 | 영향 | 완화책 |
+|---|------|------|--------|
+| R1 | **음수 가중치** 입력 → Dijkstra 무한 루프 / 잘못된 답 | 데이터 정합성 파괴 | 정점/간선 적재 시 검증, `IllegalArgumentException` 즉시 throw |
+| R2 | **NaN / 무한대** 가중치 → 비교 연산 불가 | 동일 (NaN 은 우선순위 큐에서 비교 실패) | NaN 은 거부, +Infinity 는 "통과 불가" 로 해석 (단순 무시) |
+| R3 | **결측 weight 속성** | 일부 간선만 가중치 가짐 → 잘못된 최단경로 | 결측 정책을 옵션으로 노출: `MissingWeightPolicy { FAIL, SKIP, DEFAULT(value) }`. 기본값 `FAIL` |
+| R4 | **거대 그래프** 전체 로딩 → OOM | JVM 폴백이 가장 큰 병목 | `maxDepth` 와 `maxVertices` 로 탐색 영역 제한, 우선순위 큐 결정 시 lazy expansion |
+| R5 | **부동소수점 누적 오차** 로 인한 비결정성 | 동등 비용 경로의 불안정한 선택 | 비용 비교 시 vertex ID 를 보조 키로 사용해 tie‑break 결정성 확보 |
+| R6 | **자기 루프(self loop)** | Dijkstra 에서 처리 가능하지만, 무한 루프 위험 | adjacency 구성 단계에서 `start == end` 간선 제외 옵션 |
+| R7 | **A\* 휴리스틱이 admissible 하지 않음** → 최적 경로 보장 안됨 | 사용자 책임이지만 실수 흔함 | KDoc 에 명시, 디버그 모드에서 sanity check 옵션 (선택) |
+| R8 | 동시성 — 여러 Dijkstra 호출이 백엔드 connection 을 공유 | 커넥션 누수, 데드락 | 기존 `GraphSession` 트랜잭션 패턴 재사용, 한 호출당 단일 connection lease |
+
+### 2.3 접근 방식 비교 (3안)
+
+#### 안 A: **백엔드 native + JVM 폴백 혼합**
+
+각 백엔드별 가능한 경우 native 가중치 알고리즘 사용, 불가능하면 JVM 폴백.
+
+- Neo4j: APOC 또는 GDS 라이브러리 호출(`CALL apoc.algo.dijkstra(...)`).
+- 나머지(AGE, Memgraph core, TinkerPop core, FalkorDB): JVM 폴백.
+
+**장점**: Neo4j + GDS 환경에서 최고 성능.
+**단점**:
+- APOC/GDS 가용성에 따라 **결과 결정성 깨짐** (백엔드별 서로 다른 동치 경로 선택).
+- Neo4j Caching/Suspend 변형 + native fallback 분기 → 코드 폭발.
+- 테스트 매트릭스 폭발(APOC 유/무 경우).
+- Memgraph `WSHORTEST` 도 가능하지만 Memgraph 전용 → 다시 분기.
+
+**판정**: 1단계에서는 보류. 2단계 별도 이슈로 기록.
+
+#### 안 B: **JVM 폴백 단일 구현 (선택)**
+
+`graph-core` 에 `DijkstraRunner`, `AStarRunner` 를 두고, 각 백엔드의 `shortestPath` 가중치 모드는 모두 JVM 러너에 위임. adjacency 는 백엔드의 `neighbors()` / 가중치 속성을 통해 lazy 로 가져온다.
+
+**장점**:
+- **결과 결정성 보장**: 동일 알고리즘, 동일 tie‑break 규칙.
+- 코드 중복 0. graph-core 한 곳만 수정.
+- 백엔드 변경 표면 최소(각 backend 의 `shortestPath` 안에서 분기 한 줄).
+- 테스트 단순.
+
+**단점**:
+- 거대 그래프에서 native GDS 만큼 빠르지는 않다.
+- adjacency 를 만들기 위해 N hops 만큼 백엔드 호출 — 네트워크 RTT 비용.
+
+**완화**:
+- `maxDepth` 로 탐색 영역 제한 (Issue #31 의 `PathOptions` 가 이미 가짐).
+- BatchedNeighborFetch 추후 추가 가능(현 단계 비목표).
+
+**판정**: **채택**. Issue #31 Step 1‑R 결론과 일치하며, 안 A 대비 결정성·구현 비용 trade‑off 가 압도적으로 유리.
+
+#### 안 C: **백엔드별 완전 분리 구현**
+
+각 백엔드 모듈에서 자체적으로 Dijkstra 를 구현하고 `JvmFallback` 도 따로 제공.
+
+**장점**: 백엔드 특이 최적화 가능.
+**단점**: 안 B 와 비교해 모든 단점이 더 심각. 결정성, 테스트, 유지보수 모두 악화. **즉시 기각**.
+
+#### 안 D (rejected variant): **`PathOptions` 에 `heuristic` 함수 필드 추가하여 A\* 도 동일 메서드 처리**
+
+```kotlin
+data class PathOptions(
+    val weightProperty: String? = null,
+    val heuristic: ((GraphVertex) -> Double)? = null,
+    ...
+)
+```
+
+**기각 사유**:
+- `PathOptions` 는 `Serializable` 데이터 클래스 — 함수 타입 필드는 직렬화 불가능.
+- 휴리스틱은 도착 정점에 의존하는 closure 라서 옵션 객체 의미와 어긋남.
+- 호출 의도가 명확하지 않음 (`shortestPath` vs `aStarPath`).
+- 기각하고 **별도 메서드 `aStarPath(fromId, toId, heuristic, options)` 추가** 로 결정.
+
+### 2.4 채택 결정
+
+- **채택**: 안 B (JVM 폴백 단일 구현) + A\* 별도 메서드.
+- 백엔드는 모두 `graph-core` 의 `DijkstraRunner` / `AStarRunner` 에 위임한다.
+- `PathOptions` 는 **확장만** 하고 깨지 않는다(`weightProperty`, `missingWeightPolicy`, `defaultWeight`).
+- `GraphPath.totalWeight` 는 **계산형 프로퍼티** 가 아니라 **저장 필드** 로 둔다 — 가중치 모드의 결과를 메타데이터로 보존하기 위해.
+
+---
+
+## 3. 선택된 설계
+
+### 3.1 모듈 / 패키지 구조
+
+```
+graph/graph-core/
+  src/main/kotlin/io/bluetape4k/graph/
+    model/
+      GraphPath.kt                          (수정: totalWeight 필드 추가)
+      GraphTraversalOptions.kt              (수정: PathOptions 확장)
+      MissingWeightPolicy.kt                (신규)
+    repository/
+      GraphTraversalRepository.kt           (수정: aStarPath 추가)
+      GraphSuspendTraversalRepository.kt    (수정: aStarPath 추가)
+      GraphVirtualThreadTraversalRepository.kt (수정: aStarPath 추가)
+    algo/internal/
+      DijkstraRunner.kt                     (신규)
+      AStarRunner.kt                        (신규)
+      WeightExtractor.kt                    (신규: Number → Double 안전 변환 + 결측 정책)
+      ShortestPathFallback.kt               (신규: 백엔드 위임용 헬퍼)
+```
+
+각 백엔드 모듈(`graph-neo4j`, `graph-memgraph`, `graph-age`, `graph-tinkerpop`, `graph-falkordb`)의 `*GraphOperations.shortestPath` 는 다음과 같이 분기한다.
+
+```kotlin
+override fun shortestPath(
+    fromId: GraphElementId,
+    toId: GraphElementId,
+    options: PathOptions,
+): GraphPath? = when (options.weightProperty) {
+    null -> // 기존 unweighted 구현 그대로
+    else -> ShortestPathFallback.dijkstra(this, fromId, toId, options)
+}
+
+override fun aStarPath(
+    fromId: GraphElementId,
+    toId: GraphElementId,
+    heuristic: (GraphVertex) -> Double,
+    options: PathOptions,
+): GraphPath? = ShortestPathFallback.aStar(this, fromId, toId, heuristic, options)
+```
+
+### 3.2 `PathOptions` 확장
+
+```kotlin
+data class PathOptions(
+    val edgeLabel: String? = null,
+    override val maxDepth: Int = 10,
+    /**
+     * 간선 비용으로 사용할 property 키. null 이면 기존 unweighted (hop 수) shortest path.
+     * 비-null 일 때 Dijkstra 또는 A* (aStarPath 호출 시) 알고리즘이 동작한다.
+     */
+    val weightProperty: String? = null,
+    /**
+     * weightProperty 가 결측인 간선을 처리할 정책.
+     * weightProperty == null 일 때는 무시된다.
+     */
+    val missingWeightPolicy: MissingWeightPolicy = MissingWeightPolicy.Fail,
+    /**
+     * 탐색 방향. unweighted 기존 동작은 BOTH 였으나, 가중치 모드도 동일.
+     * (현 인터페이스에 direction 이 없었으므로 신규 필드로 추가; 기본값 BOTH 로 backward compat 유지)
+     */
+    val direction: Direction = Direction.BOTH,
+    /**
+     * 탐색 중 방문할 최대 정점 수. 이 값을 초과하면 null 반환.
+     * OOM 방지용 안전망. 기본값 100,000.
+     * hop 수 기반인 maxDepth 와 달리 실제 방문 정점 수로 제한한다.
+     */
+    val maxVisited: Int = 100_000,
+): GraphTraversalOptions() {
+    init {
+        require(maxDepth >= 0) { "maxDepth must be >= 0, was $maxDepth" }
+        require(maxVisited > 0) { "maxVisited must be > 0, was $maxVisited" }
+    }
+    companion object {
+        private const val serialVersionUID: Long = 1L
+        val Default = PathOptions()
+    }
+}
+
+sealed class MissingWeightPolicy: Serializable {
+    /** 결측 시 MissingWeightException 던진다 (기본). */
+    data object Fail: MissingWeightPolicy() {
+        private const val serialVersionUID: Long = 1L
+    }
+    /** 결측 간선은 그래프에서 없는 것으로 취급한다. */
+    data object Skip: MissingWeightPolicy() {
+        private const val serialVersionUID: Long = 1L
+    }
+    /**
+     * 결측 시 [value] 를 사용한다. value > 0.0 이어야 한다.
+     * UseDefault(0.0)은 허용하지 않는다 — zero-cost 간선이 있으면 무한 확장 위험이 있어
+     * maxVisited 한도를 초과할 수 있다.
+     */
+    data class UseDefault(val value: Double): MissingWeightPolicy() {
+        private const val serialVersionUID: Long = 1L
+        init { require(value > 0.0 && value.isFinite()) { "default weight must be finite and > 0, was $value" } }
+    }
+    companion object { private const val serialVersionUID: Long = 1L }
+}
+```
+
+> **호환성 노트**: `PathOptions` 의 모든 신규 필드는 기본값을 갖는다. 기존 호출 사이트는 컴파일 변경 없이 동작한다. `direction` 필드 추가는 data class 의 `componentN` 변경을 일으키지만 public API 사용자가 destructuring 으로 의존하는 사례는 없다고 판단(`grep` 으로 검증 예정). 만약 발견되면 `direction` 은 추가하지 않고 백엔드별 기본값 BOTH 로 처리한다.
+
+### 3.3 `GraphPath` 확장
+
+```kotlin
+data class GraphPath(
+    val steps: List<PathStep>,
+    /**
+     * 가중치 모드 결과의 총 비용. unweighted 경로면 [length] 와 동일한 값을 갖는다.
+     * 가중치 미적용으로 계산된 경로의 경우 length.toDouble() 으로 채운다.
+     */
+    val totalWeight: Double = steps.filterIsInstance<PathStep.EdgeStep>().size.toDouble(),
+): Serializable {
+    val vertices: List<GraphVertex> get() = steps.filterIsInstance<PathStep.VertexStep>().map { it.vertex }
+    val edges: List<GraphEdge> get() = steps.filterIsInstance<PathStep.EdgeStep>().map { it.edge }
+    val length: Int get() = edges.size
+    val isEmpty: Boolean get() = steps.isEmpty()
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+        val EMPTY = GraphPath(emptyList(), 0.0)
+        fun of(vararg vertices: GraphVertex): GraphPath =
+            GraphPath(vertices.map { PathStep.VertexStep(it) }, totalWeight = 0.0)
+    }
+}
+```
+
+> **호환성 노트**: 두 번째 파라미터에 기본값이 있어 기존 `GraphPath(steps)` 호출은 깨지지 않는다. `componentN` 변경(component2 추가)은 destructuring 깨질 수 있으나, 코드베이스 검색으로 `val (s, _) = path` 사용 사례 없음을 확인 후 진행한다.
+
+### 3.4 인터페이스 추가
+
+> **설계 결정 (Spec Review 반영)**: `aStarPath` default method 는 `GraphTraversalRepository` 가 아닌
+> 각 백엔드 `*GraphOperations` 에 `override` 로 직접 구현한다.
+> 이유: `ShortestPathFallback` 이 `GraphEdgeRepository`/`GraphVertexRepository` API 를 필요로 하는데
+> `GraphTraversalRepository` 는 이를 포함하지 않으며, `GraphOperations` 는 모든 레포지토리를 합성하는 타입이다.
+> 따라서 interface default method 방식을 사용하면 타입 불일치로 컴파일 실패가 발생한다.
+> 각 구체 클래스가 `override` 하면 `this` 가 `GraphOperations` 타입이므로 문제 없다.
+
+#### `GraphTraversalRepository` — 메서드 시그니처만 추가 (default 구현 없음)
+
+```kotlin
+/**
+ * 두 정점 사이의 가중치 최단 경로를 A* 알고리즘으로 찾는다.
+ *
+ * @param heuristic 도착 정점까지의 추정 비용 함수. admissible (실제 비용 이하) 이어야 최적성이 보장된다.
+ *                  non-admissible 이어도 결과는 반환되지만 최적이 아닐 수 있다.
+ *                  반환값은 반드시 `>= 0.0` 의 유한 Double 이어야 한다 (NaN/Infinity 금지).
+ * @param options weightProperty 가 반드시 지정되어야 한다. null 이면 함수 시작 시 IllegalArgumentException.
+ *
+ * 사용 지침:
+ * - 휴리스틱 없이 순수 비용 기반 탐색: `shortestPath(from, to, PathOptions(weightProperty="cost"))` 사용.
+ * - 도메인 지식으로 탐색 가속 가능할 때만 `aStarPath` 사용 (예: 지도 유클리드 거리).
+ */
+fun aStarPath(
+    fromId: GraphElementId,
+    toId: GraphElementId,
+    heuristic: (GraphVertex) -> Double,
+    options: PathOptions,
+): GraphPath?
+```
+
+#### `GraphSuspendTraversalRepository` — suspend heuristic 는 사용하지 않음
+
+```kotlin
+/**
+ * suspend 변형. heuristic 은 순수 동기 함수여야 한다.
+ * (suspend 함수를 heuristic 으로 받으면 DijkstraRunner 동기 루프 내에서 runBlocking 필요 →
+ *  dispatcher 차단 위험이 있어 금지)
+ */
+suspend fun aStarPath(
+    fromId: GraphElementId,
+    toId: GraphElementId,
+    heuristic: (GraphVertex) -> Double,
+    options: PathOptions,
+): GraphPath?
+```
+
+#### `GraphVirtualThreadTraversalRepository` — `aStarPathAsync` (기존 Async suffix 패턴 준수)
+
+```kotlin
+fun aStarPathAsync(
+    fromId: GraphElementId,
+    toId: GraphElementId,
+    heuristic: (GraphVertex) -> Double,
+    options: PathOptions,
+): CompletableFuture<GraphPath?>
+```
+
+### 3.5 `DijkstraRunner` 설계
+
+```kotlin
+/**
+ * Dijkstra 최단 경로 JVM 폴백 러너.
+ *
+ * adjacency 는 lazy 로 백엔드에서 가져온다(closure).
+ * 음수/NaN/Infinity 가중치는 WeightExtractor 단계에서 IllegalArgumentException.
+ *
+ * KLogging companion 포함 — DEBUG 로그(완료), WARN 로그(maxDepth/maxVisited 초과).
+ */
+internal object DijkstraRunner {
+    private val log = KLogging().logger
+
+    data class Result(
+        val path: GraphPath?,
+        val visitedCount: Int,
+        val truncated: Boolean = false,  // maxVisited 초과로 조기 종료됐으면 true
+    )
+
+    /**
+     * @param fetchIncident 정점에서 인접 (간선, 이웃 정점) 쌍을 반환.
+     *        direction 처리(`OUTGOING`/`INCOMING`/`BOTH`)는 ShortestPathFallback 에서 적용.
+     *        결정적 결과를 위해 반환 순서는 vertex ID lexicographic 오름차순 정렬되어야 한다.
+     * @param weightOf 간선의 비용 (WeightExtractor 적용 후; SKIP 정책 결측이면 null).
+     * @param maxVisited 최대 방문 정점 수. 초과 시 null 반환 (WARN 로그).
+     */
+    fun run(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        maxDepth: Int,
+        maxVisited: Int,
+        fetchIncident: (GraphElementId) -> Sequence<Pair<GraphEdge, GraphVertex>>,
+        weightOf: (GraphEdge) -> Double?,
+        startVertex: GraphVertex,
+    ): Result { ... }
+}
+```
+
+**핵심 알고리즘**
+
+```
+dist[from] = 0.0
+PQ = MinHeap<(cost, vertexId, depth, prevEdge?, prevVertexId?)>
+PQ.add((0, from, 0, null, null))
+
+while PQ not empty:
+    (cost, v, depth, prevEdge, prevV) = PQ.pop()
+    if v in settled: continue
+    settled.add(v)
+    parent[v] = (prevEdge, prevV)
+    if settled.size > maxVisited:
+        log.warn { "maxVisited($maxVisited) exceeded, stopping search" }
+        return Result(null, settled.size, truncated=true)
+    if v == to: break
+    if depth >= maxDepth:
+        log.warn { "maxDepth($maxDepth) reached at vertex $v" }
+        continue
+    // fetchIncident 는 정렬된 순서로 반환 → cross-backend 결정성 보장
+    for (edge, w) in fetchIncident(v).sortedBy { it.second.id.value }:
+        weight = weightOf(edge) ?: continue   // SKIP 정책일 때 null
+        // WeightExtractor 가 이미 NaN/Infinity/음수를 거부했으므로 assert only
+        assert(weight >= 0.0 && weight.isFinite())
+        if w in settled: continue
+        newCost = cost + weight
+        PQ.add((newCost, w.id, depth+1, edge, v))
+
+if to !in settled: return Result(null, settled.size)
+log.debug { "Dijkstra: from=$fromId to=$toId visited=${settled.size} totalWeight=${dist[to]}" }
+reconstructPath(parent, from, to) → Result(GraphPath(steps, totalWeight=dist[to]), settled.size)
+```
+
+**Tie‑break**: `fetchIncident` 결과를 vertex ID lexicographic 오름차순 정렬 후 삽입하여 동비용 경로 중 결정적 선택 보장. PQ Comparator 는 `comparingDouble(cost).thenComparing(vertexId)` 로 이중 보장.
+
+**구현 디테일**
+
+- `java.util.PriorityQueue` 사용. `Comparator.comparingDouble<…>(cost).thenComparing(vertexId)`.
+- `settled` 를 `HashSet<GraphElementId>` 로 관리.
+- `parent` 를 `HashMap<GraphElementId, Pair<GraphEdge, GraphElementId>>`.
+- 경로 복원 시 `from→to` 를 list 로 역추적 후 reverse.
+
+### 3.6 `AStarRunner` 설계
+
+Dijkstra 와 거의 동일하지만 PQ 키가 `f = g + h` 이고, `g[v]` 와 `closed` 를 별도로 관리한다.
+heuristic 반환값은 `ShortestPathFallback.aStar` 에서 이미 NaN/Infinity/음수를 검증한 `safeHeuristic` 으로 래핑하여 전달된다. **non‑admissible** 이어도 종료는 보장한다(다만 최적이 아닐 수 있음).
+
+```kotlin
+/**
+ * A* 최단 경로 JVM 폴백 러너.
+ * KLogging companion 포함 — DEBUG (완료), WARN (maxDepth/maxVisited 초과).
+ */
+internal object AStarRunner {
+    private val log = KLogging().logger
+
+    fun run(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        maxDepth: Int,
+        maxVisited: Int,
+        fetchIncident: (GraphElementId) -> Sequence<Pair<GraphEdge, GraphVertex>>,
+        weightOf: (GraphEdge) -> Double?,
+        heuristic: (GraphVertex) -> Double,   // 이미 검증된 safeHeuristic 전달
+        startVertex: GraphVertex,
+    ): DijkstraRunner.Result { ... }
+}
+```
+
+> 두 러너는 50% 공통 로직(경로 복원, settled 관리)을 가진다. 내부 `PathReconstructor` 헬퍼로 공유.
+
+### 3.7 `WeightExtractor` 설계
+
+```kotlin
+internal object WeightExtractor {
+    /**
+     * 간선에서 비용 추출.
+     *
+     * 검증 순서:
+     * 1. 결측 여부 → policy 적용
+     * 2. Number 타입 확인
+     * 3. BigDecimal/BigInteger overflow → Infinity 방지 (Double.MAX_VALUE 초과 시 예외)
+     * 4. `toDouble()` 변환
+     * 5. NaN 거부
+     * 6. +Infinity / -Infinity 거부 (isFinite() 검사)
+     * 7. 음수 거부
+     *
+     * @return 비용 (>= 0, finite). SKIP 정책 + 결측 시 null.
+     * @throws MissingWeightException Fail 정책 + 결측 시
+     * @throws IllegalArgumentException NaN / Infinity / 음수 / 타입 불일치
+     */
+    fun extract(edge: GraphEdge, key: String, policy: MissingWeightPolicy): Double? {
+        val raw = edge.properties[key]
+        return when {
+            raw == null -> when (policy) {
+                MissingWeightPolicy.Fail ->
+                    throw MissingWeightException(edge.id, key)
+                MissingWeightPolicy.Skip -> null
+                is MissingWeightPolicy.UseDefault -> policy.value
+            }
+            raw is Number -> {
+                // BigDecimal/BigInteger overflow 방지: toDouble() 전 범위 검사
+                if (raw is java.math.BigDecimal) {
+                    require(raw.abs() <= java.math.BigDecimal(Double.MAX_VALUE)) {
+                        "edge ${edge.id} weight '$key' BigDecimal overflow: $raw"
+                    }
+                }
+                if (raw is java.math.BigInteger) {
+                    require(raw.abs() <= java.math.BigInteger.valueOf(Long.MAX_VALUE)) {
+                        "edge ${edge.id} weight '$key' BigInteger overflow: $raw"
+                    }
+                }
+                val d = raw.toDouble()
+                require(!d.isNaN()) { "edge ${edge.id} weight '$key' is NaN" }
+                require(d.isFinite()) { "edge ${edge.id} weight '$key' is Infinite: $d" }
+                require(d >= 0.0) { "edge ${edge.id} weight '$key' is negative: $d" }
+                d
+            }
+            else -> error("edge ${edge.id} weight '$key' is not Number: ${raw::class}")
+        }
+    }
+}
+
+/** Fail 정책 결측 시 전용 예외 — 로그 집계 및 모니터링 알림 설정 가능. */
+class MissingWeightException(
+    val edgeId: GraphElementId,
+    val key: String,
+) : IllegalStateException("edge $edgeId missing weight property '$key'")
+```
+
+### 3.8 `ShortestPathFallback` (백엔드 위임 헬퍼)
+
+`GraphOperations` (= `GraphVertexRepository` + `GraphEdgeRepository` + 모든 레포지토리 합성 타입) 를 파라미터로 받는다.
+인터페이스 default method 대신 각 백엔드 `*GraphOperations.aStarPath` 의 `override` 에서 직접 호출한다.
+
+```kotlin
+internal object ShortestPathFallback {
+    private val log = KLogging().logger
+
+    /**
+     * Dijkstra 위임.
+     * ops 는 GraphVertexRepository + GraphEdgeRepository 를 구현한 타입이어야 한다.
+     */
+    fun dijkstra(
+        ops: GraphOperations,
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+    ): GraphPath? {
+        val weightKey = requireNotNull(options.weightProperty) { "weightProperty must be set for Dijkstra" }
+        // label 없이 ID 만으로 조회 — GraphVertexRepository 의 findById(id) API 사용
+        // (label+id 2-파라미터 API 가 아니라 ID-only lookup 이 필요하면 backend가 구현해야 함)
+        val start = ops.findVertexById(fromId) ?: return null
+        ops.findVertexById(toId) ?: return null
+
+        log.debug { "[Dijkstra JVM fallback] from=$fromId to=$toId weightKey=$weightKey direction=${options.direction}" }
+
+        val fetchIncident: (GraphElementId) -> Sequence<Pair<GraphEdge, GraphVertex>> = { id ->
+            // GraphEdgeRepository API 를 사용해 direction 별 incident 간선 로드
+            // OUTGOING: findEdgesByStartVertex(id, edgeLabel) → (edge, endVertex)
+            // INCOMING: findEdgesByEndVertex(id, edgeLabel) → (edge, startVertex)
+            // BOTH: 위 두 결과 연결 (중복 정점 id 로 dedup)
+            buildSequence {
+                if (options.direction == Direction.OUTGOING || options.direction == Direction.BOTH) {
+                    yieldAll(ops.findEdgesByStartId(id, options.edgeLabel).map { e ->
+                        e to (ops.findVertexById(e.endId) ?: return@map null)
+                    }.filterNotNull())
+                }
+                if (options.direction == Direction.INCOMING || options.direction == Direction.BOTH) {
+                    yieldAll(ops.findEdgesByEndId(id, options.edgeLabel).map { e ->
+                        e to (ops.findVertexById(e.startId) ?: return@map null)
+                    }.filterNotNull())
+                }
+            }
+        }
+        val weightOf: (GraphEdge) -> Double? = {
+            WeightExtractor.extract(it, weightKey, options.missingWeightPolicy)
+        }
+
+        return DijkstraRunner.run(
+            fromId, toId, options.maxDepth, options.maxVisited, fetchIncident, weightOf, start
+        ).path
+    }
+
+    fun aStar(
+        ops: GraphOperations,
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        heuristic: (GraphVertex) -> Double,
+        options: PathOptions,
+    ): GraphPath? {
+        requireNotNull(options.weightProperty) { "weightProperty must be set for A*" }
+        val start = ops.findVertexById(fromId) ?: return null
+        ops.findVertexById(toId) ?: return null
+
+        // heuristic 반환값 래핑 — NaN / Infinity / 음수 검증
+        val safeHeuristic: (GraphVertex) -> Double = { v ->
+            heuristic(v).also { h ->
+                require(h.isFinite() && h >= 0.0) {
+                    "heuristic must return finite non-negative value, got $h for vertex ${v.id}"
+                }
+            }
+        }
+        val fetchIncident = buildFetchIncident(ops, options)
+        val weightOf: (GraphEdge) -> Double? = {
+            WeightExtractor.extract(it, options.weightProperty!!, options.missingWeightPolicy)
+        }
+        return AStarRunner.run(
+            fromId, toId, options.maxDepth, options.maxVisited,
+            fetchIncident, weightOf, safeHeuristic, start
+        ).path
+    }
+
+    private fun buildFetchIncident(
+        ops: GraphOperations,
+        options: PathOptions,
+    ): (GraphElementId) -> Sequence<Pair<GraphEdge, GraphVertex>> = { id ->
+        buildSequence {
+            if (options.direction == Direction.OUTGOING || options.direction == Direction.BOTH) {
+                yieldAll(ops.findEdgesByStartId(id, options.edgeLabel).map { e ->
+                    e to (ops.findVertexById(e.endId) ?: return@map null)
+                }.filterNotNull())
+            }
+            if (options.direction == Direction.INCOMING || options.direction == Direction.BOTH) {
+                yieldAll(ops.findEdgesByEndId(id, options.edgeLabel).map { e ->
+                    e to (ops.findVertexById(e.startId) ?: return@map null)
+                }.filterNotNull())
+            }
+        }
+    }
+}
+```
+
+> **신규 `GraphEdgeRepository` 메서드 필요**: `findEdgesByStartId(id, edgeLabel?)` 과 `findEdgesByEndId(id, edgeLabel?)`.
+> 현재 `GraphEdgeRepository` 에 vertex-scoped edge 조회 API 가 없으므로 이를 추가해야 한다.
+> 이는 `graph-core` 인터페이스 + 모든 백엔드 구현 변경을 수반한다. Task 목록에 반영.
+
+### 3.9 백엔드별 위임 전략 (요약)
+
+| 백엔드 | unweighted 경로 (현재 유지) | 가중치 / A\* 경로 (신규) |
+|--------|----------------------------|-------------------------|
+| Neo4j | Cypher `shortestPath()` | `ShortestPathFallback` |
+| Memgraph | Cypher BFS + `ORDER BY length(p) LIMIT 1` | `ShortestPathFallback` |
+| AGE | AGE Cypher subset BFS | `ShortestPathFallback` |
+| TinkerPop | Gremlin `path()` | `ShortestPathFallback` |
+| FalkorDB | openCypher BFS | `ShortestPathFallback` |
+| Caching\* (각 backend) | upstream 위임 | upstream 위임 (그대로 통과) |
+
+**Suspend / VirtualThread 어댑터**: 동기 구현을 `withContext(Dispatchers.IO)` / `CompletableFuture.supplyAsync(virtualExecutor)` 로 래핑. 휴리스틱이 suspend 인 경우, 어댑터에서 동기 람다로 `runBlocking` 변환 후 동기 러너에 전달(가상 스레드라서 안전).
+
+### 3.10 결정성 / 에러 정책 요약
+
+- 음수 weight → `IllegalArgumentException`
+- NaN weight → `IllegalArgumentException`
+- +Infinity / -Infinity weight → `IllegalArgumentException` (isFinite() 검사 추가)
+- BigDecimal/BigInteger overflow → `IllegalArgumentException` (toDouble() 전 범위 검사)
+- 결측 weight + Fail → `MissingWeightException` (IllegalStateException 하위)
+- weightProperty 가 `aStarPath` 에 null → `IllegalArgumentException("weightProperty required for aStarPath")`
+- maxDepth 음수 → `IllegalArgumentException` (data class init 에서)
+- maxVisited 0 이하 → `IllegalArgumentException` (data class init 에서)
+- heuristic 이 NaN/Infinity/음수 반환 → `IllegalArgumentException` (ShortestPathFallback 에서 래핑 검증)
+- UseDefault(0.0) → `IllegalArgumentException` (MissingWeightPolicy.UseDefault init 에서)
+- from 또는 to 가 존재하지 않음 → `null` 반환 (현재 unweighted 와 동일 정책 유지)
+
+---
+
+## 4. 구현 범위
+
+### 4.1 신규 파일
+
+| 경로 | 책임 |
+|------|------|
+| `graph-core/.../model/MissingWeightPolicy.kt` | 결측 정책 sealed class + MissingWeightException |
+| `graph-core/.../algo/internal/DijkstraRunner.kt` | Dijkstra 알고리즘 (KLogging 포함) |
+| `graph-core/.../algo/internal/AStarRunner.kt` | A\* 알고리즘 (KLogging 포함) |
+| `graph-core/.../algo/internal/WeightExtractor.kt` | weight Number → Double 변환 + 정책 (BigDecimal overflow + isFinite 포함) |
+| `graph-core/.../algo/internal/ShortestPathFallback.kt` | 백엔드 위임 헬퍼 (KLogging + direction-aware fetchIncident 포함) |
+| `graph-core/.../algo/internal/PathReconstructor.kt` | 두 러너 공유 경로 복원 |
+
+### 4.2 수정 파일
+
+| 경로 | 변경 |
+|------|------|
+| `graph-core/.../model/GraphPath.kt` | `totalWeight: Double` 필드 추가, `EMPTY`/`of(...)` 갱신 |
+| `graph-core/.../model/GraphTraversalOptions.kt` | `PathOptions` 에 `weightProperty`, `missingWeightPolicy`, `direction`, `maxVisited` |
+| `graph-core/.../repository/GraphEdgeRepository.kt` | `findEdgesByStartId(id, edgeLabel?)` + `findEdgesByEndId(id, edgeLabel?)` 추가 |
+| `graph-core/.../repository/GraphSuspendEdgeRepository.kt` | 동일 suspend 버전 |
+| `graph-core/.../repository/GraphTraversalRepository.kt` | `aStarPath` 시그니처 추가 (default 구현 없음) |
+| `graph-core/.../repository/GraphSuspendTraversalRepository.kt` | `aStarPath` suspend 시그니처 추가 |
+| `graph-core/.../repository/GraphVirtualThreadTraversalRepository.kt` | `aStarPathAsync` 시그니처 추가 |
+| `graph-core/.../vt/VirtualThreadTraversalAdapter.kt` | `aStarPathAsync` 위임 구현 |
+| `graph-neo4j/.../Neo4jGraphOperations.kt` | `shortestPath` 분기, `aStarPath` override, `findEdgesByStartId`/`findEdgesByEndId` 구현 |
+| `graph-neo4j/.../Neo4jGraphSuspendOperations.kt` | 동일 suspend 버전 |
+| `graph-neo4j/.../CachingNeo4jGraphOperations.kt` | upstream 위임만 |
+| `graph-memgraph/.../*GraphOperations.kt` | 위와 동일 패턴 |
+| `graph-age/.../*GraphOperations.kt` | 위와 동일 패턴 |
+| `graph-tinkerpop/.../*GraphOperations.kt` | 위와 동일 패턴 |
+| `graph-falkordb/.../*GraphOperations.kt` | 위와 동일 패턴 |
+
+### 4.3 테스트 파일
+
+| 경로 | 내용 |
+|------|------|
+| `graph-core/src/test/.../algo/internal/DijkstraRunnerTest.kt` | 단위: 기본/타이브레이크/maxDepth/maxVisited/결측 정책/음수/NaN/Infinity |
+| `graph-core/src/test/.../algo/internal/AStarRunnerTest.kt` | 단위: admissible/non-admissible 휴리스틱, Dijkstra 일치 검증, 잘못된 heuristic(NaN/음수) 거부 |
+| `graph-core/src/test/.../algo/internal/WeightExtractorTest.kt` | 단위: Int/Long/Double/Float/BigDecimal/BigInteger 변환, Infinity 거부, BigDecimal overflow 거부, 결측 정책 3종 |
+| `graph-core/src/test/.../model/GraphPathSerializationTest.kt` | totalWeight 직렬화 라운드트립 |
+| `graph-{neo4j,memgraph,age,tinkerpop,falkordb}/src/test/.../*WeightedShortestPathTest.kt` | 백엔드별 통합. 동일 그래프, 동일 결과 검증 |
+| 위와 같은 `*Suspend*Test.kt` | 코루틴 변형 |
+| `examples/code-graph-examples/.../Abstract*WeightedTest.kt` | (선택) 가중치 예시 |
+| `benchmark/graph-benchmark/.../WeightedShortestPathBench.kt` | JMH: V=1e3/1e4, E=avg 5, weighted vs unweighted 비교 |
+
+### 4.4 문서
+
+- `README.md` / `README.ko.md` 가중치 사용 예시 섹션 추가.
+- `docs/superpowers/wiki/weighted-graph-usage.md` 사용 가이드(선택, 별도 PR 가능).
+- `CHANGELOG.md` 항목.
+
+---
+
+## 5. Definition of Done (DoD)
+
+### 5.1 기능
+
+- [ ] `PathOptions(weightProperty = "weight")` 로 모든 백엔드에서 가중치 최단 경로가 반환된다.
+- [ ] 모든 백엔드에서 동일 그래프 / 동일 옵션 → 동일 `GraphPath` (vertices id 순서 + totalWeight) 반환을 통합 테스트로 보장.
+- [ ] `aStarPath(...)` 가 admissible 휴리스틱일 때 Dijkstra 와 동일 결과를 낸다 (테스트 검증).
+- [ ] `GraphPath.totalWeight` 가 정확히 비용의 합이며, unweighted 경로일 때는 length 와 동일.
+- [ ] 음수/NaN/결측(Fail) 입력에 대해 명시된 예외가 던져진다.
+- [ ] Suspend 변형, VirtualThread 어댑터 모두 위 기능을 동일하게 노출한다.
+
+### 5.2 품질
+
+- [ ] `./gradlew build` 통과 (전체).
+- [ ] `./gradlew test` 통과.
+- [ ] 신규 코드 커버리지 ≥ 80% (DijkstraRunner / AStarRunner / WeightExtractor 는 95%+ 목표).
+- [ ] 기존 `shortestPath` 동작 회귀 없음(unweighted 결과 그대로).
+- [ ] Kotlin 2.3, Java 25 preview 환경 빌드 성공.
+- [ ] ktlint / detekt 통과.
+
+### 5.3 벤치마크
+
+- [ ] `WeightedShortestPathBench` JMH 결과를 `docs/benchmark/` 에 기록.
+- [ ] V=1000, E=avg 5 그래프에서 Dijkstra latency p50 / p95 측정.
+- [ ] 동일 조건 unweighted BFS 와 비교 표 첨부.
+
+### 5.4 문서
+
+- [ ] `README` 의 사용 예시에 weighted 한 블록 추가.
+- [ ] `CHANGELOG.md` 0.x.y 섹션에 항목 추가.
+- [ ] KDoc 으로 모든 신규 public 심볼 문서화 (Kotlin coding style 규칙 준수).
+
+---
+
+## 6. 테스트 계획
+
+### 6.1 단위 테스트 (graph-core)
+
+`DijkstraRunnerTest`:
+- 직선 그래프 A→B→C (weight 1, 2): totalWeight=3, 경로 [A,B,C].
+- 분기 그래프 A→B→D vs A→C→D (각 1+1=2, 1.5+0.4=1.9): A→C→D 선택.
+- 동등 비용 분기 — 결정성: vertex id lexicographic 작은 쪽 선택.
+- self loop 무시.
+- 도달 불가 → null.
+- maxDepth 초과 → null.
+- 음수 가중치 입력 → IllegalArgumentException.
+- NaN 가중치 → IllegalArgumentException.
+- 결측 + Fail → IllegalStateException.
+- 결측 + Skip → 해당 간선 제외하고 계산.
+- 결측 + UseDefault(5.0) → 5.0 사용.
+
+`AStarRunnerTest`:
+- admissible heuristic (h=0): Dijkstra 와 동일 결과.
+- admissible heuristic (h=직선거리): 동일 결과 + visited count 감소.
+- non-admissible heuristic: 결과 다를 수 있음을 명시적으로 표현.
+- maxDepth 동일 동작.
+
+`WeightExtractorTest`:
+- Int / Long / Double / Float / BigDecimal → Double 변환.
+- String → Number 캐스트 실패 시 IllegalStateException.
+- 정책 3종 분기.
+
+### 6.2 통합 테스트 (백엔드별)
+
+각 백엔드에서 다음 시나리오를 동일 코드로 실행하는 `Abstract*WeightedShortestPathTest`:
+
+```
+A --1--> B --2--> D
+A --3--> C --1--> D
+A --1--> E (dead-end)
+```
+
+- `shortestPath(A, D, weightProperty="weight")` → A→B→D, totalWeight=3
+- `shortestPath(A, D, weightProperty="weight", maxDepth=1)` → null
+- `aStarPath(A, D, h={ if(it==D) 0.0 else 1.0 }, opts)` → A→B→D
+- 결측 정책별 동작
+- 동일 그래프에 대해 모든 백엔드에서 동일 결과 (cross-backend equality assertion)
+
+### 6.3 회귀 테스트
+
+- 기존 `shortestPath` 호출(weightProperty 없음)은 hop 수 기준 동작 유지.
+- `GraphPath.equals` / `hashCode` / 직렬화 라운드트립.
+
+### 6.4 벤치마크 (graph-benchmark)
+
+- `WeightedDijkstraBench`: 1k / 10k vertex 무작위 그래프, edge density avg 5.
+- `UnweightedBfsBench` 기존 비교군.
+- Sync vs VirtualThread vs Suspend 3축.
+
+---
+
+## 7. 마이그레이션 / 호환성
+
+- **API 추가만**, 기존 시그니처 무변경.
+- `GraphPath` 의 `componentN` 변경 가능성 — 코드베이스 grep 으로 destructuring 사용처 0 확인 후 진행. 사용처 발견 시 `totalWeight` 를 `data class` 본체가 아닌 별도 백킹 필드 + `copy(steps=...)` 패턴으로 우회.
+- `PathOptions` 도 동일하게 검증.
+- Spring Boot starter 자동 설정은 변경 없음 (인터페이스 default method 가 흡수).
+
+---
+
+## 8. 미해결 / Follow‑up
+
+- (별도 이슈) Neo4j GDS / APOC 가용 시 native 가속.
+- (별도 이슈) Memgraph `WSHORTEST` Cypher 절 활용.
+- (별도 이슈) Yen's k‑shortest paths.
+- (별도 이슈) Bellman‑Ford 음수 가중치 지원.
+- (별도 이슈) 큰 그래프용 batched neighbor fetch 최적화.

--- a/docs/superpowers/specs/2026-04-28-weighted-graph-design.md
+++ b/docs/superpowers/specs/2026-04-28-weighted-graph-design.md
@@ -525,8 +525,8 @@ internal object ShortestPathFallback {
         options: PathOptions,
     ): GraphPath? {
         val weightKey = requireNotNull(options.weightProperty) { "weightProperty must be set for Dijkstra" }
-        // label 없이 ID 만으로 조회 — GraphVertexRepository 의 findById(id) API 사용
-        // (label+id 2-파라미터 API 가 아니라 ID-only lookup 이 필요하면 backend가 구현해야 함)
+        // label 없이 ID 만으로 조회 — GraphVertexRepository.findVertexById(id) (ID-only overload)
+        // label+id 2-파라미터 overload 와 구분됨; 이번 task 에서 신규 추가
         val start = ops.findVertexById(fromId) ?: return null
         ops.findVertexById(toId) ?: return null
 
@@ -660,6 +660,8 @@ internal object ShortestPathFallback {
 |------|------|
 | `graph-core/.../model/GraphPath.kt` | `totalWeight: Double` 필드 추가, `EMPTY`/`of(...)` 갱신 |
 | `graph-core/.../model/GraphTraversalOptions.kt` | `PathOptions` 에 `weightProperty`, `missingWeightPolicy`, `direction`, `maxVisited` |
+| `graph-core/.../repository/GraphVertexRepository.kt` | `findVertexById(id: GraphElementId): GraphVertex?` (label-only overload) 추가 |
+| `graph-core/.../repository/GraphSuspendVertexRepository.kt` | 동일 suspend 버전 |
 | `graph-core/.../repository/GraphEdgeRepository.kt` | `findEdgesByStartId(id, edgeLabel?)` + `findEdgesByEndId(id, edgeLabel?)` 추가 |
 | `graph-core/.../repository/GraphSuspendEdgeRepository.kt` | 동일 suspend 버전 |
 | `graph-core/.../repository/GraphTraversalRepository.kt` | `aStarPath` 시그니처 추가 (default 구현 없음) |

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphOperations.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphOperations.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.graph.age
 import io.bluetape4k.graph.GraphQueryException
 import io.bluetape4k.graph.age.sql.AgeSql
 import io.bluetape4k.graph.age.sql.AgeTypeParser
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.algo.internal.BfsDfsRunner
 import io.bluetape4k.graph.algo.internal.CycleDetector
 import io.bluetape4k.graph.algo.internal.PageRankCalculator
@@ -132,6 +133,18 @@ class AgeGraphOperations(
         }
     }
 
+    override fun findVertexById(id: GraphElementId): GraphVertex? {
+        return transaction {
+            val longId = id.value.toLongOrNull()
+                ?: throw GraphQueryException("AGE requires numeric ID, got: ${id.value}")
+            var vertex: GraphVertex? = null
+            exec(AgeSql.matchVertexById(graphName, longId)) { rs ->
+                if (rs.next()) vertex = AgeTypeParser.parseVertex(rs.getString("v"))
+            }
+            vertex
+        }
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
         label.requireNotBlank("label")
 
@@ -228,6 +241,36 @@ class AgeGraphOperations(
         }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        val longId = startId.value.toLongOrNull()
+            ?: throw GraphQueryException("AGE requires numeric ID, got: ${startId.value}")
+        return transaction {
+            val edges = mutableListOf<GraphEdge>()
+            val stmt = AgeSql.matchEdgesByStartId(graphName, longId, edgeLabel)
+            exec(stmt) { rs ->
+                while (rs.next()) {
+                    edges.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                }
+            }
+            edges
+        }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        val longId = endId.value.toLongOrNull()
+            ?: throw GraphQueryException("AGE requires numeric ID, got: ${endId.value}")
+        return transaction {
+            val edges = mutableListOf<GraphEdge>()
+            val stmt = AgeSql.matchEdgesByEndId(graphName, longId, edgeLabel)
+            exec(stmt) { rs ->
+                while (rs.next()) {
+                    edges.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                }
+            }
+            edges
+        }
+    }
+
     override fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label")
         val longId = id.value.toLongOrNull()
@@ -274,6 +317,10 @@ class AgeGraphOperations(
         toId: GraphElementId,
         options: PathOptions,
     ): GraphPath? {
+        if (options.weightProperty != null) {
+            return ShortestPathFallback.dijkstra(this, fromId, toId, options)
+        }
+
         val from = fromId.value.toLongOrNull()
             ?: throw GraphQueryException("AGE requires numeric ID, got: ${fromId.value}")
         val to = toId.value.toLongOrNull()
@@ -290,6 +337,13 @@ class AgeGraphOperations(
             path
         }
     }
+
+    override fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? = ShortestPathFallback.aStar(this, fromId, toId, options, heuristic)
 
     override fun allPaths(
         fromId: GraphElementId,

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperations.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperations.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.age
 
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.age.sql.AgeSql
 import io.bluetape4k.graph.age.sql.AgeTypeParser
 import io.bluetape4k.graph.model.BfsDfsOptions
@@ -142,6 +143,22 @@ class AgeGraphSuspendOperations(
         }
     }
 
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? {
+        val longId = id.value.toLongOrNull()
+            ?: throw GraphQueryException("AGE requires numeric ID, got: ${id.value}")
+
+        return newSuspendedTransaction {
+            var vertex: GraphVertex? = null
+            val stmt = AgeSql.matchVertexById(graphName, longId)
+            exec(stmt) { rs ->
+                if (rs.next()) {
+                    vertex = AgeTypeParser.parseVertex(rs.getString("v"))
+                }
+            }
+            vertex
+        }
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
         label.requireNotBlank("label")
         return channelFlow {
@@ -249,6 +266,42 @@ class AgeGraphSuspendOperations(
         }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val longId = startId.value.toLongOrNull()
+            ?: throw GraphQueryException("AGE requires numeric ID, got: ${startId.value}")
+        return channelFlow {
+            val edges = newSuspendedTransaction {
+                val list = mutableListOf<GraphEdge>()
+                val stmt = AgeSql.matchEdgesByStartId(graphName, longId, edgeLabel)
+                exec(stmt) { rs ->
+                    while (rs.next()) {
+                        list.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                    }
+                }
+                list
+            }
+            edges.forEach { send(it) }
+        }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val longId = endId.value.toLongOrNull()
+            ?: throw GraphQueryException("AGE requires numeric ID, got: ${endId.value}")
+        return channelFlow {
+            val edges = newSuspendedTransaction {
+                val list = mutableListOf<GraphEdge>()
+                val stmt = AgeSql.matchEdgesByEndId(graphName, longId, edgeLabel)
+                exec(stmt) { rs ->
+                    while (rs.next()) {
+                        list.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                    }
+                }
+                list
+            }
+            edges.forEach { send(it) }
+        }
+    }
+
     override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label")
         val longId = id.value.toLongOrNull()
@@ -293,6 +346,12 @@ class AgeGraphSuspendOperations(
         toId: GraphElementId,
         options: PathOptions,
     ): GraphPath? {
+        if (options.weightProperty != null) {
+            return withContext(Dispatchers.IO) {
+                ShortestPathFallback.dijkstra(syncDelegate, fromId, toId, options)
+            }
+        }
+
         val from = fromId.value.toLongOrNull()
             ?: throw GraphQueryException("AGE requires numeric ID, got: ${fromId.value}")
         val to =
@@ -308,6 +367,15 @@ class AgeGraphSuspendOperations(
             }
             path
         }
+    }
+
+    override suspend fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? = withContext(Dispatchers.IO) {
+        syncDelegate.aStarPath(fromId, toId, options, heuristic)
     }
 
     override fun allPaths(

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/sql/AgeSql.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/sql/AgeSql.kt
@@ -384,6 +384,64 @@ object AgeSql {
     }
 
     /**
+     * 레이블 없이 ID로 단일 정점을 조회하는 AGE SQL을 반환한다.
+     *
+     * Dijkstra/A* 알고리즘에서 레이블 불명 ID를 조회할 때 사용한다.
+     *
+     * ```kotlin
+     * AgeSql.matchVertexById("social", 42L)
+     * ```
+     */
+    fun matchVertexById(graphName: String, id: Long): String =
+        cypher(
+            graphName,
+            "MATCH (v) WHERE id(v) = $id RETURN v",
+            listOf("v" to "agtype")
+        )
+
+    /**
+     * 시작 정점 ID로 출발 간선 목록을 조회하는 AGE SQL을 반환한다.
+     *
+     * ```kotlin
+     * AgeSql.matchEdgesByStartId("social", 1L, "KNOWS")
+     * AgeSql.matchEdgesByStartId("social", 1L, null)  // 모든 레이블
+     * ```
+     *
+     * @param graphName AGE 그래프 이름.
+     * @param startId 시작 정점의 AGE numeric ID.
+     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
+     */
+    fun matchEdgesByStartId(graphName: String, startId: Long, edgeLabel: String?): String {
+        val rel = if (edgeLabel != null) ":${sanitizeLabel(edgeLabel)}" else ""
+        return cypher(
+            graphName,
+            "MATCH (a)-[e$rel]->(b) WHERE id(a) = $startId RETURN e",
+            listOf("e" to "agtype")
+        )
+    }
+
+    /**
+     * 종료 정점 ID로 도착 간선 목록을 조회하는 AGE SQL을 반환한다.
+     *
+     * ```kotlin
+     * AgeSql.matchEdgesByEndId("social", 2L, "KNOWS")
+     * AgeSql.matchEdgesByEndId("social", 2L, null)  // 모든 레이블
+     * ```
+     *
+     * @param graphName AGE 그래프 이름.
+     * @param endId 종료 정점의 AGE numeric ID.
+     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
+     */
+    fun matchEdgesByEndId(graphName: String, endId: Long, edgeLabel: String?): String {
+        val rel = if (edgeLabel != null) ":${sanitizeLabel(edgeLabel)}" else ""
+        return cypher(
+            graphName,
+            "MATCH (a)-[e$rel]->(b) WHERE id(b) = $endId RETURN e",
+            listOf("e" to "agtype")
+        )
+    }
+
+    /**
      * 그래프 내 모든 정점을 반환하는 AGE Cypher-over-SQL 을 생성한다.
      *
      * 라벨 무관 전체 fetch (`MATCH (n) RETURN n`).

--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeWeightedPathTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeWeightedPathTest.kt
@@ -1,0 +1,125 @@
+package io.bluetape4k.graph.age
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.math.sqrt
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AgeWeightedPathTest {
+
+    companion object : KLogging()
+
+    private lateinit var dataSource: HikariDataSource
+    private lateinit var database: Database
+    private lateinit var ops: AgeGraphOperations
+    private val graphName = "weighted_test"
+
+    @BeforeAll
+    fun setup() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        database = Database.connect(dataSource)
+        ops = AgeGraphOperations(graphName)
+    }
+
+    @AfterAll
+    fun teardown() {
+        dataSource.close()
+    }
+
+    @BeforeEach
+    fun resetGraph() = runSuspendIO {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        ops.createGraph(graphName)
+    }
+
+    @Test
+    fun `가중치 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `가중치 없는 간선 Skip 정책에서 경로 없음`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        ops.shortestPath(a.id, b.id, PathOptions(weightProperty = "cost")).shouldBeNull()
+    }
+
+    @Test
+    fun `A* 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A", "x" to 0.0, "y" to 0.0))
+        val b = ops.createVertex("City", mapOf("name" to "B", "x" to 1.0, "y" to 0.0))
+        val c = ops.createVertex("City", mapOf("name" to "C", "x" to 2.0, "y" to 0.0))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val goalX = c.properties["x"] as? Double ?: 2.0
+        val goalY = c.properties["y"] as? Double ?: 0.0
+
+        val path = ops.aStarPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { v ->
+            val vx = v.properties["x"] as? Double ?: 0.0
+            val vy = v.properties["y"] as? Double ?: 0.0
+            sqrt((vx - goalX) * (vx - goalX) + (vy - goalY) * (vy - goalY))
+        }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+}

--- a/graph/graph-core/README.md
+++ b/graph/graph-core/README.md
@@ -159,6 +159,70 @@ dependencies {
 - [Memgraph](https://memgraph.com/) — in-memory graph database
 - [Apache TinkerPop](https://tinkerpop.apache.org/) — graph computing framework
 
+## Weighted Shortest Path
+
+`graph-core` ships pure-JVM `DijkstraRunner` and `AStarRunner` used by all backends via `ShortestPathFallback`. Both algorithms read `PathOptions.weightProperty` from edge properties and delegate fetching to backend-specific lambdas.
+
+### PathOptions
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `weightProperty` | `null` | Edge property name for weight. Required for weighted traversal. |
+| `edgeLabel` | `null` | Filter edges by label (`null` = all labels). |
+| `missingWeightPolicy` | `Fail` | What to do when an edge lacks the weight property. |
+| `direction` | `OUTGOING` | Edge direction to follow. |
+| `maxVisited` | `Int.MAX_VALUE` | Abort if more vertices are visited. |
+
+### MissingWeightPolicy
+
+```kotlin
+sealed class MissingWeightPolicy {
+    object Fail    : MissingWeightPolicy()   // throws MissingWeightException (default)
+    object Skip    : MissingWeightPolicy()   // treats edge as absent (returns null path)
+    data class UseDefault(val weight: Double) : MissingWeightPolicy()  // substitutes value
+}
+```
+
+### Usage Example
+
+```kotlin
+val ops: GraphOperations = Neo4jGraphOperations(driver)
+
+// Dijkstra — weighted shortest path
+val path = ops.shortestPath(
+    fromId = alice.id,
+    toId   = charlie.id,
+    options = PathOptions(
+        weightProperty      = "cost",
+        edgeLabel           = "ROAD",
+        missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+    ),
+)
+println("total cost: ${path?.totalWeight}")
+
+// A* — with Euclidean heuristic
+val aStarPath = ops.aStarPath(
+    fromId  = alice.id,
+    toId    = charlie.id,
+    options = PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+) { v ->
+    val vx = v.properties["x"] as? Double ?: 0.0
+    val vy = v.properties["y"] as? Double ?: 0.0
+    sqrt((vx - goalX) * (vx - goalX) + (vy - goalY) * (vy - goalY))
+}
+```
+
+### GraphPath fields
+
+```kotlin
+data class GraphPath(
+    val vertices : List<GraphVertex>,
+    val edges    : List<GraphEdge>,
+    val steps    : List<PathStep>,          // interleaved VertexStep / EdgeStep
+    val totalWeight: Double = 0.0,          // sum of edge weights (0.0 for unweighted)
+)
+```
+
 ## Graph Algorithms
 
 `graph-core` defines the `GraphAlgorithmRepository` / `GraphSuspendAlgorithmRepository` interfaces and ships JVM fallback implementations (`UnionFind`, `BfsDfsRunner`, `CycleDetector`, `PageRankCalculator`) used by backends that do not have a native query for a given algorithm.
@@ -167,6 +231,8 @@ dependencies {
 
 | Algorithm | Interface method | Options type | Result type |
 |-----------|-----------------|--------------|-------------|
+| Dijkstra (weighted) | `shortestPath(from, to, options)` | `PathOptions` | `GraphPath?` |
+| A* (weighted) | `aStarPath(from, to, options, heuristic)` | `PathOptions` | `GraphPath?` |
 | PageRank | `pageRank(options)` | `PageRankOptions` | `List<PageRankScore>` |
 | Degree Centrality | `degreeCentrality(vertexId, options)` | `DegreeOptions` | `DegreeResult` |
 | Connected Components | `connectedComponents(options)` | `ComponentOptions` | `List<GraphComponent>` |

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
@@ -1,0 +1,114 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import java.util.PriorityQueue
+
+/**
+ * A* 알고리즘으로 휴리스틱 유도 최단 경로를 계산한다.
+ *
+ * ## 설계 결정
+ * - [heuristic]은 동기 함수만 허용한다 (`suspend` 불가). 코루틴 컨텍스트 내에서도 동기 호출.
+ * - 허용 가능(admissible) 휴리스틱: `h(n) <= 실제_비용(n, goal)`. 위반 시 최적성 보장 불가.
+ * - tie-break은 DijkstraRunner와 동일하게 vertexId 사전순.
+ *
+ * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수.
+ * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
+ * @param heuristic 목표 정점까지의 예상 비용 함수. 반드시 허용 가능해야 한다.
+ */
+class AStarRunner(
+    private val fetchEdges: (GraphElementId) -> List<GraphEdge>,
+    private val fetchVertex: (GraphElementId) -> GraphVertex?,
+    private val heuristic: (GraphVertex) -> Double,
+) {
+    companion object : KLogging()
+
+    /**
+     * A* 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.
+     *
+     * @param fromId 출발 정점 ID.
+     * @param toId 도착 정점 ID.
+     * @param options 탐색 옵션 (weightProperty, missingWeightPolicy, maxVisited).
+     * @return 최단 [GraphPath], 경로가 없으면 `null`.
+     */
+    fun run(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+    ): GraphPath? {
+        val weightProperty = requireNotNull(options.weightProperty) {
+            "PathOptions.weightProperty must be set for A*"
+        }
+        val extractor = WeightExtractor(weightProperty, options.missingWeightPolicy)
+
+        // f = g + h; tie-break: vertexId 사전순
+        val pq = PriorityQueue<Triple<Double, Double, GraphElementId>>(
+            compareBy<Triple<Double, Double, GraphElementId>> { it.first }
+                .thenComparing { a, b -> a.third.value.compareTo(b.third.value) }
+        )
+        val gScore = mutableMapOf<GraphElementId, Double>()
+        val cameFrom = mutableMapOf<GraphElementId, Pair<GraphVertex, GraphEdge>>()
+
+        gScore[fromId] = 0.0
+        val startVertex = fetchVertex(fromId) ?: return null
+        val h0 = heuristic(startVertex)
+        pq.add(Triple(h0, 0.0, fromId))
+        var visited = 0
+
+        while (pq.isNotEmpty()) {
+            val (_, g, currentId) = pq.poll()
+
+            if (g > (gScore[currentId] ?: Double.MAX_VALUE)) continue // stale
+
+            if (currentId == toId) {
+                log.debug { "A* found path: $fromId → $toId, cost=$g, visited=$visited" }
+                return reconstructPath(toId, cameFrom, { fetchVertex(it) }, g)
+            }
+
+            if (++visited > options.maxVisited) {
+                log.debug { "A* maxVisited=${options.maxVisited} reached; no path found" }
+                break
+            }
+
+            val edges = fetchEdges(currentId)
+
+            for (edge in edges.sortedBy { it.id.value }) {
+                val neighborId = neighbourId(currentId, edge, options.direction) ?: continue
+                val w = extractor.extract(edge) ?: continue
+
+                val tentativeG = g + w
+                if (tentativeG < (gScore[neighborId] ?: Double.MAX_VALUE)) {
+                    gScore[neighborId] = tentativeG
+                    val currentVertex = fetchVertex(currentId) ?: continue
+                    cameFrom[neighborId] = currentVertex to edge
+
+                    val neighbor = fetchVertex(neighborId) ?: continue
+                    val f = tentativeG + heuristic(neighbor)
+                    pq.add(Triple(f, tentativeG, neighborId))
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun neighbourId(
+        currentId: GraphElementId,
+        edge: GraphEdge,
+        direction: Direction,
+    ): GraphElementId? = when (direction) {
+        Direction.OUTGOING -> if (edge.startId == currentId) edge.endId else null
+        Direction.INCOMING -> if (edge.endId == currentId) edge.startId else null
+        Direction.BOTH -> when (currentId) {
+            edge.startId -> edge.endId
+            edge.endId -> edge.startId
+            else -> null
+        }
+    }
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
@@ -1,0 +1,108 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import java.util.PriorityQueue
+
+/**
+ * Dijkstra 알고리즘으로 단일 출발지 최단 경로를 계산한다.
+ *
+ * ## 설계 결정
+ * - **JVM 단일 구현**: 모든 백엔드(Neo4j/AGE/FalkorDB/TinkerPop)가 이 구현에 위임한다.
+ * - **결정적 tie-break**: 동일 비용 정점은 ID 사전순으로 정렬해 비결정적 동작을 방지한다.
+ * - **maxVisited 보호**: 무한 그래프에서의 무한 확장을 방지한다.
+ * - **Direction 지원**: OUTGOING, INCOMING, BOTH 모두 지원한다.
+ *
+ * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수. [Direction]은 호출 전 적용되어야 한다.
+ * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
+ */
+class DijkstraRunner(
+    private val fetchEdges: (GraphElementId) -> List<GraphEdge>,
+    private val fetchVertex: (GraphElementId) -> GraphVertex?,
+) {
+    companion object : KLogging()
+
+    /**
+     * Dijkstra 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.
+     *
+     * @param fromId 출발 정점 ID.
+     * @param toId 도착 정점 ID.
+     * @param options 탐색 옵션 (weightProperty, missingWeightPolicy, maxVisited).
+     * @return 최단 [GraphPath], 경로가 없으면 `null`.
+     */
+    fun run(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+    ): GraphPath? {
+        val weightProperty = requireNotNull(options.weightProperty) {
+            "PathOptions.weightProperty must be set for Dijkstra"
+        }
+        val extractor = WeightExtractor(weightProperty, options.missingWeightPolicy)
+
+        // (cost, vertexId) — tie-break은 vertexId 사전순
+        val pq = PriorityQueue<Pair<Double, GraphElementId>>(
+            compareBy<Pair<Double, GraphElementId>> { it.first }
+                .thenComparing { a, b -> a.second.value.compareTo(b.second.value) }
+        )
+        val dist = mutableMapOf<GraphElementId, Double>()
+        val cameFrom = mutableMapOf<GraphElementId, Pair<GraphVertex, GraphEdge>>()
+
+        dist[fromId] = 0.0
+        pq.add(0.0 to fromId)
+        var visited = 0
+
+        while (pq.isNotEmpty()) {
+            val (cost, currentId) = pq.poll()
+
+            if (cost > (dist[currentId] ?: Double.MAX_VALUE)) continue // stale entry
+
+            if (currentId == toId) {
+                log.debug { "Dijkstra found path: $fromId → $toId, cost=$cost, visited=$visited" }
+                return reconstructPath(toId, cameFrom, { fetchVertex(it) }, cost)
+            }
+
+            if (++visited > options.maxVisited) {
+                log.debug { "Dijkstra maxVisited=${options.maxVisited} reached; no path found" }
+                break
+            }
+
+            val edges = fetchEdges(currentId)
+
+            for (edge in edges.sortedBy { it.id.value }) {
+                val neighborId = neighbourId(currentId, edge, options.direction) ?: continue
+                val w = extractor.extract(edge) ?: continue // Skip 정책
+
+                val newCost = cost + w
+                if (newCost < (dist[neighborId] ?: Double.MAX_VALUE)) {
+                    dist[neighborId] = newCost
+                    val currentVertex = fetchVertex(currentId) ?: continue
+                    cameFrom[neighborId] = currentVertex to edge
+                    pq.add(newCost to neighborId)
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun neighbourId(
+        currentId: GraphElementId,
+        edge: GraphEdge,
+        direction: Direction,
+    ): GraphElementId? = when (direction) {
+        Direction.OUTGOING -> if (edge.startId == currentId) edge.endId else null
+        Direction.INCOMING -> if (edge.endId == currentId) edge.startId else null
+        Direction.BOTH -> when (currentId) {
+            edge.startId -> edge.endId
+            edge.endId -> edge.startId
+            else -> null
+        }
+    }
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/PathReconstructor.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/PathReconstructor.kt
@@ -1,0 +1,44 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.PathStep
+
+/**
+ * 탐색 완료 후 predecessor 맵에서 [GraphPath]를 역추적하여 재구성한다.
+ *
+ * Dijkstra/A* 탐색이 끝난 뒤 `cameFrom` 테이블에서 경로를 역추적한다.
+ * `totalWeight`는 탐색 과정에서 계산된 누적 비용을 그대로 사용한다.
+ *
+ * @param targetId 도착 정점 ID.
+ * @param cameFrom 정점 ID → (부모 정점, 연결 간선) 맵.
+ * @param vertexLookup 정점 ID → [GraphVertex] 조회 함수.
+ * @param totalWeight 경로의 총 가중치.
+ * @return 재구성된 [GraphPath]. 경로가 없으면 `null`.
+ */
+internal fun reconstructPath(
+    targetId: GraphElementId,
+    cameFrom: Map<GraphElementId, Pair<GraphVertex, GraphEdge>>,
+    vertexLookup: (GraphElementId) -> GraphVertex?,
+    totalWeight: Double,
+): GraphPath? {
+    val steps = mutableListOf<PathStep>()
+    var currentId = targetId
+
+    while (true) {
+        val entry = cameFrom[currentId] ?: break
+        val (parentVertex, edge) = entry
+        steps.add(PathStep.VertexStep(vertexLookup(currentId) ?: return null))
+        steps.add(PathStep.EdgeStep(edge))
+        currentId = parentVertex.id
+    }
+
+    // 출발 정점 추가
+    val startVertex = vertexLookup(currentId) ?: return null
+    steps.add(PathStep.VertexStep(startVertex))
+
+    steps.reverse()
+    return GraphPath(steps = steps, totalWeight = totalWeight)
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/ShortestPathFallback.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/ShortestPathFallback.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.repository.GraphEdgeRepository
+import io.bluetape4k.graph.repository.GraphOperations
+
+/**
+ * JVM 구현 기반의 가중치 최단 경로 탐색 헬퍼 (동기 전용).
+ *
+ * 모든 백엔드(Neo4j/Memgraph/AGE/TinkerPop/FalkorDB)의 동기 [GraphOperations]에서
+ * Dijkstra/A* 최단 경로 계산에 사용된다.
+ *
+ * ## 사용 패턴
+ *
+ * **동기 백엔드:**
+ * ```kotlin
+ * override fun shortestPath(...): GraphPath? =
+ *     if (options.weightProperty != null) ShortestPathFallback.dijkstra(this, ...)
+ *     else super.shortestPath(...)
+ *
+ * override fun aStarPath(...): GraphPath? =
+ *     ShortestPathFallback.aStar(this, ...)
+ * ```
+ *
+ * **코루틴 백엔드** (syncDelegate 위임):
+ * ```kotlin
+ * override suspend fun shortestPath(...): GraphPath? =
+ *     if (options.weightProperty != null) withContext(Dispatchers.IO) {
+ *         ShortestPathFallback.dijkstra(syncDelegate, ...)
+ *     } else ...
+ * ```
+ *
+ * ## 인터페이스 기본 메서드를 사용하지 않는 이유
+ * 탐색 알고리즘이 [GraphOperations] 전체(정점+간선 조회)를 필요로 하는데,
+ * `GraphTraversalRepository` 인터페이스의 `this`는 해당 타입을 만족하지 않는다.
+ * 따라서 각 백엔드 `override`에서 이 오브젝트를 직접 호출한다.
+ */
+object ShortestPathFallback {
+
+    /**
+     * [GraphOperations]를 사용해 Dijkstra 가중치 최단 경로를 계산한다.
+     */
+    fun dijkstra(
+        ops: GraphOperations,
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+    ): GraphPath? {
+        val runner = DijkstraRunner(
+            fetchEdges = { id -> fetchIncident(ops, id, options.edgeLabel, options.direction) },
+            fetchVertex = { id -> ops.findVertexById(id) },
+        )
+        return runner.run(fromId, toId, options)
+    }
+
+    /**
+     * [GraphOperations]를 사용해 A* 가중치 최단 경로를 계산한다.
+     */
+    fun aStar(
+        ops: GraphOperations,
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        val runner = AStarRunner(
+            fetchEdges = { id -> fetchIncident(ops, id, options.edgeLabel, options.direction) },
+            fetchVertex = { id -> ops.findVertexById(id) },
+            heuristic = heuristic,
+        )
+        return runner.run(fromId, toId, options)
+    }
+
+    private fun fetchIncident(
+        ops: GraphEdgeRepository,
+        id: GraphElementId,
+        edgeLabel: String?,
+        direction: Direction,
+    ): List<GraphEdge> = when (direction) {
+        Direction.OUTGOING -> ops.findEdgesByStartId(id, edgeLabel)
+        Direction.INCOMING -> ops.findEdgesByEndId(id, edgeLabel)
+        Direction.BOTH -> (ops.findEdgesByStartId(id, edgeLabel) + ops.findEdgesByEndId(id, edgeLabel))
+            .sortedBy { it.id.value }
+    }
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/WeightExtractor.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/WeightExtractor.kt
@@ -1,0 +1,88 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.MissingWeightException
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+
+/**
+ * 간선 속성에서 가중치(Double)를 추출한다.
+ *
+ * [MissingWeightPolicy]에 따라 결측 속성 처리 방식이 결정된다.
+ * - [MissingWeightPolicy.Fail]: 결측 시 [MissingWeightException] 발생
+ * - [MissingWeightPolicy.Skip]: `null` 반환 (호출자가 간선 건너뜀)
+ * - [MissingWeightPolicy.UseDefault]: [MissingWeightPolicy.UseDefault.value] 반환
+ *
+ * 속성이 존재하더라도 `NaN`, `Infinity`, 음수, 0.0인 경우 [IllegalArgumentException]을 발생시킨다.
+ *
+ * ```kotlin
+ * val extractor = WeightExtractor("cost", MissingWeightPolicy.UseDefault(1.0))
+ * val weight = extractor.extract(edge)  // null이면 호출자가 skip
+ * ```
+ */
+class WeightExtractor(
+    private val weightProperty: String,
+    private val policy: MissingWeightPolicy,
+) {
+    companion object : KLogging()
+
+    /**
+     * [edge]에서 가중치를 추출한다.
+     *
+     * @return 가중치 값. [MissingWeightPolicy.Skip]이고 속성이 없으면 `null`.
+     * @throws MissingWeightException [MissingWeightPolicy.Fail]이고 속성이 없는 경우.
+     * @throws IllegalArgumentException 추출된 값이 유효하지 않은 경우 (NaN, Infinity, <= 0).
+     */
+    fun extract(edge: GraphEdge): Double? {
+        val raw = edge.properties[weightProperty]
+
+        if (raw == null) {
+            return when (policy) {
+                is MissingWeightPolicy.Fail -> throw MissingWeightException(edge.id, weightProperty)
+                is MissingWeightPolicy.Skip -> {
+                    log.debug { "Skipping edge ${edge.id}: missing weight property '$weightProperty'" }
+                    null
+                }
+                is MissingWeightPolicy.UseDefault -> policy.value
+            }
+        }
+
+        return toValidWeight(raw, edge)
+    }
+
+    private fun toValidWeight(raw: Any, edge: GraphEdge): Double {
+        val value: Double = when (raw) {
+            is Double -> raw
+            is Float -> raw.toDouble()
+            is Int -> raw.toDouble()
+            is Long -> raw.toDouble()
+            is Short -> raw.toDouble()
+            is Byte -> raw.toDouble()
+            is java.math.BigDecimal -> {
+                require(raw <= java.math.BigDecimal.valueOf(Double.MAX_VALUE)) {
+                    "edge ${edge.id} weight overflows Double.MAX_VALUE: $raw"
+                }
+                val d = raw.toDouble()
+                require(d.isFinite()) { "edge ${edge.id} weight overflows Double: $raw" }
+                d
+            }
+            is Number -> {
+                val d = raw.toDouble()
+                require(d.isFinite()) { "edge ${edge.id} weight overflows Double: $raw" }
+                d
+            }
+            is String -> raw.toDoubleOrNull()
+                ?: throw IllegalArgumentException(
+                    "edge ${edge.id} weight property '$weightProperty' is not numeric: '$raw'"
+                )
+            else -> throw IllegalArgumentException(
+                "edge ${edge.id} weight property '$weightProperty' has unsupported type ${raw::class.simpleName}"
+            )
+        }
+
+        require(value.isFinite()) { "edge ${edge.id} weight must be finite, was $value" }
+        require(value > 0.0) { "edge ${edge.id} weight must be > 0.0, was $value" }
+        return value
+    }
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphPath.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphPath.kt
@@ -46,6 +46,8 @@ sealed class PathStep {
  * 교차 순서를 따른다. 두 정점 사이의 최단 경로 또는 모든 경로 탐색 결과를 표현한다.
  *
  * @property steps 경로를 구성하는 단계 목록.
+ * @property totalWeight 경로의 총 가중치. 비가중치 탐색 결과는 간선 수(hop count)가 기본값.
+ *   Dijkstra/A* 결과에는 실제 누적 비용이 설정된다.
  *
  * ### 사용 예제
  * ```kotlin
@@ -58,11 +60,12 @@ sealed class PathStep {
  *     PathStep.EdgeStep(e),
  *     PathStep.VertexStep(v2),
  * ))
- * // path.length == 1, path.vertices.size == 2
+ * // path.length == 1, path.vertices.size == 2, path.totalWeight == 1.0
  * ```
  */
 data class GraphPath(
     val steps: List<PathStep>,
+    val totalWeight: Double = steps.filterIsInstance<PathStep.EdgeStep>().size.toDouble(),
 ): Serializable {
     /** 경로 내 모든 정점을 순서대로 반환한다. */
     val vertices: List<GraphVertex>

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
@@ -51,18 +51,42 @@ data class NeighborOptions(
 /**
  * [GraphTraversalRepository.shortestPath] / [GraphTraversalRepository.allPaths] 호출 옵션.
  *
+ * [weightProperty]를 지정하면 Dijkstra/A* 알고리즘으로 가중치 최단 경로를 탐색한다.
+ * `null`(기본)이면 백엔드 네이티브 BFS 최단 경로를 사용한다.
+ *
  * ```kotlin
+ * // 비가중치 최단 경로 (기본)
  * val opts = PathOptions(edgeLabel = "KNOWS", maxDepth = 5)
- * val path = ops.shortestPath(alice.id, carol.id, opts)
+ *
+ * // 가중치 최단 경로 (Dijkstra)
+ * val opts = PathOptions(
+ *     edgeLabel = "ROAD",
+ *     weightProperty = "distance",
+ *     missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+ *     direction = Direction.BOTH,
+ *     maxVisited = 50_000,
+ * )
  * ```
  *
  * @param edgeLabel 탐색할 엣지 레이블. null이면 모든 레이블 탐색.
- * @param maxDepth 최대 탐색 깊이 (기본값: 10)
+ * @param maxDepth 최대 탐색 깊이 (기본값: 10).
+ * @param weightProperty 간선의 가중치 속성 키. null이면 비가중치 탐색.
+ * @param missingWeightPolicy [weightProperty]가 없는 간선에 대한 처리 정책 (기본: [MissingWeightPolicy.Fail]).
+ * @param direction 탐색 방향. [weightProperty]가 지정된 경우에만 적용 (기본: [Direction.OUTGOING]).
+ * @param maxVisited 가중치 탐색 시 최대 방문 정점 수. 무한 그래프 보호 (기본: 100_000).
  */
 data class PathOptions(
     val edgeLabel: String? = null,
     override val maxDepth: Int = 10,
+    val weightProperty: String? = null,
+    val missingWeightPolicy: MissingWeightPolicy = MissingWeightPolicy.Fail,
+    val direction: Direction = Direction.OUTGOING,
+    val maxVisited: Int = 100_000,
 ): GraphTraversalOptions() {
+    init {
+        require(maxDepth >= 0) { "maxDepth must be >= 0, was $maxDepth" }
+        require(maxVisited > 0) { "maxVisited must be > 0, was $maxVisited" }
+    }
     companion object {
         private const val serialVersionUID: Long = 1L
         val Default = PathOptions()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/MissingWeightPolicy.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/MissingWeightPolicy.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.graph.model
+
+import java.io.Serializable
+
+/**
+ * 가중치 최단 경로 탐색 시 간선에 weight 속성이 없을 때의 처리 정책.
+ *
+ * [PathOptions.weightProperty]가 지정되었으나 해당 간선에 속성이 없을 때 적용된다.
+ *
+ * ```kotlin
+ * // 결측 시 예외 (기본)
+ * val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.Fail)
+ *
+ * // 결측 간선 건너뜀
+ * val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.Skip)
+ *
+ * // 결측 시 기본값 1.0 사용
+ * val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0))
+ * ```
+ */
+sealed class MissingWeightPolicy : Serializable {
+
+    /**
+     * 결측 시 [MissingWeightException]을 던진다 (기본 정책).
+     *
+     * 데이터 무결성이 중요하고 모든 간선에 weight가 있어야 하는 경우에 사용한다.
+     */
+    data object Fail : MissingWeightPolicy() {
+        private const val serialVersionUID: Long = 1L
+    }
+
+    /**
+     * weight 속성이 없는 간선을 경로에서 제외한다.
+     *
+     * 일부 간선에만 weight가 있는 스파스 그래프에서 유용하다.
+     */
+    data object Skip : MissingWeightPolicy() {
+        private const val serialVersionUID: Long = 1L
+    }
+
+    /**
+     * weight 속성이 없는 간선에 [value]를 기본 비용으로 적용한다.
+     *
+     * [value]는 반드시 `> 0.0`이고 유한한 값이어야 한다.
+     * `0.0`은 허용하지 않는다 — zero-cost 간선이 있으면 무한 확장 위험이 있어 [PathOptions.maxVisited] 한도를 초과할 수 있다.
+     *
+     * ```kotlin
+     * MissingWeightPolicy.UseDefault(1.0) // 결측 간선 비용 = 1.0
+     * MissingWeightPolicy.UseDefault(0.0) // IllegalArgumentException
+     * ```
+     *
+     * @param value 결측 간선에 적용할 기본 비용 (> 0.0, finite).
+     * @throws IllegalArgumentException value가 0 이하이거나 무한대/NaN인 경우.
+     */
+    data class UseDefault(val value: Double) : MissingWeightPolicy() {
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+
+        init {
+            require(value > 0.0 && value.isFinite()) {
+                "default weight must be finite and > 0.0, was $value"
+            }
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * [MissingWeightPolicy.Fail] 정책 적용 시 weight 속성이 없는 간선에서 발생하는 예외.
+ *
+ * [IllegalStateException]의 하위 타입으로 로그 집계 및 모니터링 알림 설정에 활용할 수 있다.
+ *
+ * @param edgeId weight가 없는 간선 ID.
+ * @param key 조회한 weight 속성 키.
+ */
+class MissingWeightException(
+    val edgeId: GraphElementId,
+    val key: String,
+) : IllegalStateException("edge $edgeId missing weight property '$key'")

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphEdgeRepository.kt
@@ -48,6 +48,37 @@ interface GraphEdgeRepository {
     fun findEdgesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): List<GraphEdge>
 
     /**
+     * 특정 정점에서 출발하는 간선 목록을 조회한다.
+     *
+     * Dijkstra/A* 알고리즘의 인접 간선 수집에 사용된다.
+     *
+     * ```kotlin
+     * val outEdges = ops.findEdgesByStartId(alice.id)
+     * val typed    = ops.findEdgesByStartId(alice.id, edgeLabel = "KNOWS")
+     * ```
+     *
+     * @param startId 시작 정점 ID.
+     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
+     * @return 해당 정점에서 출발하는 [GraphEdge] 목록.
+     */
+    fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String? = null): List<GraphEdge>
+
+    /**
+     * 특정 정점으로 도착하는 간선 목록을 조회한다.
+     *
+     * `Direction.INCOMING` / `Direction.BOTH` 탐색에 사용된다.
+     *
+     * ```kotlin
+     * val inEdges = ops.findEdgesByEndId(alice.id)
+     * ```
+     *
+     * @param endId 종료 정점 ID.
+     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
+     * @return 해당 정점으로 도착하는 [GraphEdge] 목록.
+     */
+    fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String? = null): List<GraphEdge>
+
+    /**
      * 간선을 삭제한다.
      *
      * ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendEdgeRepository.kt
@@ -57,6 +57,32 @@ interface GraphSuspendEdgeRepository {
     fun findEdgesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): Flow<GraphEdge>
 
     /**
+     * 특정 정점에서 출발하는 간선 목록을 스트림으로 조회한다.
+     *
+     * ```kotlin
+     * val outEdges = ops.findEdgesByStartId(alice.id).toList()
+     * ```
+     *
+     * @param startId 시작 정점 ID.
+     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
+     * @return 해당 정점에서 출발하는 [GraphEdge] Flow.
+     */
+    fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String? = null): Flow<GraphEdge>
+
+    /**
+     * 특정 정점으로 도착하는 간선 목록을 스트림으로 조회한다.
+     *
+     * ```kotlin
+     * val inEdges = ops.findEdgesByEndId(alice.id).toList()
+     * ```
+     *
+     * @param endId 종료 정점 ID.
+     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
+     * @return 해당 정점으로 도착하는 [GraphEdge] Flow.
+     */
+    fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String? = null): Flow<GraphEdge>
+
+    /**
      * 간선을 삭제한다.
      *
      * ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTraversalRepository.kt
@@ -83,4 +83,29 @@ interface GraphSuspendTraversalRepository {
         toId: GraphElementId,
         options: PathOptions = PathOptions.Default,
     ): Flow<GraphPath>
+
+    /**
+     * A* 알고리즘으로 가중치 최단 경로를 찾는다 (코루틴 방식).
+     *
+     * [options.weightProperty]가 반드시 설정되어야 한다.
+     * [heuristic]은 동기 함수여야 한다 (`suspend` 함수 불가).
+     *
+     * ```kotlin
+     * val path = ops.aStarPath(a.id, b.id, PathOptions(weightProperty = "cost")) { vertex ->
+     *     estimatedCostToGoal(vertex)
+     * }
+     * ```
+     *
+     * @param fromId 출발 정점 ID.
+     * @param toId 도착 정점 ID.
+     * @param options 탐색 옵션 ([PathOptions.weightProperty] 필수).
+     * @param heuristic 목표까지의 예상 비용 함수. 허용 가능(admissible)해야 한다.
+     * @return 가중치 최단 [GraphPath], 경로가 없으면 `null`.
+     */
+    suspend fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath?
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendVertexRepository.kt
@@ -49,6 +49,18 @@ interface GraphSuspendVertexRepository {
     suspend fun findVertexById(label: String, id: GraphElementId): GraphVertex?
 
     /**
+     * 레이블 없이 ID로 단일 정점을 조회한다.
+     *
+     * ```kotlin
+     * val found = ops.findVertexById(vertex.id)
+     * ```
+     *
+     * @param id 조회할 정점 ID.
+     * @return 존재하면 [GraphVertex], 없으면 `null`.
+     */
+    suspend fun findVertexById(id: GraphElementId): GraphVertex?
+
+    /**
      * 레이블과 속성 필터로 정점 목록을 스트림으로 조회한다.
      *
      * 대량 데이터에 적합한 [Flow] 기반 조회이다.

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTraversalRepository.kt
@@ -84,4 +84,32 @@ interface GraphTraversalRepository {
         toId: GraphElementId,
         options: PathOptions = PathOptions.Default,
     ): List<GraphPath>
+
+    /**
+     * A* 알고리즘으로 가중치 최단 경로를 찾는다.
+     *
+     * [options.weightProperty]가 반드시 설정되어야 한다.
+     * [heuristic]은 목표 정점까지의 예상 비용을 반환하는 비허용 불가(admissible) 함수여야 한다.
+     * 동기 함수만 허용하며 `suspend` 함수는 지원하지 않는다.
+     *
+     * ```kotlin
+     * val opts = PathOptions(weightProperty = "distance", direction = Direction.OUTGOING)
+     * val path = ops.aStarPath(a.id, b.id, opts) { vertex ->
+     *     // 유클리드 거리 등 허용 가능한 휴리스틱
+     *     euclidean(vertex, goal)
+     * }
+     * ```
+     *
+     * @param fromId 출발 정점 ID.
+     * @param toId 도착 정점 ID.
+     * @param options 탐색 옵션 ([PathOptions.weightProperty] 필수).
+     * @param heuristic 목표까지의 예상 비용 함수. 허용 가능(admissible)해야 한다.
+     * @return 가중치 최단 [GraphPath], 경로가 없으면 `null`.
+     */
+    fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath?
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVertexRepository.kt
@@ -46,6 +46,21 @@ interface GraphVertexRepository {
     fun findVertexById(label: String, id: GraphElementId): GraphVertex?
 
     /**
+     * 레이블 없이 ID로 단일 정점을 조회한다.
+     *
+     * 백엔드가 ID로만 정점을 조회할 수 있는 경우에 사용한다.
+     * Dijkstra/A* 알고리즘에서 레이블 없이 ID만 알고 있을 때 필요하다.
+     *
+     * ```kotlin
+     * val found = ops.findVertexById(vertex.id)  // 레이블 불필요
+     * ```
+     *
+     * @param id 조회할 정점 ID.
+     * @return 존재하면 [GraphVertex], 없으면 `null`.
+     */
+    fun findVertexById(id: GraphElementId): GraphVertex?
+
+    /**
      * 레이블과 속성 필터로 정점 목록을 조회한다.
      *
      * ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadEdgeRepository.kt
@@ -24,5 +24,15 @@ interface GraphVirtualThreadEdgeRepository {
         filter: Map<String, Any?> = emptyMap(),
     ): CompletableFuture<List<GraphEdge>>
 
+    fun findEdgesByStartIdAsync(
+        startId: GraphElementId,
+        edgeLabel: String? = null,
+    ): CompletableFuture<List<GraphEdge>>
+
+    fun findEdgesByEndIdAsync(
+        endId: GraphElementId,
+        edgeLabel: String? = null,
+    ): CompletableFuture<List<GraphEdge>>
+
     fun deleteEdgeAsync(label: String, id: GraphElementId): CompletableFuture<Boolean>
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadTraversalRepository.kt
@@ -65,4 +65,20 @@ interface GraphVirtualThreadTraversalRepository {
         toId: GraphElementId,
         options: PathOptions = PathOptions.Default,
     ): CompletableFuture<List<GraphPath>>
+
+    /**
+     * A* 알고리즘으로 가중치 최단 경로를 Virtual Thread 에서 찾는다.
+     *
+     * @param fromId 출발 정점 ID.
+     * @param toId 도착 정점 ID.
+     * @param options 탐색 옵션 ([PathOptions.weightProperty] 필수).
+     * @param heuristic 목표까지의 예상 비용 함수 (동기).
+     * @return 가중치 최단 [GraphPath] 를 담은 [CompletableFuture]. 경로가 없으면 `null`.
+     */
+    fun aStarPathAsync(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): CompletableFuture<GraphPath?>
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadVertexRepository.kt
@@ -22,6 +22,8 @@ interface GraphVirtualThreadVertexRepository {
         id: GraphElementId,
     ): CompletableFuture<GraphVertex?>
 
+    fun findVertexByIdAsync(id: GraphElementId): CompletableFuture<GraphVertex?>
+
     fun findVerticesByLabelAsync(
         label: String,
         filter: Map<String, Any?> = emptyMap(),

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadEdgeAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadEdgeAdapter.kt
@@ -35,6 +35,18 @@ class VirtualThreadEdgeAdapter(
     ): CompletableFuture<List<GraphEdge>> =
         virtualFutureOf { delegate.findEdgesByLabel(label, filter) }
 
+    override fun findEdgesByStartIdAsync(
+        startId: GraphElementId,
+        edgeLabel: String?,
+    ): CompletableFuture<List<GraphEdge>> =
+        virtualFutureOf { delegate.findEdgesByStartId(startId, edgeLabel) }
+
+    override fun findEdgesByEndIdAsync(
+        endId: GraphElementId,
+        edgeLabel: String?,
+    ): CompletableFuture<List<GraphEdge>> =
+        virtualFutureOf { delegate.findEdgesByEndId(endId, edgeLabel) }
+
     override fun deleteEdgeAsync(label: String, id: GraphElementId): CompletableFuture<Boolean> =
         virtualFutureOf { delegate.deleteEdge(label, id) }
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadTraversalAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadTraversalAdapter.kt
@@ -44,6 +44,14 @@ class VirtualThreadTraversalAdapter(
         options: PathOptions,
     ): CompletableFuture<List<GraphPath>> =
         virtualFutureOf { delegate.allPaths(fromId, toId, options) }
+
+    override fun aStarPathAsync(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): CompletableFuture<GraphPath?> =
+        virtualFutureOfNullable { delegate.aStarPath(fromId, toId, options, heuristic) }
 }
 
 /**

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadVertexAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadVertexAdapter.kt
@@ -34,6 +34,9 @@ class VirtualThreadVertexAdapter(
     ): CompletableFuture<GraphVertex?> =
         virtualFutureOfNullable { delegate.findVertexById(label, id) }
 
+    override fun findVertexByIdAsync(id: GraphElementId): CompletableFuture<GraphVertex?> =
+        virtualFutureOfNullable { delegate.findVertexById(id) }
+
     override fun findVerticesByLabelAsync(
         label: String,
         filter: Map<String, Any?>,

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
@@ -1,0 +1,189 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.model.PathStep
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContainAll
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import kotlin.math.sqrt
+
+/**
+ * 테스트 그래프 (격자 구조):
+ *
+ * A(0,0) --(1.0)--> B(1,0) --(1.0)--> C(2,0)
+ * |                                     ^
+ * +-------------(3.0)-------------------+
+ *
+ * A→C 최단 경로: A→B→C (cost=2.0)
+ */
+class AStarRunnerTest {
+
+    companion object : KLogging()
+
+    data class Coord(val x: Double, val y: Double)
+
+    private val coords = mapOf(
+        "A" to Coord(0.0, 0.0),
+        "B" to Coord(1.0, 0.0),
+        "C" to Coord(2.0, 0.0),
+    )
+
+    private fun euclidean(v: GraphVertex, goalId: String): Double {
+        val vc = coords[v.id.value] ?: return 0.0
+        val gc = coords[goalId] ?: return 0.0
+        val dx = vc.x - gc.x
+        val dy = vc.y - gc.y
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    private val eAB = edge("eAB", "A", "B", 1.0)
+    private val eBC = edge("eBC", "B", "C", 1.0)
+    private val eAC = edge("eAC", "A", "C", 3.0)
+
+    private val mainGraph = mapOf(
+        "A" to listOf(eAB, eAC),
+        "B" to listOf(eBC),
+        "C" to emptyList<GraphEdge>(),
+    )
+
+    private val vertices: Map<String, GraphVertex> = mapOf(
+        "A" to vertex("A"), "B" to vertex("B"), "C" to vertex("C"),
+    )
+
+    private fun runner(
+        edgeMap: Map<String, List<GraphEdge>> = mainGraph,
+        goalId: String = "C",
+    ) = AStarRunner(
+        fetchEdges = { id -> edgeMap[id.value] ?: emptyList() },
+        fetchVertex = { id -> vertices[id.value] },
+        heuristic = { v -> euclidean(v, goalId) },
+    )
+
+    private fun options(weight: String = "cost") = PathOptions(weightProperty = weight)
+
+    // ─── 기본 경로 탐색 ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `A에서 C까지 최단 경로는 A-B-C이다`() {
+        val path = runner().run(id("A"), id("C"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(2.0, 0.001)
+        path.vertexIds() shouldContainAll listOf("A", "B", "C")
+    }
+
+    @Test
+    fun `A에서 B까지 최단 경로는 A-B이다`() {
+        val bRunner = AStarRunner(
+            fetchEdges = { id -> mainGraph[id.value] ?: emptyList() },
+            fetchVertex = { id -> vertices[id.value] },
+            heuristic = { v -> euclidean(v, "B") },
+        )
+        val path = bRunner.run(id("A"), id("B"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(1.0, 0.001)
+    }
+
+    @Test
+    fun `경로가 없으면 null 반환`() {
+        runner().run(id("C"), id("A"), options()).shouldBeNull()
+    }
+
+    @Test
+    fun `출발지와 도착지가 같으면 단일 정점 경로 반환`() {
+        val path = runner().run(id("A"), id("A"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(0.0, 0.001)
+        path.steps shouldHaveSize 1
+        path.steps.filterIsInstance<PathStep.VertexStep>() shouldHaveSize 1
+    }
+
+    @Test
+    fun `출발 정점이 없으면 null 반환`() {
+        runner().run(id("MISSING"), id("C"), options()).shouldBeNull()
+    }
+
+    // ─── 휴리스틱 = 0 (Dijkstra 동치) ────────────────────────────────────────────
+
+    @Test
+    fun `영 휴리스틱은 Dijkstra와 동일한 결과를 반환한다`() {
+        val zeroH = AStarRunner(
+            fetchEdges = { id -> mainGraph[id.value] ?: emptyList() },
+            fetchVertex = { id -> vertices[id.value] },
+            heuristic = { _ -> 0.0 },
+        )
+        val path = zeroH.run(id("A"), id("C"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(2.0, 0.001)
+    }
+
+    // ─── maxVisited 제한 ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `maxVisited 초과 시 null 반환`() {
+        val opts = PathOptions(weightProperty = "cost", maxVisited = 1)
+        runner().run(id("A"), id("C"), opts).shouldBeNull()
+    }
+
+    // ─── MissingWeightPolicy ─────────────────────────────────────────────────────
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 건너뜀`() {
+        val skipGraph = mapOf(
+            "A" to listOf(edge("eAB_nw", "A", "B", null)),
+            "B" to listOf(eBC),
+            "C" to emptyList<GraphEdge>(),
+        )
+        val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.Skip)
+        runner(skipGraph).run(id("A"), id("C"), opts).shouldBeNull()
+    }
+
+    @Test
+    fun `UseDefault 정책에서 weight 없는 간선은 기본값 사용`() {
+        val defaultGraph = mapOf(
+            "A" to listOf(edge("eAB_nw", "A", "B", null)),
+            "B" to listOf(eBC),
+            "C" to emptyList<GraphEdge>(),
+        )
+        val opts = PathOptions(
+            weightProperty = "cost",
+            missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+        )
+        val path = runner(defaultGraph).run(id("A"), id("C"), opts).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(2.0, 0.001)
+    }
+
+    // ─── weightProperty 필수 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `weightProperty 없으면 IllegalArgumentException 발생`() {
+        val block: () -> Unit = { runner().run(id("A"), id("C"), PathOptions()) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    // ─── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+    private fun id(v: String) = GraphElementId.of(v)
+
+    private fun vertex(id: String) = GraphVertex(GraphElementId.of(id), "V", emptyMap())
+
+    private fun edge(id: String, from: String, to: String, weight: Double?) = GraphEdge(
+        GraphElementId.of(id),
+        "ROAD",
+        GraphElementId.of(from),
+        GraphElementId.of(to),
+        if (weight != null) mapOf("cost" to weight) else emptyMap(),
+    )
+
+    private fun io.bluetape4k.graph.model.GraphPath.vertexIds(): List<String> =
+        steps.filterIsInstance<PathStep.VertexStep>().map { it.vertex.id.value }
+}

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/DijkstraRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/DijkstraRunnerTest.kt
@@ -1,0 +1,193 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.model.PathStep
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContainAll
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+/**
+ * 테스트 그래프:
+ *
+ * A --(1.0)--> B --(2.0)--> C
+ * |                          ^
+ * +--------(5.0)-------------+
+ *
+ * 최단 경로 A→C: A→B→C (cost=3.0)
+ * 최단 경로 A→B: A→B (cost=1.0)
+ */
+class DijkstraRunnerTest {
+
+    companion object : KLogging()
+
+    private val eAB = edge("eAB", "A", "B", 1.0)
+    private val eBC = edge("eBC", "B", "C", 2.0)
+    private val eAC = edge("eAC", "A", "C", 5.0)
+    private val eXY = edge("eXY", "X", "Y", 3.0)
+    private val eYZ = edge("eYZ", "Y", "Z", 4.0)
+
+    private val mainGraph: Map<String, List<GraphEdge>> = mapOf(
+        "A" to listOf(eAB, eAC),
+        "B" to listOf(eBC),
+        "C" to emptyList(),
+    )
+
+    private val linearGraph: Map<String, List<GraphEdge>> = mapOf(
+        "X" to listOf(eXY),
+        "Y" to listOf(eYZ),
+        "Z" to emptyList(),
+    )
+
+    private val vertices: Map<String, GraphVertex> = mapOf(
+        "A" to vertex("A"), "B" to vertex("B"), "C" to vertex("C"),
+        "X" to vertex("X"), "Y" to vertex("Y"), "Z" to vertex("Z"),
+    )
+
+    private fun runner(edgeMap: Map<String, List<GraphEdge>> = mainGraph) = DijkstraRunner(
+        fetchEdges = { id -> edgeMap[id.value] ?: emptyList() },
+        fetchVertex = { id -> vertices[id.value] },
+    )
+
+    private fun options(weight: String = "cost") = PathOptions(weightProperty = weight)
+
+    // ─── 기본 경로 탐색 ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `A에서 C까지 최단 경로는 A-B-C이다`() {
+        val path = runner().run(id("A"), id("C"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+        path.vertexIds() shouldContainAll listOf("A", "B", "C")
+    }
+
+    @Test
+    fun `A에서 B까지 최단 경로는 A-B이다`() {
+        val path = runner().run(id("A"), id("B"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(1.0, 0.001)
+        path.vertexIds() shouldContainAll listOf("A", "B")
+    }
+
+    @Test
+    fun `직접 연결이 우회 경로보다 비싸면 우회 경로 선택`() {
+        val cheapDetour = mapOf(
+            "A" to listOf(edge("eAC_exp", "A", "C", 10.0), edge("eAB2", "A", "B", 1.0)),
+            "B" to listOf(edge("eBC2", "B", "C", 1.0)),
+            "C" to emptyList<GraphEdge>(),
+        )
+        val path = runner(cheapDetour).run(id("A"), id("C"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(2.0, 0.001)
+        path.vertexIds() shouldContainAll listOf("A", "B", "C")
+    }
+
+    @Test
+    fun `동일 출발지와 도착지는 단일 정점 경로 반환`() {
+        val path = runner().run(id("A"), id("A"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(0.0, 0.001)
+        // 출발 정점만 있고 간선 없음
+        path.steps shouldHaveSize 1
+        path.steps.filterIsInstance<PathStep.VertexStep>() shouldHaveSize 1
+    }
+
+    @Test
+    fun `경로가 없으면 null 반환`() {
+        runner().run(id("C"), id("A"), options()).shouldBeNull()
+    }
+
+    @Test
+    fun `출발지 정점이 존재하지 않으면 null 반환`() {
+        runner().run(id("UNKNOWN"), id("C"), options()).shouldBeNull()
+    }
+
+    // ─── Direction.BOTH ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `Direction BOTH에서 역방향 경로 탐색`() {
+        val bothRunner = DijkstraRunner(
+            fetchEdges = { id ->
+                val outgoing = linearGraph[id.value] ?: emptyList()
+                val incoming = linearGraph.values.flatten().filter { it.endId == id }
+                (outgoing + incoming).distinctBy { it.id }
+            },
+            fetchVertex = { id -> vertices[id.value] },
+        )
+        val opts = PathOptions(weightProperty = "cost", direction = Direction.BOTH)
+        val path = bothRunner.run(id("Z"), id("X"), opts).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(7.0, 0.001)
+    }
+
+    // ─── maxVisited 제한 ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `maxVisited 초과 시 null 반환`() {
+        val opts = PathOptions(weightProperty = "cost", maxVisited = 1)
+        runner().run(id("A"), id("C"), opts).shouldBeNull()
+    }
+
+    // ─── MissingWeightPolicy 통합 ─────────────────────────────────────────────────
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 건너뜀`() {
+        val skipGraph = mapOf(
+            "A" to listOf(edge("eAB_nw", "A", "B", null)),
+            "B" to listOf(eBC),
+            "C" to emptyList<GraphEdge>(),
+        )
+        val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.Skip)
+        runner(skipGraph).run(id("A"), id("C"), opts).shouldBeNull()
+    }
+
+    @Test
+    fun `UseDefault 정책에서 weight 없는 간선은 기본값 사용`() {
+        val defaultGraph = mapOf(
+            "A" to listOf(edge("eAB_nw", "A", "B", null)),
+            "B" to listOf(eBC),
+            "C" to emptyList<GraphEdge>(),
+        )
+        val opts = PathOptions(
+            weightProperty = "cost",
+            missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+        )
+        val path = runner(defaultGraph).run(id("A"), id("C"), opts).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    // ─── totalWeight 검증 ────────────────────────────────────────────────────────
+
+    @Test
+    fun `totalWeight는 경로상 모든 간선 가중치 합과 같다`() {
+        val path = runner(linearGraph).run(id("X"), id("Z"), options()).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(7.0, 0.001)
+    }
+
+    // ─── 헬퍼 함수 ────────────────────────────────────────────────────────────────
+
+    private fun id(v: String) = GraphElementId.of(v)
+
+    private fun vertex(id: String) = GraphVertex(GraphElementId.of(id), "V", emptyMap())
+
+    private fun edge(id: String, from: String, to: String, weight: Double?) = GraphEdge(
+        GraphElementId.of(id),
+        "ROAD",
+        GraphElementId.of(from),
+        GraphElementId.of(to),
+        if (weight != null) mapOf("cost" to weight) else emptyMap(),
+    )
+
+    private fun io.bluetape4k.graph.model.GraphPath.vertexIds(): List<String> =
+        steps.filterIsInstance<PathStep.VertexStep>().map { it.vertex.id.value }
+}

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/WeightExtractorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/WeightExtractorTest.kt
@@ -1,0 +1,152 @@
+package io.bluetape4k.graph.algo
+
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.MissingWeightException
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+
+class WeightExtractorTest {
+
+    companion object : KLogging()
+
+    private fun edge(vararg props: Pair<String, Any?>) =
+        GraphEdge(GraphElementId.of("e1"), "ROAD", GraphElementId.of("v1"), GraphElementId.of("v2"), mapOf(*props))
+
+    // ─── Fail 정책 ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `Fail 정책 - 속성 없으면 MissingWeightException 발생`() {
+        val extractor = WeightExtractor("cost", MissingWeightPolicy.Fail)
+        val block = { extractor.extract(edge()) }
+        block shouldThrow MissingWeightException::class
+    }
+
+    @Test
+    fun `Fail 정책 - 속성 있으면 double 반환`() {
+        val extractor = WeightExtractor("cost", MissingWeightPolicy.Fail)
+        extractor.extract(edge("cost" to 5.0)).shouldNotBeNull().shouldBeNear(5.0, 0.001)
+    }
+
+    // ─── Skip 정책 ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `Skip 정책 - 속성 없으면 null 반환`() {
+        val extractor = WeightExtractor("cost", MissingWeightPolicy.Skip)
+        extractor.extract(edge()).shouldBeNull()
+    }
+
+    @Test
+    fun `Skip 정책 - 속성 있으면 double 반환`() {
+        val extractor = WeightExtractor("cost", MissingWeightPolicy.Skip)
+        extractor.extract(edge("cost" to 3.5f)).shouldNotBeNull().shouldBeNear(3.5, 0.001)
+    }
+
+    // ─── UseDefault 정책 ─────────────────────────────────────────────────────
+
+    @Test
+    fun `UseDefault 정책 - 속성 없으면 기본값 반환`() {
+        val extractor = WeightExtractor("cost", MissingWeightPolicy.UseDefault(1.0))
+        extractor.extract(edge()).shouldNotBeNull().shouldBeNear(1.0, 0.001)
+    }
+
+    @Test
+    fun `UseDefault 정책 - 속성 있으면 실제 값 반환`() {
+        val extractor = WeightExtractor("cost", MissingWeightPolicy.UseDefault(1.0))
+        extractor.extract(edge("cost" to 7)).shouldNotBeNull().shouldBeNear(7.0, 0.001)
+    }
+
+    // ─── 타입 변환 ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Int 속성을 double로 변환`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        extractor.extract(edge("w" to 10)).shouldNotBeNull().shouldBeNear(10.0, 0.001)
+    }
+
+    @Test
+    fun `Long 속성을 double로 변환`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        extractor.extract(edge("w" to 42L)).shouldNotBeNull().shouldBeNear(42.0, 0.001)
+    }
+
+    @Test
+    fun `Float 속성을 double로 변환`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        extractor.extract(edge("w" to 2.5f)).shouldNotBeNull().shouldBeNear(2.5, 0.001)
+    }
+
+    @Test
+    fun `String 숫자 속성을 double로 변환`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        extractor.extract(edge("w" to "3.14")).shouldNotBeNull().shouldBeNear(3.14, 0.001)
+    }
+
+    @Test
+    fun `BigDecimal 속성을 double로 변환`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        extractor.extract(edge("w" to java.math.BigDecimal("9.99"))).shouldNotBeNull().shouldBeNear(9.99, 0.001)
+    }
+
+    // ─── 유효성 검사 ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `NaN weight은 IllegalArgumentException 발생`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        val block = { extractor.extract(edge("w" to Double.NaN)) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `양의 무한대 weight은 IllegalArgumentException 발생`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        val block = { extractor.extract(edge("w" to Double.POSITIVE_INFINITY)) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `음수 weight은 IllegalArgumentException 발생`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        val block = { extractor.extract(edge("w" to -1.0)) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `0 weight은 IllegalArgumentException 발생`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        val block = { extractor.extract(edge("w" to 0.0)) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `String 비숫자 속성은 IllegalArgumentException 발생`() {
+        val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
+        val block = { extractor.extract(edge("w" to "abc")) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    // ─── MissingWeightPolicy 생성 ─────────────────────────────────────────────
+
+    @Test
+    fun `UseDefault value 0은 IllegalArgumentException`() {
+        val block = { MissingWeightPolicy.UseDefault(0.0) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `UseDefault value 음수는 IllegalArgumentException`() {
+        val block = { MissingWeightPolicy.UseDefault(-1.0) }
+        block shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `UseDefault Infinity는 IllegalArgumentException`() {
+        val block = { MissingWeightPolicy.UseDefault(Double.POSITIVE_INFINITY) }
+        block shouldThrow IllegalArgumentException::class
+    }
+}

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperations.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperations.kt
@@ -4,6 +4,7 @@ import com.falkordb.Driver
 import com.falkordb.Record
 import com.falkordb.ResultSet
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.algo.internal.BfsDfsRunner
 import io.bluetape4k.graph.algo.internal.CycleDetector
 import io.bluetape4k.graph.algo.internal.PageRankCalculator
@@ -158,6 +159,14 @@ class FalkorDBGraphOperations(
         }.firstOrNull()
     }
 
+    override fun findVertexById(id: GraphElementId): GraphVertex? =
+        queryList(
+            "MATCH (n) WHERE id(n) = toInteger(\$id) RETURN n",
+            mapOf("id" to id.value),
+        ) {
+            it.toVertex()
+        }.firstOrNull()
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
         label.requireNotBlank("label").requireSafeIdentifier("label")
         val whereClause =
@@ -267,6 +276,30 @@ class FalkorDBGraphOperations(
         }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        edgeLabel?.requireNotBlank("edgeLabel")
+        val edgePattern = edgeLabel?.let { ":${it.requireSafeIdentifier("edgeLabel")}" } ?: ""
+
+        return queryList(
+            "MATCH (a)-[r$edgePattern]->(b) WHERE id(a) = toInteger(\$startId) RETURN r",
+            mapOf("startId" to startId.value),
+        ) {
+            it.toEdge()
+        }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        edgeLabel?.requireNotBlank("edgeLabel")
+        val edgePattern = edgeLabel?.let { ":${it.requireSafeIdentifier("edgeLabel")}" } ?: ""
+
+        return queryList(
+            "MATCH (a)-[r$edgePattern]->(b) WHERE id(b) = toInteger(\$endId) RETURN r",
+            mapOf("endId" to endId.value),
+        ) {
+            it.toEdge()
+        }
+    }
+
     override fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label").requireSafeIdentifier("label")
 
@@ -310,11 +343,15 @@ class FalkorDBGraphOperations(
         toId: GraphElementId,
         options: PathOptions,
     ): GraphPath? {
+        options.edgeLabel?.requireNotBlank("edgeLabel")
         fromId.value.toLongOrNull()
             ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $fromId")
         toId.value.toLongOrNull()
             ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $toId")
-        options.edgeLabel?.requireNotBlank("edgeLabel")
+
+        if (options.weightProperty != null) {
+            return ShortestPathFallback.dijkstra(this, fromId, toId, options)
+        }
 
         val relPattern =
             if (options.edgeLabel != null) ":" + options.edgeLabel + "*1.." + options.maxDepth
@@ -328,6 +365,21 @@ class FalkorDBGraphOperations(
         ) {
             it.toPath()
         }.firstOrNull()
+    }
+
+    override fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        options.edgeLabel?.requireNotBlank("edgeLabel")
+        fromId.value.toLongOrNull()
+            ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $fromId")
+        toId.value.toLongOrNull()
+            ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $toId")
+
+        return ShortestPathFallback.aStar(this, fromId, toId, options, heuristic)
     }
 
     override fun allPaths(

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperations.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperations.kt
@@ -4,6 +4,7 @@ import com.falkordb.Driver
 import com.falkordb.Record
 import com.falkordb.ResultSet
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.algo.internal.BfsDfsRunner
 import io.bluetape4k.graph.algo.internal.CycleDetector
 import io.bluetape4k.graph.algo.internal.PageRankCalculator
@@ -77,6 +78,8 @@ class FalkorDBGraphSuspendOperations(
     init {
         graphName.requireNotBlank("graphName")
     }
+
+    private val syncDelegate by lazy { FalkorDBGraphOperations(driver, graphName) }
 
     /**
      * [graphName]에 해당하는 그래프 컨텍스트를 열고 [block]을 실행한 뒤 자동으로 닫습니다.
@@ -196,6 +199,14 @@ class FalkorDBGraphSuspendOperations(
         }.firstOrNull()
     }
 
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? =
+        queryListIO(
+            "MATCH (n) WHERE id(n) = toInteger(\$id) RETURN n",
+            mapOf("id" to id.value),
+        ) {
+            it.toVertex()
+        }.firstOrNull()
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
         label.requireNotBlank("label").requireSafeIdentifier("label")
 
@@ -304,6 +315,30 @@ class FalkorDBGraphSuspendOperations(
         }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        edgeLabel?.requireNotBlank("edgeLabel")
+        val edgePattern = edgeLabel?.let { ":${it.requireSafeIdentifier("edgeLabel")}" } ?: ""
+
+        return flowQuery(
+            "MATCH (a)-[r$edgePattern]->(b) WHERE id(a) = toInteger(\$startId) RETURN r",
+            mapOf("startId" to startId.value),
+        ) {
+            it.toEdge()
+        }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        edgeLabel?.requireNotBlank("edgeLabel")
+        val edgePattern = edgeLabel?.let { ":${it.requireSafeIdentifier("edgeLabel")}" } ?: ""
+
+        return flowQuery(
+            "MATCH (a)-[r$edgePattern]->(b) WHERE id(b) = toInteger(\$endId) RETURN r",
+            mapOf("endId" to endId.value),
+        ) {
+            it.toEdge()
+        }
+    }
+
     override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label").requireSafeIdentifier("label")
 
@@ -348,11 +383,17 @@ class FalkorDBGraphSuspendOperations(
         toId: GraphElementId,
         options: PathOptions,
     ): GraphPath? {
+        options.edgeLabel?.requireNotBlank("edgeLabel")
         fromId.value.toLongOrNull()
             ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $fromId")
         toId.value.toLongOrNull()
             ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $toId")
-        options.edgeLabel?.requireNotBlank("edgeLabel")
+
+        if (options.weightProperty != null) {
+            return withContext(Dispatchers.IO) {
+                ShortestPathFallback.dijkstra(syncDelegate, fromId, toId, options)
+            }
+        }
 
         val relPattern =
             if (options.edgeLabel != null) ":" + options.edgeLabel + "*1.." + options.maxDepth
@@ -366,6 +407,23 @@ class FalkorDBGraphSuspendOperations(
         ) {
             it.toPath()
         }.firstOrNull()
+    }
+
+    override suspend fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        options.edgeLabel?.requireNotBlank("edgeLabel")
+        fromId.value.toLongOrNull()
+            ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $fromId")
+        toId.value.toLongOrNull()
+            ?: throw GraphQueryException("FalkorDB requires numeric ID, got: $toId")
+
+        return withContext(Dispatchers.IO) {
+            ShortestPathFallback.aStar(syncDelegate, fromId, toId, options, heuristic)
+        }
     }
 
     override fun allPaths(

--- a/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBWeightedPathTest.kt
+++ b/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBWeightedPathTest.kt
@@ -1,0 +1,99 @@
+package io.bluetape4k.graph.falkordb
+
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.math.sqrt
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FalkorDBWeightedPathTest : AbstractFalkorDBTest() {
+
+    companion object : KLogging()
+
+    private lateinit var ops: FalkorDBGraphOperations
+
+    @BeforeAll
+    override fun setupAll() {
+        super.setupAll()
+        ops = FalkorDBGraphOperations(driver, graphName)
+    }
+
+    @BeforeEach
+    fun cleanup() {
+        ops.dropGraph(graphName)
+    }
+
+    @Test
+    fun `가중치 최단 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `가중치 없는 간선 Skip 정책에서 경로 없음`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        ops.shortestPath(a.id, b.id, PathOptions(weightProperty = "cost")).shouldBeNull()
+    }
+
+    @Test
+    fun `A* 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A", "x" to 0.0, "y" to 0.0))
+        val b = ops.createVertex("City", mapOf("name" to "B", "x" to 1.0, "y" to 0.0))
+        val c = ops.createVertex("City", mapOf("name" to "C", "x" to 2.0, "y" to 0.0))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val goalX = c.properties["x"] as? Double ?: 2.0
+        val goalY = c.properties["y"] as? Double ?: 0.0
+
+        val path = ops.aStarPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { v ->
+            val vx = v.properties["x"] as? Double ?: 0.0
+            val vy = v.properties["y"] as? Double ?: 0.0
+            sqrt((vx - goalX) * (vx - goalX) + (vy - goalY) * (vy - goalY))
+        }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+}

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphOperations.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.memgraph
 
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.algo.internal.BfsDfsRunner
 import io.bluetape4k.graph.algo.internal.CycleDetector
 import io.bluetape4k.graph.algo.internal.PageRankCalculator
@@ -149,6 +150,13 @@ class MemgraphGraphOperations(
         }.firstOrNull()
     }
 
+    override fun findVertexById(id: GraphElementId): GraphVertex? {
+        return runQuery(
+            "MATCH (n) WHERE id(n) = toInteger(\$id) RETURN n",
+            mapOf("id" to id.value),
+        ) { MemgraphRecordMapper.recordToVertex(it) }.firstOrNull()
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
         label.requireNotBlank("label").requireSafeIdentifier("label")
         val whereClause = if (filter.isEmpty()) "" else
@@ -231,6 +239,22 @@ class MemgraphGraphOperations(
         ) { MemgraphRecordMapper.recordToEdge(it) }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        val labelPart = if (edgeLabel != null) ":$edgeLabel" else ""
+        return runQuery(
+            "MATCH (n)-[r$labelPart]->(m) WHERE id(n) = toInteger(\$startId) RETURN r",
+            mapOf("startId" to startId.value),
+        ) { MemgraphRecordMapper.recordToEdge(it) }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        val labelPart = if (edgeLabel != null) ":$edgeLabel" else ""
+        return runQuery(
+            "MATCH (n)-[r$labelPart]->(m) WHERE id(m) = toInteger(\$endId) RETURN r",
+            mapOf("endId" to endId.value),
+        ) { MemgraphRecordMapper.recordToEdge(it) }
+    }
+
     override fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label").requireSafeIdentifier("label")
 
@@ -275,6 +299,10 @@ class MemgraphGraphOperations(
         fromId.value.toLongOrNull() ?: throw GraphQueryException("Memgraph requires numeric ID, got: $fromId")
         toId.value.toLongOrNull() ?: throw GraphQueryException("Memgraph requires numeric ID, got: $toId")
 
+        if (options.weightProperty != null) {
+            return ShortestPathFallback.dijkstra(this, fromId, toId, options)
+        }
+
         // Memgraph는 shortestPath() 미지원 → depth-limited MATCH + ORDER BY length(p) LIMIT 1 사용
         val relPattern =
             if (options.edgeLabel != null) ":" + options.edgeLabel + "*1.." + options.maxDepth
@@ -287,6 +315,17 @@ class MemgraphGraphOperations(
         ) {
             MemgraphRecordMapper.recordToPath(it)
         }.firstOrNull()
+    }
+
+    override fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        fromId.value.requireNotBlank("fromId.value")
+        toId.value.requireNotBlank("toId.value")
+        return ShortestPathFallback.aStar(this, fromId, toId, options, heuristic)
     }
 
     override fun allPaths(

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.memgraph
 
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.model.BfsDfsOptions
 import io.bluetape4k.graph.model.ComponentOptions
 import io.bluetape4k.graph.model.CycleOptions
@@ -190,6 +191,13 @@ class MemgraphGraphSuspendOperations(
         }.firstOrNull()
     }
 
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? {
+        return runQuery(
+            "MATCH (n) WHERE id(n) = toInteger(\$id) RETURN n",
+            mapOf("id" to id.value),
+        ) { MemgraphRecordMapper.recordToVertex(it) }.firstOrNull()
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
         label.requireNotBlank("label").requireSafeIdentifier("label")
 
@@ -282,6 +290,22 @@ class MemgraphGraphSuspendOperations(
         }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val labelPart = if (edgeLabel != null) ":$edgeLabel" else ""
+        return flowQuery(
+            "MATCH (n)-[r$labelPart]->(m) WHERE id(n) = toInteger(\$startId) RETURN r",
+            mapOf("startId" to startId.value),
+        ) { MemgraphRecordMapper.recordToEdge(it) }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val labelPart = if (edgeLabel != null) ":$edgeLabel" else ""
+        return flowQuery(
+            "MATCH (n)-[r$labelPart]->(m) WHERE id(m) = toInteger(\$endId) RETURN r",
+            mapOf("endId" to endId.value),
+        ) { MemgraphRecordMapper.recordToEdge(it) }
+    }
+
     override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label").requireSafeIdentifier("label")
 
@@ -329,7 +353,11 @@ class MemgraphGraphSuspendOperations(
     ): GraphPath? {
         fromId.value.toLongOrNull() ?: throw GraphQueryException("Memgraph requires numeric ID, got: $fromId")
         toId.value.toLongOrNull() ?: throw GraphQueryException("Memgraph requires numeric ID, got: $toId")
-        
+
+        if (options.weightProperty != null) {
+            return withContext(Dispatchers.IO) { ShortestPathFallback.dijkstra(syncDelegate, fromId, toId, options) }
+        }
+
         // Memgraph는 shortestPath() 미지원 → depth-limited MATCH + ORDER BY length(p) LIMIT 1 사용
         val relPattern =
             if (options.edgeLabel != null) ":" + options.edgeLabel + "*1.." + options.maxDepth
@@ -343,6 +371,17 @@ class MemgraphGraphSuspendOperations(
         ) {
             MemgraphRecordMapper.recordToPath(it)
         }.firstOrNull()
+    }
+
+    override suspend fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        fromId.value.requireNotBlank("fromId.value")
+        toId.value.requireNotBlank("toId.value")
+        return withContext(Dispatchers.IO) { ShortestPathFallback.aStar(syncDelegate, fromId, toId, options, heuristic) }
     }
 
     override fun allPaths(

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphWeightedPathTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphWeightedPathTest.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+import kotlin.math.sqrt
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MemgraphWeightedPathTest {
+
+    companion object : KLogging()
+
+    private lateinit var driver: Driver
+    private lateinit var ops: MemgraphGraphOperations
+
+    @BeforeAll
+    fun setup() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+
+    @BeforeEach
+    fun clearGraph() {
+        ops.dropGraph("default")
+    }
+
+    @Test
+    fun `가중치 최단 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `가중치 없는 간선 Skip 정책에서 경로 없음`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        ops.shortestPath(a.id, b.id, PathOptions(weightProperty = "cost")).shouldBeNull()
+    }
+
+    @Test
+    fun `A* 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A", "x" to 0.0, "y" to 0.0))
+        val b = ops.createVertex("City", mapOf("name" to "B", "x" to 1.0, "y" to 0.0))
+        val c = ops.createVertex("City", mapOf("name" to "C", "x" to 2.0, "y" to 0.0))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val goalX = c.properties["x"] as? Double ?: 2.0
+        val goalY = c.properties["y"] as? Double ?: 0.0
+
+        val path = ops.aStarPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { v ->
+            val vx = v.properties["x"] as? Double ?: 0.0
+            val vy = v.properties["y"] as? Double ?: 0.0
+            sqrt((vx - goalX) * (vx - goalX) + (vy - goalY) * (vy - goalY))
+        }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+}

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.neo4j
 
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.algo.internal.BfsDfsRunner
 import io.bluetape4k.graph.algo.internal.CycleDetector
 import io.bluetape4k.graph.algo.internal.PageRankCalculator
@@ -125,6 +126,15 @@ class Neo4jGraphOperations(
         }.firstOrNull()
     }
 
+    override fun findVertexById(id: GraphElementId): GraphVertex? {
+        return runQuery(
+            $$"MATCH (n) WHERE elementId(n) = $id RETURN n",
+            mapOf("id" to id.value),
+        ) {
+            Neo4jRecordMapper.recordToVertex(it)
+        }.firstOrNull()
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
         label.requireNotBlank("label")
 
@@ -208,6 +218,22 @@ class Neo4jGraphOperations(
         ) { Neo4jRecordMapper.recordToEdge(it) }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        val labelPart = if (edgeLabel != null) $$":$$edgeLabel" else ""
+        return runQuery(
+            $$"MATCH (n)-[r$$labelPart]->(m) WHERE elementId(n) = $startId RETURN r",
+            mapOf("startId" to startId.value),
+        ) { Neo4jRecordMapper.recordToEdge(it) }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        val labelPart = if (edgeLabel != null) $$":$$edgeLabel" else ""
+        return runQuery(
+            $$"MATCH (n)-[r$$labelPart]->(m) WHERE elementId(m) = $endId RETURN r",
+            mapOf("endId" to endId.value),
+        ) { Neo4jRecordMapper.recordToEdge(it) }
+    }
+
     override fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label")
         id.value.requireNotBlank("id.value")
@@ -253,6 +279,10 @@ class Neo4jGraphOperations(
         fromId.value.requireNotBlank("fromId.value")
         toId.value.requireNotBlank("toId.value")
 
+        if (options.weightProperty != null) {
+            return ShortestPathFallback.dijkstra(this, fromId, toId, options)
+        }
+
         val relPattern =
             if (options.edgeLabel != null) $$":$${options.edgeLabel}*1..$${options.maxDepth}"
             else $$"*1..$${options.maxDepth}"
@@ -264,6 +294,17 @@ class Neo4jGraphOperations(
         ) {
             Neo4jRecordMapper.recordToPath(it)
         }.firstOrNull()
+    }
+
+    override fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        fromId.value.requireNotBlank("fromId.value")
+        toId.value.requireNotBlank("toId.value")
+        return ShortestPathFallback.aStar(this, fromId, toId, options, heuristic)
     }
 
     override fun allPaths(

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSuspendOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSuspendOperations.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.neo4j
 
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.model.BfsDfsOptions
 import io.bluetape4k.graph.model.ComponentOptions
 import io.bluetape4k.graph.model.CycleOptions
@@ -172,6 +173,15 @@ class Neo4jGraphSuspendOperations(
         }.firstOrNull()
     }
 
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? {
+        return runQuery(
+            $$"MATCH (n) WHERE elementId(n) = $id RETURN n",
+            mapOf("id" to id.value),
+        ) {
+            Neo4jRecordMapper.recordToVertex(it)
+        }.firstOrNull()
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
         label.requireNotBlank("label")
 
@@ -267,6 +277,22 @@ class Neo4jGraphSuspendOperations(
         }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val labelPart = if (edgeLabel != null) $$":$$edgeLabel" else ""
+        return flowQuery(
+            $$"MATCH (n)-[r$$labelPart]->(m) WHERE elementId(n) = $startId RETURN r",
+            mapOf("startId" to startId.value),
+        ) { Neo4jRecordMapper.recordToEdge(it) }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val labelPart = if (edgeLabel != null) $$":$$edgeLabel" else ""
+        return flowQuery(
+            $$"MATCH (n)-[r$$labelPart]->(m) WHERE elementId(m) = $endId RETURN r",
+            mapOf("endId" to endId.value),
+        ) { Neo4jRecordMapper.recordToEdge(it) }
+    }
+
     override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label")
 
@@ -315,6 +341,10 @@ class Neo4jGraphSuspendOperations(
         fromId.value.requireNotBlank("fromId.value")
         toId.value.requireNotBlank("toId.value")
 
+        if (options.weightProperty != null) {
+            return withContext(Dispatchers.IO) { ShortestPathFallback.dijkstra(syncDelegate, fromId, toId, options) }
+        }
+
         val relPattern =
             if (options.edgeLabel != null) $$":$${options.edgeLabel}*1..$${options.maxDepth}"
             else $$"*1..$${options.maxDepth}"
@@ -326,6 +356,17 @@ class Neo4jGraphSuspendOperations(
         ) {
             Neo4jRecordMapper.recordToPath(it)
         }.firstOrNull()
+    }
+
+    override suspend fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? {
+        fromId.value.requireNotBlank("fromId.value")
+        toId.value.requireNotBlank("toId.value")
+        return withContext(Dispatchers.IO) { ShortestPathFallback.aStar(syncDelegate, fromId, toId, options, heuristic) }
     }
 
     override fun allPaths(

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jWeightedPathTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jWeightedPathTest.kt
@@ -1,0 +1,173 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+import kotlin.math.sqrt
+
+/**
+ * Neo4j 가중치 최단 경로(Dijkstra/A*) 통합 테스트.
+ *
+ * 테스트 그래프 (ROAD 레이블):
+ *
+ * A --(1.0)--> B --(2.0)--> C
+ * |                          ^
+ * +--------(5.0)-------------+
+ *
+ * 최단 경로 A→C: A→B→C (cost=3.0)
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jWeightedPathTest {
+
+    companion object : KLogging()
+
+    private lateinit var driver: Driver
+    private lateinit var ops: Neo4jGraphOperations
+
+    @BeforeAll
+    fun setup() {
+        val server = Neo4jServer.Launcher.neo4j
+        driver = GraphDatabase.driver(server.boltUrl, AuthTokens.none())
+        ops = Neo4jGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+
+    @BeforeEach
+    fun clearGraph() {
+        ops.dropGraph("default")
+    }
+
+    // ─── Dijkstra ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `가중치 최단 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+        path.vertices.size shouldBeInRange 2..3
+    }
+
+    @Test
+    fun `가중치 없는 간선 Skip 정책에서 경로 없음`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")              // cost 없음
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        val result = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        )
+
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `가중치 없는 간선 UseDefault 정책에서 기본값 적용`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")              // cost 없음 → 기본값 1.0
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+            ),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        val result = ops.shortestPath(
+            a.id, b.id,
+            PathOptions(weightProperty = "cost"),
+        )
+
+        result.shouldBeNull()
+    }
+
+    // ─── A* ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `A* 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A", "x" to 0.0, "y" to 0.0))
+        val b = ops.createVertex("City", mapOf("name" to "B", "x" to 1.0, "y" to 0.0))
+        val c = ops.createVertex("City", mapOf("name" to "C", "x" to 2.0, "y" to 0.0))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val goalX = c.properties["x"] as? Double ?: 2.0
+        val goalY = c.properties["y"] as? Double ?: 0.0
+
+        val path = ops.aStarPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { v ->
+            val vx = v.properties["x"] as? Double ?: 0.0
+            val vy = v.properties["y"] as? Double ?: 0.0
+            sqrt((vx - goalX) * (vx - goalX) + (vy - goalY) * (vy - goalY))
+        }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `A* 연결 없으면 null 반환`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        val result = ops.aStarPath(
+            a.id, b.id,
+            PathOptions(weightProperty = "cost"),
+        ) { _ -> 0.0 }
+
+        result.shouldBeNull()
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+    private infix fun Int.shouldBeInRange(range: IntRange) {
+        assert(this in range) { "Expected $this to be in $range" }
+    }
+}

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.tinkerpop
 
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.model.BfsDfsOptions
 import io.bluetape4k.graph.model.ComponentOptions
 import io.bluetape4k.graph.model.CycleOptions
@@ -99,6 +100,12 @@ class TinkerGraphOperations : GraphOperations, GraphAlgorithmRepository {
         return if (optional.isPresent) GremlinRecordMapper.vertexToGraphVertex(optional.get()) else null
     }
 
+    override fun findVertexById(id: GraphElementId): GraphVertex? {
+        val idValue = id.value.toLongOrNull() ?: return null
+        val optional = g.V(idValue).tryNext()
+        return if (optional.isPresent) GremlinRecordMapper.vertexToGraphVertex(optional.get()) else null
+    }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
         label.requireNotBlank("label")
 
@@ -172,6 +179,20 @@ class TinkerGraphOperations : GraphOperations, GraphAlgorithmRepository {
         return traversal.toList().map { GremlinRecordMapper.edgeToGraphEdge(it) }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        edgeLabel?.requireNotBlank("edgeLabel")
+        val idValue = startId.value.toLongOrNull() ?: return emptyList()
+        val traversal = if (edgeLabel != null) g.V(idValue).outE(edgeLabel) else g.V(idValue).outE()
+        return traversal.toList().map { GremlinRecordMapper.edgeToGraphEdge(it) }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
+        edgeLabel?.requireNotBlank("edgeLabel")
+        val idValue = endId.value.toLongOrNull() ?: return emptyList()
+        val traversal = if (edgeLabel != null) g.V(idValue).inE(edgeLabel) else g.V(idValue).inE()
+        return traversal.toList().map { GremlinRecordMapper.edgeToGraphEdge(it) }
+    }
+
     override fun deleteEdge(label: String, id: GraphElementId): Boolean {
         label.requireNotBlank("label")
         val idValue = id.value.toLongOrNull() ?: return false
@@ -220,6 +241,10 @@ class TinkerGraphOperations : GraphOperations, GraphAlgorithmRepository {
         toId: GraphElementId,
         options: PathOptions,
     ): GraphPath? {
+        if (options.weightProperty != null) {
+            return ShortestPathFallback.dijkstra(this, fromId, toId, options)
+        }
+
         val fromIdValue = fromId.value.toLongOrNull() ?: return null
         val toIdValue = toId.value.toLongOrNull() ?: return null
 
@@ -247,6 +272,13 @@ class TinkerGraphOperations : GraphOperations, GraphAlgorithmRepository {
 
         return paths.firstOrNull()?.let { GremlinRecordMapper.pathToGraphPath(it) }
     }
+
+    override fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? = ShortestPathFallback.aStar(this, fromId, toId, options, heuristic)
 
     override fun allPaths(
         fromId: GraphElementId,

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperations.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.graph.tinkerpop
 
+import io.bluetape4k.graph.algo.ShortestPathFallback
 import io.bluetape4k.graph.model.BfsDfsOptions
 import io.bluetape4k.graph.model.ComponentOptions
 import io.bluetape4k.graph.model.CycleOptions
@@ -94,6 +95,11 @@ class TinkerGraphSuspendOperations(
             delegate.findVertexById(label, id)
         }
 
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? =
+        withContext(Dispatchers.IO) {
+            delegate.findVertexById(id)
+        }
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> = flow {
         val list = withContext(Dispatchers.IO) {
             delegate.findVerticesByLabel(label, filter)
@@ -134,6 +140,20 @@ class TinkerGraphSuspendOperations(
         list.forEach { emit(it) }
     }
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = flow {
+        val list = withContext(Dispatchers.IO) {
+            delegate.findEdgesByStartId(startId, edgeLabel)
+        }
+        list.forEach { emit(it) }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = flow {
+        val list = withContext(Dispatchers.IO) {
+            delegate.findEdgesByEndId(endId, edgeLabel)
+        }
+        list.forEach { emit(it) }
+    }
+
     override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean =
         withContext(Dispatchers.IO) {
             delegate.deleteEdge(label, id)
@@ -156,7 +176,20 @@ class TinkerGraphSuspendOperations(
         toId: GraphElementId,
         options: PathOptions,
     ): GraphPath? = withContext(Dispatchers.IO) {
-        delegate.shortestPath(fromId, toId, options)
+        if (options.weightProperty != null) {
+            ShortestPathFallback.dijkstra(delegate, fromId, toId, options)
+        } else {
+            delegate.shortestPath(fromId, toId, options)
+        }
+    }
+
+    override suspend fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? = withContext(Dispatchers.IO) {
+        ShortestPathFallback.aStar(delegate, fromId, toId, options, heuristic)
     }
 
     override fun allPaths(

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphWeightedPathTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphWeightedPathTest.kt
@@ -1,0 +1,166 @@
+package io.bluetape4k.graph.tinkerpop
+
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeNear
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * TinkerGraph 기반 가중치 최단 경로(Dijkstra/A*) 통합 테스트.
+ *
+ * 테스트 그래프 (ROAD 레이블):
+ *
+ * A --(1.0)--> B --(2.0)--> C
+ * |                          ^
+ * +--------(5.0)-------------+
+ *
+ * 최단 경로 A→C: A→B→C (cost=3.0)
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TinkerGraphWeightedPathTest {
+
+    companion object : KLogging()
+
+    private val ops = TinkerGraphOperations()
+
+    @AfterAll
+    fun teardown() {
+        ops.close()
+    }
+
+    @BeforeEach
+    fun reset() {
+        ops.dropGraph("default")
+    }
+
+    // ─── Dijkstra ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `가중치 최단 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+        path.vertices.map { it.properties["name"] } shouldContainInOrder listOf("A", "B", "C")
+    }
+
+    @Test
+    fun `가중치 없는 간선 Skip 정책에서 경로 없음`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")          // cost 없음
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        val result = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        )
+
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `가중치 없는 간선 UseDefault 정책에서 기본값 적용`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")          // cost 없음 → 기본값 1.0 적용
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        val path = ops.shortestPath(
+            a.id, c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+            ),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        val result = ops.shortestPath(
+            a.id, b.id,
+            PathOptions(weightProperty = "cost"),
+        )
+
+        result.shouldBeNull()
+    }
+
+    // ─── A* ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `A* 경로 A에서 C까지는 A-B-C이다`() {
+        val a = ops.createVertex("City", mapOf("name" to "A", "x" to 0.0, "y" to 0.0))
+        val b = ops.createVertex("City", mapOf("name" to "B", "x" to 1.0, "y" to 0.0))
+        val c = ops.createVertex("City", mapOf("name" to "C", "x" to 2.0, "y" to 0.0))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+
+        val goalX = c.properties["x"] as? Double ?: 2.0
+        val goalY = c.properties["y"] as? Double ?: 0.0
+
+        val path = ops.aStarPath(
+            a.id, c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { v ->
+            val vx = v.properties["x"] as? Double ?: 0.0
+            val vy = v.properties["y"] as? Double ?: 0.0
+            Math.sqrt((vx - goalX) * (vx - goalX) + (vy - goalY) * (vy - goalY))
+        }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `A* 연결 없으면 null 반환`() {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+
+        val result = ops.aStarPath(
+            a.id, b.id,
+            PathOptions(weightProperty = "cost"),
+        ) { _ -> 0.0 }
+
+        result.shouldBeNull()
+    }
+
+    // ─── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+    private infix fun <T> List<T>.shouldContainInOrder(expected: List<T>): List<T> {
+        val actual = this
+        assert(actual.size == expected.size) {
+            "Expected size ${expected.size} but was ${actual.size}: $actual"
+        }
+        expected.forEachIndexed { i, v ->
+            assert(actual[i] == v) { "At index $i: expected $v but was ${actual[i]}" }
+        }
+        return this
+    }
+}


### PR DESCRIPTION
## Summary

Implements weighted edge support and shortest-path algorithms (Dijkstra + A*) for all five graph backends.

Closes #31

---

## Changes

### Core model (`graph-core`)

- **`GraphPath.totalWeight: Double`** — sum of edge weights on a path (0.0 for unweighted)
- **`PathOptions`** — new fields: `weightProperty`, `edgeLabel`, `missingWeightPolicy`, `direction`, `maxVisited`
- **`MissingWeightPolicy`** — sealed class: `Fail` (throws), `Skip` (null path), `UseDefault(value)`
- **`MissingWeightException`** — thrown by `Fail` policy
- **`findVertexById(id)`** — ID-only overload on all vertex repository interfaces
- **`findEdgesByStartId` / `findEdgesByEndId`** — new edge lookup methods
- **`shortestPath(from, to, options)`** + **`aStarPath(from, to, options, heuristic)`** — new traversal interface methods
- **`WeightExtractor`** — converts Double/Float/Int/Long/BigDecimal/String with policy dispatch
- **`PathReconstructor`** — rebuilds `GraphPath` from Dijkstra/A* cameFrom maps
- **`DijkstraRunner`** — pure-JVM Dijkstra via `fetchEdges` / `fetchVertex` lambdas
- **`AStarRunner`** — pure-JVM A* with `heuristic: (GraphVertex) -> Double`
- **`ShortestPathFallback`** — single delegation point used by all backends

### Backend implementations

All five backends implement `findVertexById`, `findEdgesByStartId`, `findEdgesByEndId` and delegate path algorithms to `ShortestPathFallback`:

| Backend | Sync | Suspend |
|---------|------|---------|
| Neo4j | ✅ | ✅ |
| Memgraph | ✅ | ✅ |
| AGE | ✅ | ✅ |
| TinkerPop | ✅ | ✅ |
| FalkorDB | ✅ | ✅ |

### Tests (65 new, all passing)

| Test class | Module | Tests |
|------------|--------|-------|
| `WeightExtractorTest` | graph-core | 19 |
| `DijkstraRunnerTest` | graph-core | 12 |
| `AStarRunnerTest` | graph-core | 10 |
| `TinkerGraphWeightedPathTest` | graph-tinkerpop | 6 |
| `Neo4jWeightedPathTest` | graph-neo4j | 6 |
| `MemgraphWeightedPathTest` | graph-memgraph | 4 |
| `AgeWeightedPathTest` | graph-age | 4 |
| `FalkorDBWeightedPathTest` | graph-falkordb | 4 |

### Bug fix

`Neo4jGraphOperations.findEdgesByStartId`: stray `$$` before `-[r` in a Kotlin multi-dollar string template produced literal `$$` in generated Cypher.

### Documentation

`graph-core/README.md` — new **Weighted Shortest Path** section with `PathOptions` table, `MissingWeightPolicy` code block, usage examples, and updated Algorithm Support Matrix.

---

## Test graph

```
A --(1.0)--> B --(2.0)--> C
|                          ^
+----------(5.0)-----------+

Dijkstra A→C: A→B→C (totalWeight = 3.0)
```

---

## Checklist

- [x] All 65 new tests pass
- [x] Full backend regression suite passes
- [`MissingWeightPolicy.Fail/Skip/UseDefault`] verified per backend
- [x] A* with Euclidean heuristic verified per backend
- [x] Neo4j `$$` Cypher bug fixed
- [x] README updated