### PR TITLE
fix: PR #44 머지 후 컴파일 회귀 수정

### DIFF
--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/testsupport/FakeGraphOperations.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/testsupport/FakeGraphOperations.kt
@@ -39,6 +39,9 @@ class FakeGraphOperations: GraphOperations {
     override fun findVertexById(label: String, id: GraphElementId): GraphVertex? =
         error("not used in this test")
 
+    override fun findVertexById(id: GraphElementId): GraphVertex? =
+        error("not used in this test")
+
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> =
         error("not used in this test")
 
@@ -64,6 +67,12 @@ class FakeGraphOperations: GraphOperations {
     override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): List<GraphEdge> =
         error("not used in this test")
 
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> =
+        error("not used in this test")
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> =
+        error("not used in this test")
+
     override fun deleteEdge(label: String, id: GraphElementId): Boolean =
         error("not used in this test")
 
@@ -82,6 +91,13 @@ class FakeGraphOperations: GraphOperations {
         toId: GraphElementId,
         options: PathOptions,
     ): List<GraphPath> = error("not used in this test")
+
+    override fun aStarPath(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        options: PathOptions,
+        heuristic: (GraphVertex) -> Double,
+    ): GraphPath? = error("not used in this test")
 
     // --- GraphAlgorithmRepository ---
     override fun pageRank(options: PageRankOptions): List<PageRankScore> =

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/sql/AgeSql.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/sql/AgeSql.kt
@@ -411,7 +411,7 @@ object AgeSql {
      * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
      */
     fun matchEdgesByStartId(graphName: String, startId: Long, edgeLabel: String?): String {
-        val rel = if (edgeLabel != null) ":${sanitizeLabel(edgeLabel)}" else ""
+        val rel = if (edgeLabel != null) ":${edgeLabel.requireSafeIdentifier("edgeLabel")}" else ""
         return cypher(
             graphName,
             "MATCH (a)-[e$rel]->(b) WHERE id(a) = $startId RETURN e",
@@ -432,7 +432,7 @@ object AgeSql {
      * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
      */
     fun matchEdgesByEndId(graphName: String, endId: Long, edgeLabel: String?): String {
-        val rel = if (edgeLabel != null) ":${sanitizeLabel(edgeLabel)}" else ""
+        val rel = if (edgeLabel != null) ":${edgeLabel.requireSafeIdentifier("edgeLabel")}" else ""
         return cypher(
             graphName,
             "MATCH (a)-[e$rel]->(b) WHERE id(b) = $endId RETURN e",

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jWeightedPathTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jWeightedPathTest.kt
@@ -128,6 +128,7 @@ class Neo4jWeightedPathTest {
 
     // ─── A* ─────────────────────────────────────────────────────────────────────
 
+    @Suppress("DANGEROUS_CHARACTERS")
     @Test
     fun `A* 경로 A에서 C까지는 A-B-C이다`() {
         val a = ops.createVertex("City", mapOf("name" to "A", "x" to 0.0, "y" to 0.0))
@@ -152,6 +153,7 @@ class Neo4jWeightedPathTest {
         path.totalWeight.shouldBeNear(3.0, 0.001)
     }
 
+    @Suppress("DANGEROUS_CHARACTERS")
     @Test
     fun `A* 연결 없으면 null 반환`() {
         val a = ops.createVertex("City", mapOf("name" to "A"))


### PR DESCRIPTION
## Summary

Fixes compile regression introduced after merging #44.

`develop` branch was broken with two compile errors:

### Root Causes

**1. `AgeSql.kt` — Unresolved reference: `sanitizeLabel`**

PR #44 removed the private `sanitizeLabel()` function and replaced it with the shared `requireSafeIdentifier()` from `graph-core`, but two call sites in `matchEdgesByStartId` and `matchEdgesByEndId` were missed.

Fix: Replace `:sanitizeLabel(edgeLabel)` → `:edgeLabel.requireSafeIdentifier("edgeLabel")`

**2. `FakeGraphOperations.kt` — Unimplemented abstract members**

PR #31 (weighted graph) added new methods to the `GraphOperations` interface hierarchy:
- `GraphVertexRepository.findVertexById(id: GraphElementId)`
- `GraphEdgeRepository.findEdgesByStartId()`
- `GraphEdgeRepository.findEdgesByEndId()`
- `GraphTraversalRepository.aStarPath()`

`FakeGraphOperations` (test stub in `graph-io-core`) was not updated when those methods were added.

Fix: Add `error("not used in this test")` stub implementations for all four methods.

### Also included

- `Neo4jWeightedPathTest.kt`: `@Suppress("DANGEROUS_CHARACTERS")` added by linter

### Verification

```
./gradlew compileKotlin compileTestKotlin  → BUILD SUCCESSFUL
```
