### PR TITLE
fix: spring-boot3/4 + examples 코드 리뷰 CRITICAL/HIGH/MEDIUM 수정

### DIFF
--- a/examples/code-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/code/service/CodeGraphService.kt
+++ b/examples/code-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/code/service/CodeGraphService.kt
@@ -8,6 +8,8 @@ import io.bluetape4k.graph.model.NeighborOptions
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
 
 /**
  * 소스 코드 의존성 그래프 서비스.
@@ -42,7 +44,7 @@ class CodeGraphService(
     fun initialize() {
         if (!ops.graphExists(graphName)) {
             ops.createGraph(graphName)
-            log.info("Code graph '$graphName' created")
+            log.info { "Code graph '$graphName' created" }
         }
     }
 
@@ -64,10 +66,13 @@ class CodeGraphService(
         path: String = "",
         version: String = "",
         language: String = "kotlin",
-    ): GraphVertex = ops.createVertex(
-        "Module",
-        mapOf("name" to name, "path" to path, "version" to version, "language" to language)
-    )
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            "Module",
+            mapOf("name" to name, "path" to path, "version" to version, "language" to language)
+        )
+    }
 
     /**
      * 클래스 정점을 추가한다.
@@ -82,16 +87,20 @@ class CodeGraphService(
         module: String = "",
         isAbstract: Boolean = false,
         isInterface: Boolean = false,
-    ): GraphVertex = ops.createVertex(
-        "Class",
-        mapOf(
-            "name" to name,
-            "qualifiedName" to qualifiedName,
-            "module" to module,
-            "isAbstract" to isAbstract,
-            "isInterface" to isInterface,
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        qualifiedName.requireNotBlank("qualifiedName")
+        return ops.createVertex(
+            "Class",
+            mapOf(
+                "name" to name,
+                "qualifiedName" to qualifiedName,
+                "module" to module,
+                "isAbstract" to isAbstract,
+                "isInterface" to isInterface,
+            )
         )
-    )
+    }
 
     /**
      * 함수 정점을 추가한다.
@@ -106,16 +115,20 @@ class CodeGraphService(
         className: String = "",
         module: String = "",
         lineCount: Int = 0,
-    ): GraphVertex = ops.createVertex(
-        "Function",
-        mapOf(
-            "name" to name,
-            "signature" to signature,
-            "className" to className,
-            "module" to module,
-            "lineCount" to lineCount,
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        signature.requireNotBlank("signature")
+        return ops.createVertex(
+            "Function",
+            mapOf(
+                "name" to name,
+                "signature" to signature,
+                "className" to className,
+                "module" to module,
+                "lineCount" to lineCount,
+            )
         )
-    )
+    }
 
     /**
      * 모듈 간 의존성 간선을 추가한다.
@@ -292,8 +305,10 @@ class CodeGraphService(
      * val modules = service.findModuleByName("graph-core")
      * ```
      */
-    fun findModuleByName(name: String): List<GraphVertex> =
-        ops.findVerticesByLabel("Module", mapOf("name" to name))
+    fun findModuleByName(name: String): List<GraphVertex> {
+        name.requireNotBlank("name")
+        return ops.findVerticesByLabel("Module", mapOf("name" to name))
+    }
 
     /**
      * 클래스 이름으로 검색한다.
@@ -302,6 +317,8 @@ class CodeGraphService(
      * val classes = service.findClassByName("GraphOperations")
      * ```
      */
-    fun findClassByName(name: String): List<GraphVertex> =
-        ops.findVerticesByLabel("Class", mapOf("name" to name))
+    fun findClassByName(name: String): List<GraphVertex> {
+        name.requireNotBlank("name")
+        return ops.findVerticesByLabel("Class", mapOf("name" to name))
+    }
 }

--- a/examples/code-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/code/service/CodeGraphSuspendService.kt
+++ b/examples/code-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/code/service/CodeGraphSuspendService.kt
@@ -8,6 +8,8 @@ import io.bluetape4k.graph.model.NeighborOptions
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -46,7 +48,7 @@ class CodeGraphSuspendService(
     suspend fun initialize() {
         if (!ops.graphExists(graphName)) {
             ops.createGraph(graphName)
-            log.info("Code graph '$graphName' created")
+            log.info { "Code graph '$graphName' created" }
         }
     }
 
@@ -57,8 +59,18 @@ class CodeGraphSuspendService(
      * val module = service.addModule("graph-core", path = "graph/graph-core")
      * ```
      */
-    suspend fun addModule(name: String, path: String = "", version: String = "", language: String = "kotlin"): GraphVertex =
-        ops.createVertex("Module", mapOf("name" to name, "path" to path, "version" to version, "language" to language))
+    suspend fun addModule(
+        name: String,
+        path: String = "",
+        version: String = "",
+        language: String = "kotlin",
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            "Module",
+            mapOf("name" to name, "path" to path, "version" to version, "language" to language)
+        )
+    }
 
     /**
      * 클래스 정점을 추가한다.
@@ -67,8 +79,26 @@ class CodeGraphSuspendService(
      * val cls = service.addClass("MyClass", "com.example.MyClass", module = "core")
      * ```
      */
-    suspend fun addClass(name: String, qualifiedName: String, module: String = "", isAbstract: Boolean = false, isInterface: Boolean = false): GraphVertex =
-        ops.createVertex("Class", mapOf("name" to name, "qualifiedName" to qualifiedName, "module" to module, "isAbstract" to isAbstract, "isInterface" to isInterface))
+    suspend fun addClass(
+        name: String,
+        qualifiedName: String,
+        module: String = "",
+        isAbstract: Boolean = false,
+        isInterface: Boolean = false,
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        qualifiedName.requireNotBlank("qualifiedName")
+        return ops.createVertex(
+            "Class",
+            mapOf(
+                "name" to name,
+                "qualifiedName" to qualifiedName,
+                "module" to module,
+                "isAbstract" to isAbstract,
+                "isInterface" to isInterface,
+            )
+        )
+    }
 
     /**
      * 함수 정점을 추가한다.
@@ -77,8 +107,26 @@ class CodeGraphSuspendService(
      * val fn = service.addFunction("doSomething", "fun doSomething(): Unit", className = "MyClass")
      * ```
      */
-    suspend fun addFunction(name: String, signature: String, className: String = "", module: String = "", lineCount: Int = 0): GraphVertex =
-        ops.createVertex("Function", mapOf("name" to name, "signature" to signature, "className" to className, "module" to module, "lineCount" to lineCount))
+    suspend fun addFunction(
+        name: String,
+        signature: String,
+        className: String = "",
+        module: String = "",
+        lineCount: Int = 0,
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        signature.requireNotBlank("signature")
+        return ops.createVertex(
+            "Function",
+            mapOf(
+                "name" to name,
+                "signature" to signature,
+                "className" to className,
+                "module" to module,
+                "lineCount" to lineCount,
+            )
+        )
+    }
 
     /**
      * 모듈 간 의존성 간선을 추가한다.
@@ -87,8 +135,16 @@ class CodeGraphSuspendService(
      * service.addDependency(ageModule.id, coreModule.id, dependencyType = "compile")
      * ```
      */
-    suspend fun addDependency(fromModuleId: GraphElementId, toModuleId: GraphElementId, dependencyType: String = "compile", version: String = "") {
-        ops.createEdge(fromModuleId, toModuleId, "DEPENDS_ON", mapOf("dependencyType" to dependencyType, "version" to version))
+    suspend fun addDependency(
+        fromModuleId: GraphElementId,
+        toModuleId: GraphElementId,
+        dependencyType: String = "compile",
+        version: String = "",
+    ) {
+        ops.createEdge(
+            fromModuleId, toModuleId, "DEPENDS_ON",
+            mapOf("dependencyType" to dependencyType, "version" to version)
+        )
     }
 
     /**
@@ -120,8 +176,16 @@ class CodeGraphSuspendService(
      * service.addCall(callerFn.id, calleeFn.id, callCount = 3)
      * ```
      */
-    suspend fun addCall(callerFunctionId: GraphElementId, calleeFunctionId: GraphElementId, callCount: Int = 1, isRecursive: Boolean = false) {
-        ops.createEdge(callerFunctionId, calleeFunctionId, "CALLS", mapOf("callCount" to callCount, "isRecursive" to isRecursive))
+    suspend fun addCall(
+        callerFunctionId: GraphElementId,
+        calleeFunctionId: GraphElementId,
+        callCount: Int = 1,
+        isRecursive: Boolean = false,
+    ) {
+        ops.createEdge(
+            callerFunctionId, calleeFunctionId, "CALLS",
+            mapOf("callCount" to callCount, "isRecursive" to isRecursive)
+        )
     }
 
     /**
@@ -222,8 +286,10 @@ class CodeGraphSuspendService(
      * val modules = service.findModuleByName("graph-core").toList()
      * ```
      */
-    fun findModuleByName(name: String): Flow<GraphVertex> =
-        ops.findVerticesByLabel("Module", mapOf("name" to name))
+    fun findModuleByName(name: String): Flow<GraphVertex> {
+        name.requireNotBlank("name")
+        return ops.findVerticesByLabel("Module", mapOf("name" to name))
+    }
 
     /**
      * 클래스 이름으로 검색한다.
@@ -232,6 +298,8 @@ class CodeGraphSuspendService(
      * val classes = service.findClassByName("GraphOperations").toList()
      * ```
      */
-    fun findClassByName(name: String): Flow<GraphVertex> =
-        ops.findVerticesByLabel("Class", mapOf("name" to name))
+    fun findClassByName(name: String): Flow<GraphVertex> {
+        name.requireNotBlank("name")
+        return ops.findVerticesByLabel("Class", mapOf("name" to name))
+    }
 }

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
@@ -5,7 +5,6 @@ import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeNull
@@ -16,14 +15,14 @@ import org.junit.jupiter.api.Test
 
 abstract class AbstractCodeGraphSuspendTest {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     protected abstract val ops: GraphSuspendOperations
     protected open val graphName: String = "code_graph"
     protected val service: CodeGraphSuspendService by lazy { CodeGraphSuspendService(ops, graphName) }
 
     @BeforeEach
-    fun cleanGraph() = runBlocking {
+    fun cleanGraph() = runTest {
         if (ops.graphExists(graphName)) ops.dropGraph(graphName)
         service.initialize()
     }

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 
 abstract class AbstractCodeGraphTest {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     protected abstract val ops: GraphOperations
     protected open val graphName: String = "code_graph"

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AgeCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AgeCodeGraphSuspendTest.kt
@@ -12,7 +12,6 @@ class AgeCodeGraphSuspendTest : AbstractCodeGraphSuspendTest() {
     override val graphName = "code_test_suspend"
 
     private lateinit var dataSource: HikariDataSource
-    private lateinit var database: Database
     override lateinit var ops: AgeGraphSuspendOperations
 
     @BeforeAll
@@ -27,7 +26,8 @@ class AgeCodeGraphSuspendTest : AbstractCodeGraphSuspendTest() {
             connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
             maximumPoolSize = 5
         })
-        database = Database.connect(dataSource)
+        // Registers the DataSource globally in Exposed — required side-effect
+        Database.connect(dataSource)
         ops = AgeGraphSuspendOperations(graphName)
     }
 

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AgeCodeGraphTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AgeCodeGraphTest.kt
@@ -12,7 +12,6 @@ class AgeCodeGraphTest: AbstractCodeGraphTest() {
     override val graphName = "code_test"
 
     private lateinit var dataSource: HikariDataSource
-    private lateinit var database: Database
     override lateinit var ops: AgeGraphOperations
 
     @BeforeAll
@@ -27,7 +26,8 @@ class AgeCodeGraphTest: AbstractCodeGraphTest() {
             connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
             maximumPoolSize = 5
         })
-        database = Database.connect(dataSource)
+        // Registers the DataSource globally in Exposed — required side-effect
+        Database.connect(dataSource)
         ops = AgeGraphOperations(graphName)
     }
 

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphSuspendTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.graph.examples.code
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -21,6 +23,8 @@ class FalkorDBCodeGraphSuspendTest : AbstractCodeGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
+        runCatching { runBlocking { ops.dropGraph(graphName) } }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }
 }

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.graph.examples.code
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.logging.warn
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -21,6 +22,8 @@ class FalkorDBCodeGraphTest : AbstractCodeGraphTest() {
 
     @AfterAll
     fun stopServer() {
+        runCatching { ops.dropGraph(graphName) }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }
 }

--- a/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphService.kt
+++ b/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphService.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.graph.model.NeighborOptions
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
 
 /**
  * LinkedIn 인맥 그래프 서비스.
@@ -41,7 +43,7 @@ class LinkedInGraphService(
     fun initialize() {
         if (!ops.graphExists(graphName)) {
             ops.createGraph(graphName)
-            log.info("LinkedIn graph '{}' created", graphName)
+            log.info { "LinkedIn graph '$graphName' created" }
         }
     }
 
@@ -63,10 +65,13 @@ class LinkedInGraphService(
         title: String = "",
         company: String = "",
         location: String = "",
-    ): GraphVertex = ops.createVertex(
-        "Person",
-        mapOf("name" to name, "title" to title, "company" to company, "location" to location)
-    )
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            "Person",
+            mapOf("name" to name, "title" to title, "company" to company, "location" to location)
+        )
+    }
 
     /**
      * 회사 정점을 추가한다.
@@ -79,10 +84,13 @@ class LinkedInGraphService(
         name: String,
         industry: String = "",
         location: String = "",
-    ): GraphVertex = ops.createVertex(
-        "Company",
-        mapOf("name" to name, "industry" to industry, "location" to location)
-    )
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            "Company",
+            mapOf("name" to name, "industry" to industry, "location" to location)
+        )
+    }
 
     /**
      * 인맥 연결을 추가한다 (양방향: A KNOWS B, B KNOWS A).
@@ -205,6 +213,8 @@ class LinkedInGraphService(
      * val persons = service.findPersonByName("Alice")
      * ```
      */
-    fun findPersonByName(name: String): List<GraphVertex> =
-        ops.findVerticesByLabel("Person", mapOf("name" to name))
+    fun findPersonByName(name: String): List<GraphVertex> {
+        name.requireNotBlank("name")
+        return ops.findVerticesByLabel("Person", mapOf("name" to name))
+    }
 }

--- a/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphSuspendService.kt
+++ b/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphSuspendService.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.graph.model.NeighborOptions
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -44,6 +46,7 @@ class LinkedInGraphSuspendService(
     suspend fun initialize() {
         if (!ops.graphExists(graphName)) {
             ops.createGraph(graphName)
+            log.info { "LinkedIn graph '$graphName' created" }
         }
     }
 
@@ -61,10 +64,13 @@ class LinkedInGraphSuspendService(
         title: String = "",
         company: String = "",
         location: String = "",
-    ): GraphVertex = ops.createVertex(
-        "Person",
-        mapOf("name" to name, "title" to title, "company" to company, "location" to location)
-    )
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            "Person",
+            mapOf("name" to name, "title" to title, "company" to company, "location" to location)
+        )
+    }
 
     /**
      * 회사 정점을 추가한다.
@@ -77,10 +83,13 @@ class LinkedInGraphSuspendService(
         name: String,
         industry: String = "",
         location: String = "",
-    ): GraphVertex = ops.createVertex(
-        "Company",
-        mapOf("name" to name, "industry" to industry, "location" to location)
-    )
+    ): GraphVertex {
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            "Company",
+            mapOf("name" to name, "industry" to industry, "location" to location)
+        )
+    }
 
     /**
      * 인맥 연결 (양방향: A KNOWS B, B KNOWS A).
@@ -186,6 +195,8 @@ class LinkedInGraphSuspendService(
      * val persons = service.findPersonByName("Alice").toList()
      * ```
      */
-    fun findPersonByName(name: String): Flow<GraphVertex> =
-        ops.findVerticesByLabel("Person", mapOf("name" to name))
+    fun findPersonByName(name: String): Flow<GraphVertex> {
+        name.requireNotBlank("name")
+        return ops.findVerticesByLabel("Person", mapOf("name" to name))
+    }
 }

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphSuspendTest.kt
@@ -13,12 +13,10 @@ import org.amshove.kluent.shouldNotBeEmpty
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractLinkedInGraphSuspendTest {
 
-    companion object: KLoggingChannel()
+    companion object : KLoggingChannel()
 
     protected abstract val ops: GraphSuspendOperations
     protected open val graphName: String = "linkedin_test"

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 
 abstract class AbstractLinkedInGraphTest {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     protected abstract val ops: GraphOperations
     protected open val graphName: String = "linkedin_test"

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AgeLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AgeLinkedInGraphSuspendTest.kt
@@ -11,9 +11,7 @@ import org.junit.jupiter.api.BeforeAll
 class AgeLinkedInGraphSuspendTest: AbstractLinkedInGraphSuspendTest() {
     override val graphName = "linkedin_test_suspend"
     private lateinit var dataSource: HikariDataSource
-    private lateinit var database: Database
     override lateinit var ops: AgeGraphSuspendOperations
-
 
     @BeforeAll
     fun startServer() {
@@ -26,7 +24,8 @@ class AgeLinkedInGraphSuspendTest: AbstractLinkedInGraphSuspendTest() {
             connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
             maximumPoolSize = 5
         })
-        database = Database.connect(dataSource)
+        // Registers the DataSource globally in Exposed — required side-effect
+        Database.connect(dataSource)
         ops = AgeGraphSuspendOperations(graphName)
     }
 

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AgeLinkedInGraphTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AgeLinkedInGraphTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll
 class AgeLinkedInGraphTest: AbstractLinkedInGraphTest() {
     override val graphName = "linkedin_test"
     private lateinit var dataSource: HikariDataSource
-    private lateinit var database: Database
     override lateinit var ops: AgeGraphOperations
 
     @BeforeAll
@@ -25,7 +24,8 @@ class AgeLinkedInGraphTest: AbstractLinkedInGraphTest() {
             connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
             maximumPoolSize = 5
         })
-        database = Database.connect(dataSource)
+        // Registers the DataSource globally in Exposed — required side-effect
+        Database.connect(dataSource)
         ops = AgeGraphOperations(graphName)
     }
 

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphSuspendTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.graph.examples.linkedin
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -21,6 +23,8 @@ class FalkorDBLinkedInGraphSuspendTest : AbstractLinkedInGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
+        runCatching { runBlocking { ops.dropGraph(graphName) } }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }
 }

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.graph.examples.linkedin
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.logging.warn
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -21,6 +22,8 @@ class FalkorDBLinkedInGraphTest : AbstractLinkedInGraphTest() {
 
     @AfterAll
     fun stopServer() {
+        runCatching { ops.dropGraph(graphName) }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }
 }

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAgeAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAgeAutoConfiguration.kt
@@ -88,8 +88,14 @@ class GraphAgeAutoConfiguration {
     fun ageGraphInitializer(ops: AgeGraphOperations, props: AgeGraphProperties): InitializingBean =
         InitializingBean {
             runCatching { ops.createGraph(props.graphName) }
-                .onSuccess { log.info { "AGE graph '${props.graphName}' created / verified" } }
-                .onFailure { log.debug { "AGE graph '${props.graphName}' already exists: ${it.message}" } }
+                .onSuccess { log.info { "AGE graph '${props.graphName}' created" } }
+                .onFailure { ex ->
+                    if (ex.message?.contains("already exists", ignoreCase = true) == true) {
+                        log.debug { "AGE graph '${props.graphName}' already exists — skipping" }
+                    } else {
+                        throw ex
+                    }
+                }
         }
 
     /**
@@ -131,14 +137,23 @@ class GraphAgeAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
-        fun ageHealthIndicator(props: AgeGraphProperties): org.springframework.boot.actuate.health.HealthIndicator =
+        fun ageHealthIndicator(dataSource: DataSource): org.springframework.boot.actuate.health.HealthIndicator =
             org.springframework.boot.actuate.health.HealthIndicator {
-                org.springframework.boot.actuate.health.Health.up()
-                    .withDetail("backend", "age")
-                    .withDetail("graphName", props.graphName)
-                    .build()
+                try {
+                    dataSource.connection.use { conn ->
+                        conn.createStatement().execute("SELECT 1")
+                    }
+                    org.springframework.boot.actuate.health.Health.up()
+                        .withDetail("backend", "age")
+                        .build()
+                } catch (ex: Exception) {
+                    org.springframework.boot.actuate.health.Health.down(ex).build()
+                }
             }
     }
 }

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAutoConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
         GraphNeo4jAutoConfiguration::class,
         GraphMemgraphAutoConfiguration::class,
         GraphAgeAutoConfiguration::class,
+        GraphFalkorDBAutoConfiguration::class,
     ],
 )
 @EnableConfigurationProperties(GraphProperties::class)

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -91,6 +91,9 @@ class GraphFalkorDBAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         /**
          * FalkorDB 연결 상태를 확인하는 HealthIndicator 빈.
          *

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.graph.vt.asVirtualThread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Config
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -19,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
 
 /**
  * Memgraph 백엔드 AutoConfiguration.
@@ -41,10 +43,15 @@ class GraphMemgraphAutoConfiguration {
     @Bean(name = ["memgraphDriver"], destroyMethod = "close")
     @ConditionalOnMissingBean(Driver::class)
     fun memgraphDriver(props: MemgraphGraphProperties): Driver {
-        val auth = if (props.password.isBlank()) AuthTokens.none()
+        val auth = if (props.username.isBlank() || props.password.isBlank()) AuthTokens.none()
                    else AuthTokens.basic(props.username, props.password)
-        log.info { "Creating Memgraph Driver: uri=${props.uri}" }
-        return GraphDatabase.driver(props.uri, auth)
+        val safeUri = props.uri.replace(Regex("//[^@]+@"), "//***@")
+        log.info { "Creating Memgraph Driver: uri=$safeUri" }
+        val config = Config.builder()
+            .withConnectionTimeout(props.connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+            .withMaxConnectionLifetime(props.maxConnectionLifetimeMillis, TimeUnit.MILLISECONDS)
+            .build()
+        return GraphDatabase.driver(props.uri, auth, config)
     }
 
     /**
@@ -90,6 +97,9 @@ class GraphMemgraphAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
         fun memgraphHealthIndicator(driver: Driver): org.springframework.boot.actuate.health.HealthIndicator =

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphNeo4jAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphNeo4jAutoConfiguration.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.graph.vt.asVirtualThread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Config
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -19,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
 
 /**
  * Neo4j 백엔드 AutoConfiguration.
@@ -40,10 +42,15 @@ class GraphNeo4jAutoConfiguration {
     @Bean(name = ["neo4jDriver"], destroyMethod = "close")
     @ConditionalOnMissingBean(Driver::class)
     fun neo4jDriver(props: Neo4jGraphProperties): Driver {
-        val auth = if (props.password.isBlank()) AuthTokens.none()
+        val auth = if (props.username.isBlank() || props.password.isBlank()) AuthTokens.none()
                    else AuthTokens.basic(props.username, props.password)
-        log.info { "Creating Neo4j Driver: uri=${props.uri}, database=${props.database}" }
-        return GraphDatabase.driver(props.uri, auth)
+        val safeUri = props.uri.replace(Regex("//[^@]+@"), "//***@")
+        log.info { "Creating Neo4j Driver: uri=$safeUri, database=${props.database}" }
+        val config = Config.builder()
+            .withConnectionTimeout(props.connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+            .withMaxConnectionLifetime(props.maxConnectionLifetimeMillis, TimeUnit.MILLISECONDS)
+            .build()
+        return GraphDatabase.driver(props.uri, auth, config)
     }
 
     /**
@@ -89,6 +96,9 @@ class GraphNeo4jAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
         fun neo4jHealthIndicator(driver: Driver): org.springframework.boot.actuate.health.HealthIndicator =

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -59,12 +59,8 @@ class GraphTinkerGraphAutoConfiguration {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun graphSuspendOperations(ops: GraphOperations): GraphSuspendOperations {
-        val tinkerOps = checkNotNull(ops as? TinkerGraphOperations) {
-            "Expected TinkerGraphOperations but got ${ops::class.simpleName}"
-        }
-        return TinkerGraphSuspendOperations(tinkerOps)
-    }
+    fun graphSuspendOperations(ops: TinkerGraphOperations): GraphSuspendOperations =
+        TinkerGraphSuspendOperations(ops)
 
     /**
      * Virtual Thread 기반 `GraphVirtualThreadOperations` 빈.
@@ -87,6 +83,9 @@ class GraphTinkerGraphAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
         fun tinkerGraphHealthIndicator(): org.springframework.boot.actuate.health.HealthIndicator =

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -43,7 +43,7 @@ class GraphTinkerGraphAutoConfiguration {
      */
     @Bean(destroyMethod = "close")
     @ConditionalOnMissingBean(GraphOperations::class)
-    fun graphOperations(): GraphOperations {
+    fun graphOperations(): TinkerGraphOperations {
         log.info { "Registering TinkerGraphOperations (in-memory backend)" }
         return TinkerGraphOperations()
     }

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/AgeGraphProperties.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/AgeGraphProperties.kt
@@ -7,8 +7,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.age")
 data class AgeGraphProperties(
-    var graphName: String = "bluetape4k_graph",
-    var autoCreateGraph: Boolean = true,
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val graphName: String = "bluetape4k_graph",
+    val autoCreateGraph: Boolean = true,
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
 )

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/FalkorDBGraphProperties.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/FalkorDBGraphProperties.kt
@@ -11,17 +11,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "bluetape4k.graph.falkordb")
 data class FalkorDBGraphProperties(
     /** FalkorDB 호스트 주소 */
-    var host: String = "localhost",
+    val host: String = "localhost",
     /** FalkorDB Redis 포트 번호 */
-    var port: Int = 6379,
+    val port: Int = 6379,
     /** 인증 사용자명 (비어있으면 인증 없음) */
-    var username: String = "",
+    val username: String = "",
     /** 인증 비밀번호 (비어있으면 인증 없음) */
-    var password: String = "",
+    val password: String = "",
     /** 대상 그래프 이름 */
-    var graphName: String = "bluetape4k",
+    val graphName: String = "bluetape4k",
     /** 코루틴 suspend 기반 [io.bluetape4k.graph.repository.GraphSuspendOperations] 빈 등록 여부 */
-    var registerSuspend: Boolean = true,
+    val registerSuspend: Boolean = true,
     /** Virtual Thread 기반 [io.bluetape4k.graph.repository.GraphVirtualThreadOperations] 빈 등록 여부 */
-    var registerVirtualThread: Boolean = true,
+    val registerVirtualThread: Boolean = true,
 )

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/GraphProperties.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/GraphProperties.kt
@@ -12,5 +12,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "bluetape4k.graph")
 data class GraphProperties(
     /** 활성 백엔드: `tinkergraph` | `neo4j` | `memgraph` | `age` */
-    var backend: String? = null,
+    val backend: String? = null,
 )

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/MemgraphGraphProperties.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/MemgraphGraphProperties.kt
@@ -7,10 +7,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.memgraph")
 data class MemgraphGraphProperties(
-    var uri: String = "bolt://localhost:7687",
-    var username: String = "",
-    var password: String = "",
-    var database: String = "memgraph",
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val uri: String = "bolt://localhost:7687",
+    val username: String = "",
+    val password: String = "",
+    val database: String = "memgraph",
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
+    val connectionTimeoutMillis: Long = 5000L,
+    val maxConnectionLifetimeMillis: Long = 3600000L,
 )

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/Neo4jGraphProperties.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/Neo4jGraphProperties.kt
@@ -7,10 +7,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.neo4j")
 data class Neo4jGraphProperties(
-    var uri: String = "bolt://localhost:7687",
-    var username: String = "neo4j",
-    var password: String = "",
-    var database: String = "neo4j",
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val uri: String = "bolt://localhost:7687",
+    val username: String = "neo4j",
+    val password: String = "",
+    val database: String = "neo4j",
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
+    val connectionTimeoutMillis: Long = 5000L,
+    val maxConnectionLifetimeMillis: Long = 3600000L,
 )

--- a/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/TinkerGraphGraphProperties.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot3/properties/TinkerGraphGraphProperties.kt
@@ -7,6 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.tinkergraph")
 data class TinkerGraphGraphProperties(
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
 )

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAgeAutoConfigurationTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAgeAutoConfigurationTest.kt
@@ -2,44 +2,48 @@ package io.bluetape4k.graph.spring.boot3.autoconfigure
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.graph.age.AgeGraphOperations
+import io.bluetape4k.graph.age.AgeGraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
+import io.bluetape4k.graph.vt.VirtualThreadOperationsAdapter
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldBeInstanceOf
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
+import java.util.function.Supplier
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GraphAgeAutoConfigurationTest {
 
-    companion object : KLogging()
-
-    @Configuration(proxyBeanMethods = false)
-    class DataSourceConfig {
-        @Bean(destroyMethod = "close")
-        fun dataSource(): DataSource {
-            val cfg = HikariConfig().apply {
+    companion object : KLogging() {
+        private val sharedDataSource: HikariDataSource by lazy {
+            HikariDataSource(HikariConfig().apply {
                 jdbcUrl = PostgreSQLAgeServer.Launcher.postgresqlAge.jdbcUrl
                 username = PostgreSQLAgeServer.Launcher.postgresqlAge.username
                 password = PostgreSQLAgeServer.Launcher.postgresqlAge.password
                 maximumPoolSize = 2
                 connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
-            }
-            return HikariDataSource(cfg)
+            })
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardown() {
+            sharedDataSource.close()
         }
     }
 
     private val runner = ApplicationContextRunner()
-        .withUserConfiguration(DataSourceConfig::class.java)
+        .withBean(DataSource::class.java, Supplier { sharedDataSource })
         .withConfiguration(
             AutoConfigurations.of(
                 GraphAutoConfiguration::class.java,
@@ -57,9 +61,19 @@ class GraphAgeAutoConfigurationTest {
     fun `backend=age 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues(*ageProperties)
             .run { ctx ->
-                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldBeInstanceOf<AgeGraphOperations>()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldBeInstanceOf<AgeGraphSuspendOperations>()
+                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldBeInstanceOf<VirtualThreadOperationsAdapter>()
+            }
+    }
+
+    @Test
+    fun `age backend not selected — no GraphOperations bean registered`() {
+        runner
+            .withPropertyValues("bluetape4k.graph.backend=tinkergraph")
+            .run { ctx ->
+                assertThatThrownBy { ctx.getBean(GraphOperations::class.java) }
+                    .isInstanceOf(NoSuchBeanDefinitionException::class.java)
             }
     }
 

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAgeAutoConfigurationTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphAgeAutoConfigurationTest.kt
@@ -12,38 +12,37 @@ import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
 import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeInstanceOf
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
-import java.util.function.Supplier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GraphAgeAutoConfigurationTest {
 
-    companion object : KLogging() {
-        private val sharedDataSource: HikariDataSource by lazy {
-            HikariDataSource(HikariConfig().apply {
+    companion object : KLogging()
+
+    @Configuration(proxyBeanMethods = false)
+    class DataSourceConfig {
+        @Bean(destroyMethod = "close")
+        fun dataSource(): DataSource {
+            val cfg = HikariConfig().apply {
                 jdbcUrl = PostgreSQLAgeServer.Launcher.postgresqlAge.jdbcUrl
                 username = PostgreSQLAgeServer.Launcher.postgresqlAge.username
                 password = PostgreSQLAgeServer.Launcher.postgresqlAge.password
                 maximumPoolSize = 2
                 connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
-            })
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun teardown() {
-            sharedDataSource.close()
+            }
+            return HikariDataSource(cfg)
         }
     }
 
     private val runner = ApplicationContextRunner()
-        .withBean(DataSource::class.java, Supplier { sharedDataSource })
+        .withUserConfiguration(DataSourceConfig::class.java)
         .withConfiguration(
             AutoConfigurations.of(
                 GraphAutoConfiguration::class.java,

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphFalkorDBAutoConfigurationTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphFalkorDBAutoConfigurationTest.kt
@@ -1,11 +1,14 @@
 package io.bluetape4k.graph.spring.boot3.autoconfigure
 
+import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
+import io.bluetape4k.graph.vt.VirtualThreadOperationsAdapter
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldBeInstanceOf
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -42,9 +45,9 @@ class GraphFalkorDBAutoConfigurationTest {
     fun `backend=falkordb 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues(*falkordbProperties)
             .run { ctx ->
-                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldBeInstanceOf<FalkorDBGraphOperations>()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldBeInstanceOf<FalkorDBGraphSuspendOperations>()
+                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldBeInstanceOf<VirtualThreadOperationsAdapter>()
             }
     }
 

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
@@ -1,11 +1,14 @@
 package io.bluetape4k.graph.spring.boot3.autoconfigure
 
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
+import io.bluetape4k.graph.vt.VirtualThreadOperationsAdapter
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldBeInstanceOf
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -38,9 +41,19 @@ class GraphMemgraphAutoConfigurationTest {
     fun `backend=memgraph 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues(*memgraphProperties)
             .run { ctx ->
-                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldBeInstanceOf<MemgraphGraphOperations>()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldBeInstanceOf<MemgraphGraphSuspendOperations>()
+                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldBeInstanceOf<VirtualThreadOperationsAdapter>()
+            }
+    }
+
+    @Test
+    fun `memgraph backend not selected — no GraphOperations bean registered`() {
+        runner
+            .withPropertyValues("bluetape4k.graph.backend=tinkergraph")
+            .run { ctx ->
+                assertThatThrownBy { ctx.getBean(GraphOperations::class.java) }
+                    .isInstanceOf(NoSuchBeanDefinitionException::class.java)
             }
     }
 

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphNeo4jAutoConfigurationTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphNeo4jAutoConfigurationTest.kt
@@ -1,11 +1,14 @@
 package io.bluetape4k.graph.spring.boot3.autoconfigure
 
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
+import io.bluetape4k.graph.vt.VirtualThreadOperationsAdapter
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldBeInstanceOf
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -37,9 +40,19 @@ class GraphNeo4jAutoConfigurationTest {
     fun `backend=neo4j 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues(*neo4jProperties)
             .run { ctx ->
-                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldBeInstanceOf<Neo4jGraphOperations>()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldBeInstanceOf<Neo4jGraphSuspendOperations>()
+                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldBeInstanceOf<VirtualThreadOperationsAdapter>()
+            }
+    }
+
+    @Test
+    fun `neo4j backend not selected — no GraphOperations bean registered`() {
+        runner
+            .withPropertyValues("bluetape4k.graph.backend=tinkergraph")
+            .run { ctx ->
+                assertThatThrownBy { ctx.getBean(GraphOperations::class.java) }
+                    .isInstanceOf(NoSuchBeanDefinitionException::class.java)
             }
     }
 

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphTinkerGraphAutoConfigurationTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/autoconfigure/GraphTinkerGraphAutoConfigurationTest.kt
@@ -3,9 +3,12 @@ package io.bluetape4k.graph.spring.boot3.autoconfigure
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.graph.vt.VirtualThreadOperationsAdapter
 import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldBeInstanceOf
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
@@ -28,16 +31,16 @@ class GraphTinkerGraphAutoConfigurationTest {
     fun `backend=tinkergraph 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues("bluetape4k.graph.backend=tinkergraph")
             .run { ctx ->
-                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
-                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldBeInstanceOf<TinkerGraphOperations>()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldBeInstanceOf<TinkerGraphSuspendOperations>()
+                ctx.getBean(GraphVirtualThreadOperations::class.java).shouldBeInstanceOf<VirtualThreadOperationsAdapter>()
             }
     }
 
     @Test
     fun `backend 미설정 시 tinkergraph matchIfMissing 으로 빈 등록`() {
         runner.run { ctx ->
-            ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
+            ctx.getBean(GraphOperations::class.java).shouldBeInstanceOf<TinkerGraphOperations>()
         }
     }
 

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/webflux/TinkerGraphWebFluxTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/webflux/TinkerGraphWebFluxTest.kt
@@ -19,6 +19,9 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+// NOTE: @WebFluxTest slice is not used here because the controller under test is defined as an inner
+// class of this test (TestApp.SuspendController). Extracting it to a standalone class would add
+// production scope just for testing; @SpringBootTest with RANDOM_PORT keeps the setup self-contained.
 @SpringBootTest(
     classes = [TinkerGraphWebFluxTest.TestApp::class],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -62,5 +65,21 @@ class TinkerGraphWebFluxTest {
                 val body = r.responseBody.shouldNotBeNull()
                 body.containsKey("id").shouldBeTrue()
             }
+    }
+
+    @Test
+    fun `존재하지 않는 경로 요청 시 404 반환`() = runBlocking<Unit> {
+        // Error path: POST to an unmapped path returns 404
+        webClient.post().uri("/test/suspend/nonexistent/path")
+            .exchange()
+            .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `GET 요청으로 POST 전용 엔드포인트 접근 시 405 반환`() = runBlocking<Unit> {
+        // Error path: wrong HTTP method on the suspend vertices endpoint returns 405
+        webClient.get().uri("/test/suspend/vertices/User")
+            .exchange()
+            .expectStatus().isEqualTo(405)
     }
 }

--- a/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/webmvc/TinkerGraphWebMvcTest.kt
+++ b/spring-boot3/graph-spring-boot3-starter/src/test/kotlin/io/bluetape4k/graph/spring/boot3/webmvc/TinkerGraphWebMvcTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
+import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringBootConfiguration
@@ -19,6 +20,9 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+// NOTE: @WebMvcTest slice is not used here because the controller under test is defined as an inner
+// class of this test (TestApp.GraphController). Extracting it to a standalone class would add
+// production scope just for testing; @SpringBootTest with RANDOM_PORT keeps the setup self-contained.
 @SpringBootTest(
     classes = [TinkerGraphWebMvcTest.TestApp::class],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -64,5 +68,23 @@ class TinkerGraphWebMvcTest {
         val body = (resp.body.shouldNotBeNull()) as Map<String, String>
         body["virtual"].shouldBeEqualTo("true")
         body["id"].shouldNotBeNull()
+    }
+
+    @Test
+    fun `존재하지 않는 경로 요청 시 404 반환`() {
+        // Error path: POST to an unmapped sub-path returns 404
+        val resp = restTemplate.postForEntity(
+            "/test/graph/nonexistent/path", null, String::class.java,
+        )
+        resp.statusCode.shouldBeEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `GET 요청으로 POST 전용 엔드포인트 접근 시 405 반환`() {
+        // Error path: wrong HTTP method on the vertices endpoint returns 405
+        val resp = restTemplate.getForEntity(
+            "/test/graph/vertices/Person", String::class.java,
+        )
+        resp.statusCode.shouldBeEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
     }
 }

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphAgeAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphAgeAutoConfiguration.kt
@@ -88,8 +88,14 @@ class GraphAgeAutoConfiguration {
     fun ageGraphInitializer(ops: AgeGraphOperations, props: AgeGraphProperties): InitializingBean =
         InitializingBean {
             runCatching { ops.createGraph(props.graphName) }
-                .onSuccess { log.info { "AGE graph '${props.graphName}' created / verified" } }
-                .onFailure { log.debug { "AGE graph '${props.graphName}' already exists: ${it.message}" } }
+                .onSuccess { log.info { "AGE graph '${props.graphName}' created" } }
+                .onFailure { ex ->
+                    if (ex.message?.contains("already exists", ignoreCase = true) == true) {
+                        log.debug { "AGE graph '${props.graphName}' already exists — skipping" }
+                    } else {
+                        throw ex
+                    }
+                }
         }
 
     /**
@@ -131,14 +137,23 @@ class GraphAgeAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
-        fun ageHealthIndicator(props: AgeGraphProperties): org.springframework.boot.health.contributor.HealthIndicator =
+        fun ageHealthIndicator(dataSource: DataSource): org.springframework.boot.health.contributor.HealthIndicator =
             org.springframework.boot.health.contributor.HealthIndicator {
-                org.springframework.boot.health.contributor.Health.up()
-                    .withDetail("backend", "age")
-                    .withDetail("graphName", props.graphName)
-                    .build()
+                try {
+                    dataSource.connection.use { conn ->
+                        conn.createStatement().execute("SELECT 1")
+                    }
+                    org.springframework.boot.health.contributor.Health.up()
+                        .withDetail("backend", "age")
+                        .build()
+                } catch (ex: Exception) {
+                    org.springframework.boot.health.contributor.Health.down(ex).build()
+                }
             }
     }
 }

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphAutoConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
         GraphNeo4jAutoConfiguration::class,
         GraphMemgraphAutoConfiguration::class,
         GraphAgeAutoConfiguration::class,
+        GraphFalkorDBAutoConfiguration::class,
     ],
 )
 @EnableConfigurationProperties(GraphProperties::class)

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -91,6 +91,9 @@ class GraphFalkorDBAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         /**
          * FalkorDB 연결 상태를 확인하는 HealthIndicator 빈.
          *

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.graph.vt.asVirtualThread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Config
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -19,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
 
 /**
  * Memgraph 백엔드 AutoConfiguration.
@@ -41,10 +43,15 @@ class GraphMemgraphAutoConfiguration {
     @Bean(name = ["memgraphDriver"], destroyMethod = "close")
     @ConditionalOnMissingBean(Driver::class)
     fun memgraphDriver(props: MemgraphGraphProperties): Driver {
-        val auth = if (props.password.isBlank()) AuthTokens.none()
+        val auth = if (props.username.isBlank() || props.password.isBlank()) AuthTokens.none()
                    else AuthTokens.basic(props.username, props.password)
-        log.info { "Creating Memgraph Driver: uri=${props.uri}" }
-        return GraphDatabase.driver(props.uri, auth)
+        val safeUri = props.uri.replace(Regex("//[^@]+@"), "//***@")
+        log.info { "Creating Memgraph Driver: uri=$safeUri" }
+        val config = Config.builder()
+            .withConnectionTimeout(props.connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+            .withMaxConnectionLifetime(props.maxConnectionLifetimeMillis, TimeUnit.MILLISECONDS)
+            .build()
+        return GraphDatabase.driver(props.uri, auth, config)
     }
 
     /**
@@ -90,6 +97,9 @@ class GraphMemgraphAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
         fun memgraphHealthIndicator(driver: Driver): org.springframework.boot.health.contributor.HealthIndicator =

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphNeo4jAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphNeo4jAutoConfiguration.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.graph.vt.asVirtualThread
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
 import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Config
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -19,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
 
 /**
  * Neo4j 백엔드 AutoConfiguration.
@@ -40,10 +42,15 @@ class GraphNeo4jAutoConfiguration {
     @Bean(name = ["neo4jDriver"], destroyMethod = "close")
     @ConditionalOnMissingBean(Driver::class)
     fun neo4jDriver(props: Neo4jGraphProperties): Driver {
-        val auth = if (props.password.isBlank()) AuthTokens.none()
+        val auth = if (props.username.isBlank() || props.password.isBlank()) AuthTokens.none()
                    else AuthTokens.basic(props.username, props.password)
-        log.info { "Creating Neo4j Driver: uri=${props.uri}, database=${props.database}" }
-        return GraphDatabase.driver(props.uri, auth)
+        val safeUri = props.uri.replace(Regex("//[^@]+@"), "//***@")
+        log.info { "Creating Neo4j Driver: uri=$safeUri, database=${props.database}" }
+        val config = Config.builder()
+            .withConnectionTimeout(props.connectionTimeoutMillis, TimeUnit.MILLISECONDS)
+            .withMaxConnectionLifetime(props.maxConnectionLifetimeMillis, TimeUnit.MILLISECONDS)
+            .build()
+        return GraphDatabase.driver(props.uri, auth, config)
     }
 
     /**
@@ -89,6 +96,9 @@ class GraphNeo4jAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
         fun neo4jHealthIndicator(driver: Driver): org.springframework.boot.health.contributor.HealthIndicator =

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -43,7 +43,7 @@ class GraphTinkerGraphAutoConfiguration {
      */
     @Bean(destroyMethod = "close")
     @ConditionalOnMissingBean(GraphOperations::class)
-    fun graphOperations(): GraphOperations {
+    fun graphOperations(): TinkerGraphOperations {
         log.info { "Registering TinkerGraphOperations (in-memory backend)" }
         return TinkerGraphOperations()
     }

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -59,12 +59,8 @@ class GraphTinkerGraphAutoConfiguration {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun graphSuspendOperations(ops: GraphOperations): GraphSuspendOperations {
-        val tinkerOps = checkNotNull(ops as? TinkerGraphOperations) {
-            "Expected TinkerGraphOperations but got ${ops::class.simpleName}"
-        }
-        return TinkerGraphSuspendOperations(tinkerOps)
-    }
+    fun graphSuspendOperations(ops: TinkerGraphOperations): GraphSuspendOperations =
+        TinkerGraphSuspendOperations(ops)
 
     /**
      * Virtual Thread 기반 `GraphVirtualThreadOperations` 빈.
@@ -87,6 +83,9 @@ class GraphTinkerGraphAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])
     class HealthConfig {
+
+        companion object : KLogging()
+
         @Bean
         @ConditionalOnMissingBean
         fun tinkerGraphHealthIndicator(): org.springframework.boot.health.contributor.HealthIndicator =

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/AgeGraphProperties.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/AgeGraphProperties.kt
@@ -7,8 +7,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.age")
 data class AgeGraphProperties(
-    var graphName: String = "bluetape4k_graph",
-    var autoCreateGraph: Boolean = true,
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val graphName: String = "bluetape4k_graph",
+    val autoCreateGraph: Boolean = true,
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
 )

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/FalkorDBGraphProperties.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/FalkorDBGraphProperties.kt
@@ -11,17 +11,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "bluetape4k.graph.falkordb")
 data class FalkorDBGraphProperties(
     /** FalkorDB 호스트 주소 */
-    var host: String = "localhost",
+    val host: String = "localhost",
     /** FalkorDB Redis 포트 번호 */
-    var port: Int = 6379,
+    val port: Int = 6379,
     /** 인증 사용자명 (비어있으면 인증 없음) */
-    var username: String = "",
+    val username: String = "",
     /** 인증 비밀번호 (비어있으면 인증 없음) */
-    var password: String = "",
+    val password: String = "",
     /** 대상 그래프 이름 */
-    var graphName: String = "bluetape4k",
+    val graphName: String = "bluetape4k",
     /** 코루틴 suspend 기반 [io.bluetape4k.graph.repository.GraphSuspendOperations] 빈 등록 여부 */
-    var registerSuspend: Boolean = true,
+    val registerSuspend: Boolean = true,
     /** Virtual Thread 기반 [io.bluetape4k.graph.repository.GraphVirtualThreadOperations] 빈 등록 여부 */
-    var registerVirtualThread: Boolean = true,
+    val registerVirtualThread: Boolean = true,
 )

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/GraphProperties.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/GraphProperties.kt
@@ -12,5 +12,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "bluetape4k.graph")
 data class GraphProperties(
     /** 활성 백엔드: `tinkergraph` | `neo4j` | `memgraph` | `age` */
-    var backend: String? = null,
+    val backend: String? = null,
 )

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/MemgraphGraphProperties.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/MemgraphGraphProperties.kt
@@ -7,10 +7,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.memgraph")
 data class MemgraphGraphProperties(
-    var uri: String = "bolt://localhost:7687",
-    var username: String = "",
-    var password: String = "",
-    var database: String = "memgraph",
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val uri: String = "bolt://localhost:7687",
+    val username: String = "",
+    val password: String = "",
+    val database: String = "memgraph",
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
+    val connectionTimeoutMillis: Long = 5000L,
+    val maxConnectionLifetimeMillis: Long = 3600000L,
 )

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/Neo4jGraphProperties.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/Neo4jGraphProperties.kt
@@ -7,10 +7,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.neo4j")
 data class Neo4jGraphProperties(
-    var uri: String = "bolt://localhost:7687",
-    var username: String = "neo4j",
-    var password: String = "",
-    var database: String = "neo4j",
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val uri: String = "bolt://localhost:7687",
+    val username: String = "neo4j",
+    val password: String = "",
+    val database: String = "neo4j",
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
+    val connectionTimeoutMillis: Long = 5000L,
+    val maxConnectionLifetimeMillis: Long = 3600000L,
 )

--- a/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/TinkerGraphGraphProperties.kt
+++ b/spring-boot4/graph-spring-boot4-starter/src/main/kotlin/io/bluetape4k/graph/spring/boot4/properties/TinkerGraphGraphProperties.kt
@@ -7,6 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.tinkergraph")
 data class TinkerGraphGraphProperties(
-    var registerSuspend: Boolean = true,
-    var registerVirtualThread: Boolean = true,
+    val registerSuspend: Boolean = true,
+    val registerVirtualThread: Boolean = true,
 )


### PR DESCRIPTION
## Summary

Code review findings fixed for spring-boot3/**, spring-boot4/**, and examples/**.

### CRITICAL
C1 — TinkerGraph graphOperations() return type: GraphOperations→TinkerGraphOperations
  → graphSuspendOperations(ops: TinkerGraphOperations) can now be injected

### HIGH
- H2: GraphFalkorDBAutoConfiguration added to @AutoConfiguration(before=[...])
- H3: GraphAgeAutoConfiguration real HealthIndicator + exception distinction
- H4: Neo4j/Memgraph URI masking, timeout config, auth fix
- H5/H8: CodeGraph/LinkedIn service requireNotBlank + lambda logging
- H9/H12: AutoConfig tests shouldBeInstanceOf, negative/conditional tests added

### MEDIUM
- M1: Properties var→val (immutable binding)
- M3: TinkerGraph unsafe cast removed (via C1)
- M4: Timeout fields in Neo4j/Memgraph properties
- M6: AbstractCodeGraphSuspendTest runBlocking→runTest
- M8: AgeCodeGraphTest dead database field removed
- M9/M14: FalkorDB tests dropGraph in @AfterAll

### Not included (deferred)
- M5: common module extraction
- H6: backend String?→enum
- H7: TinkerGraphGraphProperties rename

### Verification
- graph-spring-boot3-starter:test → 27 passing
- graph-spring-boot4-starter:test → 20 passing
