### PR TITLE
fix/test/docs: graph-core 모델 빌더 유틸 CRITICAL/HIGH 수정 및 테스트·KDoc 보강

### DIFF
--- a/graph/graph-core/README.ko.md
+++ b/graph/graph-core/README.ko.md
@@ -1274,6 +1274,32 @@ coroutineScope {
 }
 ```
 
+## 모델 빌더 유틸리티
+
+생성자를 직접 호출하지 않고 편리하게 모델 객체를 만들 수 있는 최상위 함수들.
+
+```kotlin
+// GraphElementId
+val id1 = graphElementIdOf("node-abc")          // String → GraphElementId
+val id2 = graphElementIdOf(42L)                  // Long → GraphElementId("42")
+val id3 = graphElementIdOf(existingId)           // GraphElementId 그대로 반환 (이중 변환 없음)
+
+// GraphVertex
+val v1 = graphVertexOf(GraphElementId.of("v1"), "Person", mapOf("name" to "Alice"))
+val v2 = graphVertexOf("v2", "Person")           // Any 타입 id 오버로드
+val v3 = graphVertexOf(42L, "Item", mapOf("weight" to 10.0))
+
+// GraphPath — vararg 오버로드
+val pathFromSteps    = graphPathOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1), PathStep.VertexStep(v2))
+val pathFromVertices = graphPathOf(v1, v2, v3)   // 정점만 있는 경로
+val pathFromEdges    = graphPathOf(e1, e2)        // 간선만 있는 경로
+val empty            = emptyGraphPath()           // GraphPath.EMPTY
+
+// GraphCycle
+val cycle = detectedPath.toCycle()               // GraphPath → GraphCycle
+println("cycle length = ${cycle.length}")
+```
+
 ## 의존성
 
 ```kotlin

--- a/graph/graph-core/README.md
+++ b/graph/graph-core/README.md
@@ -99,6 +99,32 @@ object KnowsLabel : EdgeLabel("KNOWS") {
 }
 ```
 
+## Model Builder Utilities
+
+Convenience top-level functions for constructing model objects without verbose constructors.
+
+```kotlin
+// GraphElementId
+val id1 = graphElementIdOf("node-abc")          // from String
+val id2 = graphElementIdOf(42L)                  // from Long → "42"
+val id3 = graphElementIdOf(existingId)           // GraphElementId pass-through (no double-wrap)
+
+// GraphVertex
+val v1 = graphVertexOf(GraphElementId.of("v1"), "Person", mapOf("name" to "Alice"))
+val v2 = graphVertexOf("v2", "Person")           // Any id overload
+val v3 = graphVertexOf(42L, "Item", mapOf("weight" to 10.0))
+
+// GraphPath — vararg overloads
+val pathFromSteps    = graphPathOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1), PathStep.VertexStep(v2))
+val pathFromVertices = graphPathOf(v1, v2, v3)   // vertex-only path
+val pathFromEdges    = graphPathOf(e1, e2)        // edge-only path
+val empty            = emptyGraphPath()           // GraphPath.EMPTY
+
+// GraphCycle
+val cycle = detectedPath.toCycle()               // GraphPath → GraphCycle
+println("cycle length = ${cycle.length}")
+```
+
 ## Usage Example
 
 ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
@@ -27,7 +27,7 @@ class AStarRunner(
     private val fetchVertex: (GraphElementId) -> GraphVertex?,
     private val heuristic: (GraphVertex) -> Double,
 ) {
-    companion object: KLogging()
+    companion object : KLogging()
 
     /**
      * A* 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphCycle.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphCycle.kt
@@ -27,4 +27,15 @@ data class GraphCycle(
     }
 }
 
+/**
+ * 이 경로를 [GraphCycle]로 변환한다.
+ *
+ * 경로의 첫 번째 정점과 마지막 정점이 동일한 순환 경로를 표현할 때 사용한다.
+ * 호출 전에 순환 여부를 직접 검증해야 한다 — 이 함수는 단순 래핑만 수행한다.
+ *
+ * ```kotlin
+ * val cycle = detectedPath.toCycle()
+ * println("cycle length = ${cycle.length}")
+ * ```
+ */
 fun GraphPath.toCycle() = GraphCycle(this)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphElementId.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphElementId.kt
@@ -57,4 +57,23 @@ value class GraphElementId(val value: String): Serializable {
     }
 }
 
-fun graphElementIdOf(value: Any): GraphElementId = GraphElementId.of(value.toString())
+/**
+ * 임의 타입의 값을 [GraphElementId]로 변환한다.
+ *
+ * - [GraphElementId]를 그대로 전달하면 새 인스턴스를 만들지 않고 반환한다.
+ * - [Long]은 [GraphElementId.of] Long 오버로드로 위임한다.
+ * - 그 외 타입은 `toString()` 결과를 ID 값으로 사용한다.
+ *
+ * ```kotlin
+ * graphElementIdOf("node-1")           // GraphElementId("node-1")
+ * graphElementIdOf(42L)                // GraphElementId("42")
+ * graphElementIdOf(GraphElementId("x")) // GraphElementId("x") — 이중 변환 없음
+ * ```
+ *
+ * @param value ID로 변환할 값. `Any` 타입이지만 `toString()` 결과가 비어있어선 안 된다.
+ */
+fun graphElementIdOf(value: Any): GraphElementId = when (value) {
+    is GraphElementId -> value
+    is Long -> GraphElementId.of(value)
+    else -> GraphElementId.of(value.toString())
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphPath.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphPath.kt
@@ -106,29 +106,74 @@ data class GraphPath(
     }
 }
 
+/**
+ * [PathStep] 목록으로 경로를 생성한다.
+ *
+ * ```kotlin
+ * val path = graphPathOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1), PathStep.VertexStep(v2))
+ * ```
+ */
 @JvmName("graphPathOfPathSteps")
 fun graphPathOf(vararg steps: PathStep): GraphPath = GraphPath(steps.toList())
 
+/**
+ * [PathStep] 리스트로 경로를 생성한다.
+ *
+ * ```kotlin
+ * val path = graphPathOf(listOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1)))
+ * ```
+ */
 @JvmName("graphPathOfPathStepsList")
 fun graphPathOf(steps: List<PathStep>): GraphPath = GraphPath(steps)
 
+/**
+ * 정점 목록으로 정점만 있는 경로를 생성한다 (간선 없음).
+ *
+ * ```kotlin
+ * val path = graphPathOf(v1, v2, v3)
+ * println(path.length) // 0 (간선 없음)
+ * ```
+ */
 @JvmName("graphPathOfGraphVertices")
 fun graphPathOf(vararg vertices: GraphVertex): GraphPath = GraphPath(vertices.map { PathStep.VertexStep(it) })
 
+/**
+ * 정점 리스트로 정점만 있는 경로를 생성한다 (간선 없음).
+ *
+ * ```kotlin
+ * val path = graphPathOf(listOf(v1, v2, v3))
+ * ```
+ */
 @JvmName("graphPathOfGraphVertexList")
 fun graphPathOf(vertices: List<GraphVertex>): GraphPath = GraphPath(vertices.map { PathStep.VertexStep(it) })
 
+/**
+ * 간선 목록으로 간선만 있는 경로를 생성한다 (정점 없음).
+ *
+ * ```kotlin
+ * val path = graphPathOf(e1, e2)
+ * println(path.length) // 2
+ * ```
+ */
 @JvmName("graphPathOfGraphEdges")
 fun graphPathOf(vararg edges: GraphEdge): GraphPath = GraphPath(edges.map { PathStep.EdgeStep(it) })
 
+/**
+ * 간선 리스트로 간선만 있는 경로를 생성한다 (정점 없음).
+ *
+ * ```kotlin
+ * val path = graphPathOf(listOf(e1, e2))
+ * ```
+ */
 @JvmName("graphPathOfGraphEdgeList")
 fun graphPathOf(edges: List<GraphEdge>): GraphPath = GraphPath(edges.map { PathStep.EdgeStep(it) })
 
-@JvmName("graphPathOfGraphVertex")
-fun graphPathOf(vertex: GraphVertex): GraphPath = GraphPath(listOf(PathStep.VertexStep(vertex)))
-
-@JvmName("graphPathOfGraphEdge")
-fun graphPathOf(edge: GraphEdge): GraphPath = GraphPath(listOf(PathStep.EdgeStep(edge)))
-
-@JvmName("emptyGraphPathOf")
-fun emptyGraphPathOf(): GraphPath = GraphPath.EMPTY
+/**
+ * 빈 경로 ([GraphPath.EMPTY])를 반환한다.
+ *
+ * ```kotlin
+ * val path = emptyGraphPath()
+ * path.isEmpty // true
+ * ```
+ */
+fun emptyGraphPath(): GraphPath = GraphPath.EMPTY

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphVertex.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphVertex.kt
@@ -32,8 +32,33 @@ data class GraphVertex(
     }
 }
 
+/**
+ * [GraphElementId]와 레이블로 정점을 생성한다.
+ *
+ * ```kotlin
+ * val v = graphVertexOf(GraphElementId.of("v-1"), "Person", mapOf("name" to "Alice"))
+ * ```
+ *
+ * @param id 정점 ID.
+ * @param label 정점 레이블.
+ * @param properties 정점 속성 맵. 기본값은 빈 맵.
+ */
 fun graphVertexOf(id: GraphElementId, label: String, properties: Map<String, Any?> = emptyMap()) =
     GraphVertex(id, label, properties)
 
-fun graphVertexOf(id: Any, label: String): GraphVertex =
-    graphVertexOf(graphElementIdOf(id.toString()), label)
+/**
+ * 임의 타입의 ID 값으로 정점을 생성한다.
+ *
+ * ID 변환에 [graphElementIdOf]를 사용하므로 [GraphElementId]를 그대로 전달해도 이중 변환이 발생하지 않는다.
+ *
+ * ```kotlin
+ * val v = graphVertexOf("v-1", "Person")
+ * val v2 = graphVertexOf(42L, "Item", mapOf("name" to "Foo"))
+ * ```
+ *
+ * @param id 정점 ID. [GraphElementId], [Long], 또는 `toString()` 결과를 사용하는 임의 타입.
+ * @param label 정점 레이블.
+ * @param properties 정점 속성 맵. 기본값은 빈 맵.
+ */
+fun graphVertexOf(id: Any, label: String, properties: Map<String, Any?> = emptyMap()): GraphVertex =
+    graphVertexOf(graphElementIdOf(id), label, properties)

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphCycleTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphCycleTest.kt
@@ -1,0 +1,103 @@
+package io.bluetape4k.graph.model
+
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class GraphCycleTest {
+
+    private fun vertex(id: String, label: String = "Person") =
+        GraphVertex(GraphElementId(id), label)
+
+    private fun edge(id: String, start: String, end: String, label: String = "KNOWS") =
+        GraphEdge(
+            GraphElementId(id),
+            label,
+            GraphElementId(start),
+            GraphElementId(end)
+        )
+
+    @Test
+    fun `GraphCycle은 경로를 래핑한다`() {
+        val v1 = vertex("1")
+        val v2 = vertex("2")
+        val e1 = edge("e1", "1", "2")
+        val e2 = edge("e2", "2", "1")
+        val path = GraphPath(
+            listOf(
+                PathStep.VertexStep(v1),
+                PathStep.EdgeStep(e1),
+                PathStep.VertexStep(v2),
+                PathStep.EdgeStep(e2),
+                PathStep.VertexStep(v1),
+            )
+        )
+
+        val cycle = GraphCycle(path)
+        cycle.path shouldBe path
+        cycle.length shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `length는 경로의 간선 수다`() {
+        val v1 = vertex("1")
+        val e1 = edge("e1", "1", "1")
+        val path = GraphPath(listOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1), PathStep.VertexStep(v1)))
+
+        val cycle = GraphCycle(path)
+        cycle.length shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `빈 경로로 만든 GraphCycle의 length는 0이다`() {
+        val cycle = GraphCycle(GraphPath.EMPTY)
+        cycle.length shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `GraphPath toCycle 확장 함수가 GraphCycle을 반환한다`() {
+        val v1 = vertex("a")
+        val v2 = vertex("b")
+        val e1 = edge("e1", "a", "b")
+        val e2 = edge("e2", "b", "a")
+        val path = GraphPath(
+            listOf(
+                PathStep.VertexStep(v1),
+                PathStep.EdgeStep(e1),
+                PathStep.VertexStep(v2),
+                PathStep.EdgeStep(e2),
+                PathStep.VertexStep(v1),
+            )
+        )
+
+        val cycle = path.toCycle()
+
+        cycle shouldBeInstanceOf GraphCycle::class
+        cycle.path shouldBe path
+        cycle.length shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `GraphPath EMPTY에서 toCycle을 호출하면 length 0인 순환을 반환한다`() {
+        val cycle = GraphPath.EMPTY.toCycle()
+        cycle.length shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `단일 간선 경로에서 toCycle이 동작한다`() {
+        val e = edge("e1", "1", "2")
+        val path = GraphPath(listOf(PathStep.EdgeStep(e)))
+        val cycle = path.toCycle()
+        cycle.length shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `GraphCycle은 data class이므로 동등 비교가 가능하다`() {
+        val v1 = vertex("1")
+        val path = GraphPath.of(v1)
+        val c1 = GraphCycle(path)
+        val c2 = GraphCycle(path)
+        c1 shouldBeEqualTo c2
+    }
+}

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphElementIdTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphElementIdTest.kt
@@ -69,4 +69,34 @@ class GraphElementIdTest {
         val id = GraphElementId("test-123")
         id.toString() shouldBeEqualTo "GraphElementId(value=test-123)"
     }
+
+    // --- graphElementIdOf 유틸 함수 테스트 ---
+
+    @Test
+    fun `graphElementIdOf - String을 GraphElementId로 변환한다`() {
+        val id = graphElementIdOf("node-1")
+        id.value shouldBeEqualTo "node-1"
+        id shouldBeEqualTo GraphElementId("node-1")
+    }
+
+    @Test
+    fun `graphElementIdOf - Long을 GraphElementId로 변환한다`() {
+        val id = graphElementIdOf(42L)
+        id.value shouldBeEqualTo "42"
+    }
+
+    @Test
+    fun `graphElementIdOf - GraphElementId를 전달하면 이중 변환 없이 반환한다`() {
+        val original = GraphElementId("v-1")
+        val result = graphElementIdOf(original)
+        result shouldBeEqualTo original
+        // toString()이 "GraphElementId(value=v-1)"이므로 이중 변환 시 값이 오염된다
+        result.value shouldBeEqualTo "v-1"
+    }
+
+    @Test
+    fun `graphElementIdOf - 정수 타입을 String으로 변환한다`() {
+        val id = graphElementIdOf(100)
+        id.value shouldBeEqualTo "100"
+    }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphPathTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphPathTest.kt
@@ -133,4 +133,85 @@ class GraphPathTest {
         modified.isEmpty.shouldBeTrue()
         original.isEmpty.shouldBeFalse()
     }
+
+    // --- graphPathOf 유틸 함수 테스트 ---
+
+    @Test
+    fun `graphPathOf PathStep vararg로 혼합 경로를 만든다`() {
+        val v1 = vertex("1")
+        val v2 = vertex("2")
+        val e1 = edge("e1", "1", "2")
+        val path = graphPathOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1), PathStep.VertexStep(v2))
+        path.vertices shouldHaveSize 2
+        path.edges shouldHaveSize 1
+        path.length shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `graphPathOf PathStep List로 경로를 만든다`() {
+        val v1 = vertex("1")
+        val steps = listOf(PathStep.VertexStep(v1))
+        val path = graphPathOf(steps)
+        path.vertices shouldHaveSize 1
+        path.isEmpty.shouldBeFalse()
+    }
+
+    @Test
+    fun `graphPathOf GraphVertex vararg로 정점만 있는 경로를 만든다`() {
+        val v1 = vertex("1")
+        val v2 = vertex("2")
+        val path = graphPathOf(v1, v2)
+        path.vertices shouldContainSame listOf(v1, v2)
+        path.edges.shouldBeEmpty()
+        path.length shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `graphPathOf GraphVertex List로 경로를 만든다`() {
+        val vertices = listOf(vertex("1"), vertex("2"))
+        val path = graphPathOf(vertices)
+        path.vertices shouldContainSame vertices
+        path.edges.shouldBeEmpty()
+    }
+
+    @Test
+    fun `graphPathOf GraphEdge vararg로 간선만 있는 경로를 만든다`() {
+        val e1 = edge("e1", "1", "2")
+        val e2 = edge("e2", "2", "3")
+        val path = graphPathOf(e1, e2)
+        path.edges shouldContainSame listOf(e1, e2)
+        path.vertices.shouldBeEmpty()
+        path.length shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `graphPathOf GraphEdge List로 경로를 만든다`() {
+        val edges = listOf(edge("e1", "1", "2"))
+        val path = graphPathOf(edges)
+        path.edges shouldContainSame edges
+        path.vertices.shouldBeEmpty()
+    }
+
+    @Test
+    fun `emptyGraphPath는 GraphPath EMPTY와 동일하다`() {
+        val path = emptyGraphPath()
+        path.isEmpty.shouldBeTrue()
+        path shouldBeEqualTo GraphPath.EMPTY
+    }
+
+    @Test
+    fun `graphPathOf vararg 단일 정점으로 경로를 만든다`() {
+        val v = vertex("1")
+        val path = graphPathOf(v)
+        path.vertices shouldHaveSize 1
+        path.edges.shouldBeEmpty()
+    }
+
+    @Test
+    fun `graphPathOf vararg 단일 간선으로 경로를 만든다`() {
+        val e = edge("e1", "1", "2")
+        val path = graphPathOf(e)
+        path.edges shouldHaveSize 1
+        path.vertices.shouldBeEmpty()
+    }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphVertexTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphVertexTest.kt
@@ -90,4 +90,51 @@ class GraphVertexTest {
         val v2 = GraphVertex(id, "Company")
         v1 shouldNotBeEqualTo v2
     }
+
+    // --- graphVertexOf 유틸 함수 테스트 ---
+
+    @Test
+    fun `graphVertexOf - GraphElementId로 정점을 생성한다`() {
+        val v = graphVertexOf(id, "Person", mapOf("name" to "Alice"))
+        v.id shouldBeEqualTo id
+        v.label shouldBeEqualTo "Person"
+        v.properties["name"] shouldBeEqualTo "Alice"
+    }
+
+    @Test
+    fun `graphVertexOf - GraphElementId + label만으로 빈 properties 정점을 생성한다`() {
+        val v = graphVertexOf(id, "Person")
+        v.id shouldBeEqualTo id
+        v.label shouldBeEqualTo "Person"
+        v.properties.shouldBeEmpty()
+    }
+
+    @Test
+    fun `graphVertexOf - Any id String으로 정점을 생성한다`() {
+        val v = graphVertexOf("v-2", "Company")
+        v.id shouldBeEqualTo GraphElementId("v-2")
+        v.label shouldBeEqualTo "Company"
+    }
+
+    @Test
+    fun `graphVertexOf - Any id Long으로 정점을 생성한다`() {
+        val v = graphVertexOf(42L, "Item")
+        v.id.value shouldBeEqualTo "42"
+        v.label shouldBeEqualTo "Item"
+    }
+
+    @Test
+    fun `graphVertexOf - Any id GraphElementId 전달 시 이중 변환 없다`() {
+        val existing = GraphElementId("original")
+        val v = graphVertexOf(existing, "Node")
+        // 이중 toString 변환 시 "GraphElementId(value=original)" 이 됨을 방지
+        v.id.value shouldBeEqualTo "original"
+    }
+
+    @Test
+    fun `graphVertexOf - Any id에 properties도 전달할 수 있다`() {
+        val v = graphVertexOf("v-3", "Person", mapOf("age" to 30))
+        v.id.value shouldBeEqualTo "v-3"
+        v.properties["age"] shouldBeEqualTo 30
+    }
 }


### PR DESCRIPTION
## 작업 배경

지난 24시간 내에 추가된 그래프 모델 빌더 유틸 함수들 (`graphElementIdOf`, `graphVertexOf`, `graphPathOf`, `toCycle`)에 대해 자동 코드 리뷰를 수행하고 발견된 CRITICAL/HIGH 이슈를 수정한 PR.

## 작업 내용

### CRITICAL 수정
- **`graphElementIdOf(Any)` 이중 toString 버그 수정**: `GraphElementId`를 인자로 전달하면 `.toString()`이 `"GraphElementId(value=x)"`를 반환하여 ID 값이 오염되는 문제. `when` 분기로 `GraphElementId`, `Long`, 기타 타입을 각각 처리.

### HIGH 수정
- **`graphVertexOf(Any, label)` `properties` 파라미터 추가**: 기존 `GraphElementId` 오버로드는 properties를 지원하지만 Any 오버로드는 누락. 추가하고 내부에서 `graphElementIdOf`를 활용해 이중 변환도 제거.
- **`graphPathOf` 오버로드 정리**: 단일-arg 중복 오버로드(`graphPathOf(vertex: GraphVertex)`, `graphPathOf(edge: GraphEdge)`) 제거 (vararg 오버로드로 통합).
- **`emptyGraphPathOf()` → `emptyGraphPath()` 이름 변경**: Kotlin 표준 라이브러리 관례 (`emptyList()`, `emptyMap()`) 준수.
- **모든 신규 public API에 KDoc + 코드 예제 추가** (12개 함수).

### MEDIUM 수정
- **`AStarRunner companion object` 콜론 앞 공백 추가**: ktlint 스타일 준수.

## 테스트 결과

| 모듈 | 통과 | 실패 | 시간 |
|------|------|------|------|
| `graph-core` | **224** | 0 | 2.5s |

### 신규 테스트
- **`GraphCycleTest`** (신규 생성): `toCycle()`, `length`, 동등 비교 등 7개 케이스
- **`GraphElementIdTest`**: `graphElementIdOf` 4개 케이스 추가 (GraphElementId 이중변환 회귀 테스트 포함)
- **`GraphVertexTest`**: `graphVertexOf` 6개 케이스 추가 (Any id 이중변환 포함)
- **`GraphPathTest`**: `graphPathOf` 8개 케이스 + `emptyGraphPath` 추가

## 코드 리뷰 결과

| 검토 항목 | 발견 | 처리 |
|----------|------|------|
| CRITICAL: graphElementIdOf 이중 변환 버그 | 1건 | ✅ 수정 |
| HIGH: graphVertexOf properties 누락 | 1건 | ✅ 수정 |
| HIGH: KDoc 누락 (12개 함수) | 1건 | ✅ 추가 |
| HIGH: 누락 테스트 | 1건 | ✅ 추가 |
| MEDIUM: companion object 스타일 | 1건 | ✅ 수정 |
| **최종: CRITICAL 0, HIGH 0** | | **✅** |

## 커밋 목록

```
321d7e7 fix/test/docs: graph-core 모델 빌더 유틸 CRITICAL/HIGH 수정 및 테스트·KDoc 보강
```

## README 업데이트

`README.md`, `README.ko.md` 양쪽에 **모델 빌더 유틸리티** 섹션 추가.
