### PR TITLE
ci: publish-snapshot을 Nightly 성공 시에만 실행

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,8 +1,10 @@
 name: Publish Snapshot
 
 on:
-  schedule:
-    - cron: '0 18 * * *'  # 매일 03:00 KST (18:00 UTC)
+  workflow_run:
+    workflows: ["Nightly"]
+    types: [completed]
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:
@@ -15,53 +17,25 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  # ── 최근 24시간 내 커밋 여부 확인 ────────────────────────────────────────
-  check-activity:
-    name: Check Recent Commits
-    runs-on: ubuntu-latest
-    outputs:
-      has_commits: ${{ steps.check.outputs.has_commits }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: develop
-
-      - name: Check commits in last 24 hours
-        id: check
-        run: |
-          COUNT=$(git log --oneline --since="24 hours ago" origin/develop | wc -l)
-          echo "Recent commit count: $COUNT"
-          if [ "$COUNT" -gt 0 ]; then
-            echo "has_commits=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_commits=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  # ── SNAPSHOT 배포 ─────────────────────────────────────────────────────────
   publish:
     name: Publish SNAPSHOT to Maven Central
     runs-on: ubuntu-latest
-    needs: check-activity
+    # workflow_run: Nightly 성공 시에만 실행. 수동 dispatch는 항상 실행.
     if: |
-      needs.check-activity.outputs.has_commits == 'true' ||
-      github.event_name == 'workflow_dispatch'
-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
         with:
           ref: develop
-
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
           cache-read-only: true
-
       - name: Publish SNAPSHOT
         run: |
           ./gradlew publishAggregationToCentralSnapshots \


### PR DESCRIPTION
Nightly 워크플로 성공 시에만 SNAPSHOT 배포 실행. 수동 dispatch 유지. check-activity 잡 제거.