### PR TITLE
fix/test/docs: graph-io-okio 스케줄 코드 리뷰 — CRITICAL/HIGH 수정 및 테스트·KDoc 보강

### DIFF
--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
@@ -170,6 +170,7 @@ internal class StaxGraphMlReader {
             setProperty(XMLInputFactory.IS_COALESCING, true)
             setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false)
             setProperty(XMLInputFactory.SUPPORT_DTD, false)
+            setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
         }
     }
 }

--- a/graph-io/okio/README.ko.md
+++ b/graph-io/okio/README.ko.md
@@ -273,10 +273,11 @@ class MyGraphIoTest {
 
 ## 보안
 
-- **XXE 방지**: GraphML StAX 파서에 `IS_SUPPORTING_EXTERNAL_ENTITIES=false`, `SUPPORT_DTD=false` 적용 (기존 구현 위임)
+- **XXE 방지**: GraphML StAX 파서에 `SUPPORT_DTD=false`, `IS_SUPPORTING_EXTERNAL_ENTITIES=false` 적용 (기존 구현 위임)
 - **Decompression bomb 방지**: `BombGuardSource`가 해제 바이트를 추적하여 `maxDecompressedBytes` 초과 시 `IOException` 발생
   - 기본 한계: 512 MiB (`DEFAULT_MAX_DECOMPRESSED_BYTES`)
   - 커스텀 한계: `openDecompressedSource(source, compressor, maxDecompressedBytes = 1L * 1024 * 1024 * 1024)` (1 GiB)
+- **CSV Gzip 스트리밍**: `importGraphGzip` / `exportGraphGzip` 모두 단일 패스 스트리밍 — 중간 버퍼링 없음
 
 ## Gradle 의존성
 

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/Compressor.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/Compressor.kt
@@ -15,17 +15,28 @@ import io.bluetape4k.io.compressor.StreamingCompressor
  * - 암호화: bluetape4k-projects #240 완료 후 v2에서 추가 예정
  */
 enum class Compressor(
+    /** 클래스패스 가드용 클래스 이름. JDK 내장 압축기는 null. */
     val requiredClassName: String?,
+    /** 해당 의존성 추가 방법 안내. 항상 사용 가능한 압축기는 빈 문자열. */
     val installHint: String,
 ) {
+    /** JDK 내장 GZip 압축. 항상 사용 가능. */
     GZIP(
         requiredClassName = null,
         installHint = "",
     ),
+    /** JDK 내장 Deflate 압축. 항상 사용 가능. */
     DEFLATE(
         requiredClassName = null,
         installHint = "",
     ),
+    /**
+     * LZ4 고속 압축. `lz4-java` 의존성 필요.
+     *
+     * ```kotlin
+     * implementation("org.lz4:lz4-java:<version>")
+     * ```
+     */
     LZ4(
         requiredClassName = "net.jpountz.lz4.LZ4Factory",
         installHint = """
@@ -34,6 +45,13 @@ enum class Compressor(
               implementation("org.lz4:lz4-java:<version>")
         """.trimIndent(),
     ),
+    /**
+     * Snappy 고속 압축. `snappy-java` 의존성 필요.
+     *
+     * ```kotlin
+     * implementation("org.xerial.snappy:snappy-java:<version>")
+     * ```
+     */
     SNAPPY(
         requiredClassName = "org.xerial.snappy.Snappy",
         installHint = """
@@ -42,6 +60,13 @@ enum class Compressor(
               implementation("org.xerial.snappy:snappy-java:<version>")
         """.trimIndent(),
     ),
+    /**
+     * Zstd 고압축률 압축. `zstd-jni` 의존성 필요.
+     *
+     * ```kotlin
+     * implementation("com.github.luben:zstd-jni:<version>")
+     * ```
+     */
     ZSTD(
         requiredClassName = "com.github.luben.zstd.ZstdInputStream",
         installHint = """
@@ -50,6 +75,13 @@ enum class Compressor(
               implementation("com.github.luben:zstd-jni:<version>")
         """.trimIndent(),
     ),
+    /**
+     * BZip2 압축. `commons-compress` 의존성 필요.
+     *
+     * ```kotlin
+     * implementation("org.apache.commons:commons-compress:<version>")
+     * ```
+     */
     BZIP2(
         requiredClassName = "org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream",
         installHint = """

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.graph.io.okio
 
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.okio.compress.Compressable
 import okio.Buffer
 import okio.BufferedSink
@@ -39,7 +41,7 @@ import java.util.UUID
  * ### v2 예정
  * 암호화 지원 (bluetape4k-projects #240 완료 후) — `TinkEncryptSink` / `TinkDecryptSource` 체이닝 추가 예정.
  */
-object GraphIoOkioPaths {
+object GraphIoOkioPaths : KLogging() {
 
     /** 압축 해제 기본 최대 크기 (512 MiB). decompression bomb 방지. */
     const val DEFAULT_MAX_DECOMPRESSED_BYTES: Long = 512L * 1024 * 1024
@@ -142,7 +144,7 @@ object GraphIoOkioPaths {
         return try {
             openCompressedSink(bs, Compressor.GZIP)
         } catch (e: Throwable) {
-            try { bs.close() } catch (_: Throwable) {}
+            try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip init failure" } }
             throw e
         }
     }
@@ -163,7 +165,7 @@ object GraphIoOkioPaths {
         return try {
             openDecompressedSource(bs, Compressor.GZIP, maxDecompressedBytes)
         } catch (e: Throwable) {
-            try { bs.close() } catch (_: Throwable) {}
+            try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close source after gzip init failure" } }
             throw e
         }
     }
@@ -212,12 +214,13 @@ object GraphIoOkioPaths {
     /**
      * decompression bomb 방지용 Source 래퍼.
      *
-     * [maxBytes]를 초과하면 [IOException]을 던진다.
+     * [maxBytes]를 초과하면 [IOException]을 던진다. 단일 스레드 전용.
      */
     private class BombGuardSource(
         delegate: Source,
         private val maxBytes: Long,
     ) : ForwardingSource(delegate) {
+        @Volatile
         private var totalRead: Long = 0L
 
         override fun read(sink: Buffer, byteCount: Long): Long {
@@ -243,6 +246,7 @@ object GraphIoOkioPaths {
         private val targetPath: Path,
         private val fs: FileSystem,
     ) : ForwardingSink(delegate) {
+        @Volatile
         private var failed = false
 
         override fun write(source: Buffer, byteCount: Long) {
@@ -258,13 +262,17 @@ object GraphIoOkioPaths {
             try {
                 super.close()
                 if (failed) {
-                    try { fs.delete(tmpPath) } catch (_: IOException) {}
+                    try { fs.delete(tmpPath) } catch (e: IOException) {
+                        GraphIoOkioPaths.log.warn(e) { "Failed to delete temp file after write failure: $tmpPath" }
+                    }
                 } else {
                     fs.atomicMove(tmpPath, targetPath)
                 }
             } catch (e: Exception) {
                 failed = true
-                try { fs.delete(tmpPath) } catch (_: IOException) {}
+                try { fs.delete(tmpPath) } catch (de: IOException) {
+                    GraphIoOkioPaths.log.warn(de) { "Failed to delete temp file after close failure: $tmpPath" }
+                }
                 throw e
             }
         }

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/OkioGraphExportSink.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/OkioGraphExportSink.kt
@@ -40,6 +40,17 @@ sealed interface OkioGraphExportSink {
         val atomicWrite: Boolean = true,
     ) : OkioGraphExportSink {
         companion object {
+            /**
+             * [PathSink]를 생성하는 팩토리 함수.
+             *
+             * @param path 쓰기 대상 OkIO [Path]
+             * @param fileSystem 파일 시스템 (기본값: [FileSystem.SYSTEM])
+             * @param mustCreate `true`이면 파일 이미 존재 시 예외
+             * @param mustExist `true`이면 파일 없을 시 예외
+             * @param createParentDirectories `true`(기본)이면 부모 디렉토리 자동 생성
+             * @param atomicWrite `true`(기본)이면 임시 파일에 쓰고 성공 시 atomic move
+             * @return 설정된 [PathSink] 인스턴스
+             */
             fun from(
                 path: Path,
                 fileSystem: FileSystem = FileSystem.SYSTEM,
@@ -62,6 +73,13 @@ sealed interface OkioGraphExportSink {
         val ownsSink: Boolean = false,
     ) : OkioGraphExportSink {
         companion object {
+            /**
+             * [SinkBased]를 생성하는 팩토리 함수.
+             *
+             * @param sink OkIO [Sink]
+             * @param ownsSink `true`이면 완료 후 [sink] 닫음 (기본: `false`)
+             * @return 설정된 [SinkBased] 인스턴스
+             */
             fun from(sink: Sink, ownsSink: Boolean = false): SinkBased =
                 SinkBased(sink, ownsSink)
         }
@@ -78,6 +96,13 @@ sealed interface OkioGraphExportSink {
         val ownsStream: Boolean = false,
     ) : OkioGraphExportSink {
         companion object {
+            /**
+             * [OutputStreamBased]를 생성하는 팩토리 함수.
+             *
+             * @param outputStream 대상 [OutputStream]
+             * @param ownsStream `true`이면 완료 후 [outputStream] 닫음 (기본: `false`)
+             * @return 설정된 [OutputStreamBased] 인스턴스
+             */
             fun from(outputStream: OutputStream, ownsStream: Boolean = false): OutputStreamBased =
                 OutputStreamBased(outputStream, ownsStream)
         }

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendGraphIoOkioBulkAdapter.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendGraphIoOkioBulkAdapter.kt
@@ -12,14 +12,12 @@ import io.bluetape4k.graph.io.report.GraphImportProgress
 import io.bluetape4k.graph.io.report.GraphImportReport
 import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.repository.GraphOperations
-import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runInterruptible
-import kotlinx.coroutines.withContext
 import java.io.IOException
 
 /**
@@ -33,8 +31,9 @@ import java.io.IOException
  * [importGraphAwait] / [exportGraphAwait]: 완료 보고서를 직접 반환한다.
  *
  * ### 취소 안전성
- * - 모든 blocking I/O는 [runInterruptible] 로 래핑하여 코루틴 취소 시 `Thread.interrupt()` 가 전달된다.
- * - finally 블록의 `flush()` / `close()` 는 [NonCancellable] 로 보호하여 취소 도중에도 반드시 실행된다.
+ * 모든 blocking I/O는 [runInterruptible] 로 래핑하여 코루틴 취소 시 `Thread.interrupt()` 가 전달된다.
+ * 리소스 정리(close)는 [OkioGraphBulkImporter] / [OkioGraphBulkExporter] 내부에서 처리하며,
+ * 각 호출이 독립적으로 소스/싱크를 열고 닫으므로 어댑터 레벨 cleanup 은 불필요하다.
  *
  * ### close 책임
  * 이 어댑터 자체는 [AutoCloseable]이 아니다. 내부 [OkioGraphBulkImporter] / [OkioGraphBulkExporter]가
@@ -45,7 +44,7 @@ class SuspendGraphIoOkioBulkAdapter(
     private val exporter: OkioGraphBulkExporter = OkioGraphBulkExporter(),
 ) {
 
-    companion object : KLoggingChannel()
+    companion object : KLogging()
 
     // ─── Flow (진행 상태 스트림) ────────────────────────────────────────────────
 
@@ -141,15 +140,8 @@ class SuspendGraphIoOkioBulkAdapter(
         options: GraphImportOptions,
     ): GraphImportReport {
         log.debug { "Starting OkIO import (suspend): format=$format" }
-        return try {
-            runInterruptible(Dispatchers.IO) {
-                importer.importGraph(source, format, operations, options)
-            }
-        } finally {
-            withContext(NonCancellable) {
-                // OkioGraphBulkImporter 는 자체적으로 openSource/openSink 내에서 close를 처리한다.
-                // source 객체 자체를 닫지 않는다 (ownsSource=false 기본).
-            }
+        return runInterruptible(Dispatchers.IO) {
+            importer.importGraph(source, format, operations, options)
         }
     }
 
@@ -161,14 +153,8 @@ class SuspendGraphIoOkioBulkAdapter(
         options: GraphExportOptions,
     ): GraphExportReport {
         log.debug { "Starting OkIO export (suspend): format=$format" }
-        return try {
-            runInterruptible(Dispatchers.IO) {
-                exporter.exportGraph(sink, format, operations, options)
-            }
-        } finally {
-            withContext(NonCancellable) {
-                // exporter 내부에서 sink close 처리. 별도 자원 없음.
-            }
+        return runInterruptible(Dispatchers.IO) {
+            exporter.exportGraph(sink, format, operations, options)
         }
     }
 }

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/CsvOkioExtensions.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/CsvOkioExtensions.kt
@@ -49,8 +49,13 @@ fun CsvGraphBulkImporter.importGraph(
 /**
  * CSV 포맷으로 그래프를 OkIO 소스(Gzip 압축)에서 임포트한다.
  *
- * `{stem}_vertices.csv.gz` + `{stem}_edges.csv.gz` 파일 쌍에서 읽는다.
+ * `{stem}_vertices.csv.gz` + `{stem}_edges.csv.gz` 파일 쌍에서 스트리밍으로 읽는다.
  * [OkioGraphImportSource.PathSource] 만 지원한다.
+ *
+ * @param source Gzip 압축 CSV 파일 경로 기반 OkIO 임포트 소스
+ * @param operations 임포트 대상 그래프 API
+ * @param options 임포트 옵션
+ * @return 임포트 결과 보고서
  */
 fun CsvGraphBulkImporter.importGraphGzip(
     source: OkioGraphImportSource,
@@ -63,17 +68,15 @@ fun CsvGraphBulkImporter.importGraphGzip(
     val stem = source.path.toString().removeSuffix(".csv.gz").removeSuffix(".csv")
     val verticesSource = OkioGraphImportSource.PathSource("${stem}_vertices.csv.gz".toPath(), source.fileSystem)
     val edgesSource = OkioGraphImportSource.PathSource("${stem}_edges.csv.gz".toPath(), source.fileSystem)
-    val csvSource = CsvGraphImportSource(
-        vertices = GraphIoOkioPaths.openGzipSource(verticesSource).use { bs ->
-            val bytes = bs.readByteArray()
-            GraphImportSource.InputStreamSource(bytes.inputStream(), closeInput = true)
-        },
-        edges = GraphIoOkioPaths.openGzipSource(edgesSource).use { bs ->
-            val bytes = bs.readByteArray()
-            GraphImportSource.InputStreamSource(bytes.inputStream(), closeInput = true)
-        },
-    )
-    return this.importGraph(csvSource, operations, options)
+    return GraphIoOkioPaths.openGzipSource(verticesSource).use { vbs ->
+        GraphIoOkioPaths.openGzipSource(edgesSource).use { ebs ->
+            val csvSource = CsvGraphImportSource(
+                vertices = GraphImportSource.InputStreamSource(vbs.toInputStream(), closeInput = false),
+                edges = GraphImportSource.InputStreamSource(ebs.toInputStream(), closeInput = false),
+            )
+            this.importGraph(csvSource, operations, options)
+        }
+    }
 }
 
 /**
@@ -93,8 +96,13 @@ fun CsvGraphBulkExporter.exportGraph(
 /**
  * 그래프를 CSV 포맷(Gzip 압축)으로 OkIO 싱크에 익스포트한다.
  *
- * `{stem}_vertices.csv.gz` + `{stem}_edges.csv.gz` 에 쓴다.
+ * `{stem}_vertices.csv.gz` + `{stem}_edges.csv.gz` 에 단일 패스로 쓴다.
  * [OkioGraphExportSink.PathSink] 만 지원한다.
+ *
+ * @param sink Gzip 압축 CSV 파일 경로 기반 OkIO 익스포트 싱크
+ * @param operations 익스포트 대상 그래프 API
+ * @param options 익스포트 옵션
+ * @return 익스포트 결과 보고서 (정점/간선 수 모두 정확)
  */
 fun CsvGraphBulkExporter.exportGraphGzip(
     sink: OkioGraphExportSink,
@@ -107,19 +115,15 @@ fun CsvGraphBulkExporter.exportGraphGzip(
     val stem = sink.path.toString().removeSuffix(".csv.gz").removeSuffix(".csv")
     val verticesSink = OkioGraphExportSink.PathSink("${stem}_vertices.csv.gz".toPath(), sink.fileSystem)
     val edgesSink = OkioGraphExportSink.PathSink("${stem}_edges.csv.gz".toPath(), sink.fileSystem)
-    val vReport = GraphIoOkioPaths.openGzipSink(verticesSink).use { bs ->
-        // 정점만 익스포트하기 위한 임시 버퍼 접근 — Java.io Path 기반으로 위임
-        val jVerticesSink = GraphExportSink.OutputStreamSink(bs.outputStream(), closeOutput = false)
-        val jEdgesSink = GraphExportSink.OutputStreamSink(java.io.ByteArrayOutputStream(), closeOutput = false)
-        exportGraph(CsvGraphExportSink(jVerticesSink, jEdgesSink), operations, options)
+    return GraphIoOkioPaths.openGzipSink(verticesSink).use { vbs ->
+        GraphIoOkioPaths.openGzipSink(edgesSink).use { ebs ->
+            val csvSink = CsvGraphExportSink(
+                vertices = GraphExportSink.OutputStreamSink(vbs.outputStream(), closeOutput = false),
+                edges = GraphExportSink.OutputStreamSink(ebs.outputStream(), closeOutput = false),
+            )
+            exportGraph(csvSink, operations, options)
+        }
     }
-    // edges는 별도 gzip 싱크에 쓰기 (단순 구현 — 속도보다 정확성 우선)
-    GraphIoOkioPaths.openGzipSink(edgesSink).use { bs ->
-        val jVerticesSink = GraphExportSink.OutputStreamSink(java.io.ByteArrayOutputStream(), closeOutput = false)
-        val jEdgesSink = GraphExportSink.OutputStreamSink(bs.outputStream(), closeOutput = false)
-        exportGraph(CsvGraphExportSink(jVerticesSink, jEdgesSink), operations, options)
-    }
-    return vReport
 }
 
 // ─── VirtualThread ────────────────────────────────────────────────────────────
@@ -208,6 +212,9 @@ private fun OkioGraphImportSource.toCsvImportSource(): CsvGraphImportSource {
     require(this is OkioGraphImportSource.PathSource) {
         "CSV 포맷은 두 파일(vertices/edges)이 필요하므로 PathSource 만 지원합니다."
     }
+    require(fileSystem == okio.FileSystem.SYSTEM) {
+        "CSV extension 함수는 FileSystem.SYSTEM 만 지원합니다. 제공된 FileSystem: $fileSystem"
+    }
     val stem = path.toString().removeSuffix(".csv")
     return CsvGraphImportSource(
         vertices = GraphImportSource.PathSource(java.nio.file.Paths.get("${stem}_vertices.csv")),
@@ -218,6 +225,9 @@ private fun OkioGraphImportSource.toCsvImportSource(): CsvGraphImportSource {
 private fun OkioGraphExportSink.toCsvExportSink(): CsvGraphExportSink {
     require(this is OkioGraphExportSink.PathSink) {
         "CSV 포맷은 두 파일(vertices/edges)이 필요하므로 PathSink 만 지원합니다."
+    }
+    require(fileSystem == okio.FileSystem.SYSTEM) {
+        "CSV extension 함수는 FileSystem.SYSTEM 만 지원합니다. 제공된 FileSystem: $fileSystem"
     }
     val stem = path.toString().removeSuffix(".csv")
     return CsvGraphExportSink(

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/GraphMLOkioExtensions.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/GraphMLOkioExtensions.kt
@@ -31,7 +31,7 @@ private val graphmlSuspendAdapter = SuspendGraphIoOkioBulkAdapter()
  * GraphML 포맷으로 그래프를 OkIO 소스에서 임포트한다.
  *
  * StAX 파서는 [InputStream] 기반이므로 OkIO [okio.BufferedSource]를 InputStream 으로 변환하여 전달한다.
- * XXE 방지 하드닝: StAX 팩토리에 `IS_SUPPORTING_EXTERNAL_ENTITIES=false`, `SUPPORT_DTD=false` 적용 (기존 구현 위임).
+ * XXE 방지: StAX 팩토리에 `SUPPORT_DTD=false`, `IS_SUPPORTING_EXTERNAL_ENTITIES=false` 적용 (기존 구현 위임).
  *
  * @param source OkIO 기반 임포트 소스
  * @param operations 임포트 대상 그래프 API

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/JacksonOkioExtensions.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/JacksonOkioExtensions.kt
@@ -24,10 +24,9 @@ import io.bluetape4k.graph.repository.GraphOperations
 import kotlinx.coroutines.flow.Flow
 import java.util.concurrent.CompletableFuture
 
-private val jackson2VtAdapter = VirtualThreadGraphIoOkioBulkAdapter()
-private val jackson2SuspendAdapter = SuspendGraphIoOkioBulkAdapter()
-private val jackson3VtAdapter = VirtualThreadGraphIoOkioBulkAdapter()
-private val jackson3SuspendAdapter = SuspendGraphIoOkioBulkAdapter()
+// 두 어댑터 모두 상태 없는 싱글턴 — Jackson2/3가 공유해도 무관
+private val jacksonVtAdapter = VirtualThreadGraphIoOkioBulkAdapter()
+private val jacksonSuspendAdapter = SuspendGraphIoOkioBulkAdapter()
 
 // ─── Jackson 2 — Sync ─────────────────────────────────────────────────────────
 
@@ -103,7 +102,7 @@ fun Jackson2NdJsonBulkImporter.importGraphAsync(
     operations: GraphOperations,
     options: GraphImportOptions = GraphImportOptions(),
 ): CompletableFuture<GraphImportReport> =
-    jackson2VtAdapter.importGraphAsync(source, GraphIoFormat.NDJSON_JACKSON2, operations, options)
+    jacksonVtAdapter.importGraphAsync(source, GraphIoFormat.NDJSON_JACKSON2, operations, options)
 
 /** Jackson 2 NDJSON OkIO Virtual Thread 비동기 익스포트 */
 fun Jackson2NdJsonBulkExporter.exportGraphAsync(
@@ -111,7 +110,7 @@ fun Jackson2NdJsonBulkExporter.exportGraphAsync(
     operations: GraphOperations,
     options: GraphExportOptions = GraphExportOptions(),
 ): CompletableFuture<GraphExportReport> =
-    jackson2VtAdapter.exportGraphAsync(sink, GraphIoFormat.NDJSON_JACKSON2, operations, options)
+    jacksonVtAdapter.exportGraphAsync(sink, GraphIoFormat.NDJSON_JACKSON2, operations, options)
 
 // ─── Jackson 2 — Suspend ─────────────────────────────────────────────────────
 
@@ -121,7 +120,7 @@ fun Jackson2NdJsonBulkImporter.importGraphFlow(
     operations: GraphOperations,
     options: GraphImportOptions = GraphImportOptions(),
 ): Flow<GraphImportProgress> =
-    jackson2SuspendAdapter.importGraph(source, GraphIoFormat.NDJSON_JACKSON2, operations, options)
+    jacksonSuspendAdapter.importGraph(source, GraphIoFormat.NDJSON_JACKSON2, operations, options)
 
 /** Jackson 2 NDJSON OkIO 코루틴 await 임포트 (완료 보고서) */
 suspend fun Jackson2NdJsonBulkImporter.importGraphAwait(
@@ -129,7 +128,7 @@ suspend fun Jackson2NdJsonBulkImporter.importGraphAwait(
     operations: GraphOperations,
     options: GraphImportOptions = GraphImportOptions(),
 ): GraphImportReport =
-    jackson2SuspendAdapter.importGraphAwait(source, GraphIoFormat.NDJSON_JACKSON2, operations, options)
+    jacksonSuspendAdapter.importGraphAwait(source, GraphIoFormat.NDJSON_JACKSON2, operations, options)
 
 /** Jackson 2 NDJSON OkIO 코루틴 진행 상태 Flow 익스포트 */
 fun Jackson2NdJsonBulkExporter.exportGraphFlow(
@@ -137,7 +136,7 @@ fun Jackson2NdJsonBulkExporter.exportGraphFlow(
     operations: GraphOperations,
     options: GraphExportOptions = GraphExportOptions(),
 ): Flow<GraphExportProgress> =
-    jackson2SuspendAdapter.exportGraph(sink, GraphIoFormat.NDJSON_JACKSON2, operations, options)
+    jacksonSuspendAdapter.exportGraph(sink, GraphIoFormat.NDJSON_JACKSON2, operations, options)
 
 /** Jackson 2 NDJSON OkIO 코루틴 await 익스포트 (완료 보고서) */
 suspend fun Jackson2NdJsonBulkExporter.exportGraphAwait(
@@ -145,7 +144,7 @@ suspend fun Jackson2NdJsonBulkExporter.exportGraphAwait(
     operations: GraphOperations,
     options: GraphExportOptions = GraphExportOptions(),
 ): GraphExportReport =
-    jackson2SuspendAdapter.exportGraphAwait(sink, GraphIoFormat.NDJSON_JACKSON2, operations, options)
+    jacksonSuspendAdapter.exportGraphAwait(sink, GraphIoFormat.NDJSON_JACKSON2, operations, options)
 
 // ─── Jackson 3 — Sync ─────────────────────────────────────────────────────────
 
@@ -211,7 +210,7 @@ fun Jackson3NdJsonBulkImporter.importGraphAsync(
     operations: GraphOperations,
     options: GraphImportOptions = GraphImportOptions(),
 ): CompletableFuture<GraphImportReport> =
-    jackson3VtAdapter.importGraphAsync(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
+    jacksonVtAdapter.importGraphAsync(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
 /** Jackson 3 NDJSON OkIO Virtual Thread 비동기 익스포트 */
 fun Jackson3NdJsonBulkExporter.exportGraphAsync(
@@ -219,7 +218,7 @@ fun Jackson3NdJsonBulkExporter.exportGraphAsync(
     operations: GraphOperations,
     options: GraphExportOptions = GraphExportOptions(),
 ): CompletableFuture<GraphExportReport> =
-    jackson3VtAdapter.exportGraphAsync(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)
+    jacksonVtAdapter.exportGraphAsync(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
 // ─── Jackson 3 — Suspend ─────────────────────────────────────────────────────
 
@@ -229,7 +228,7 @@ fun Jackson3NdJsonBulkImporter.importGraphFlow(
     operations: GraphOperations,
     options: GraphImportOptions = GraphImportOptions(),
 ): Flow<GraphImportProgress> =
-    jackson3SuspendAdapter.importGraph(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
+    jacksonSuspendAdapter.importGraph(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
 /** Jackson 3 NDJSON OkIO 코루틴 await 임포트 */
 suspend fun Jackson3NdJsonBulkImporter.importGraphAwait(
@@ -237,7 +236,7 @@ suspend fun Jackson3NdJsonBulkImporter.importGraphAwait(
     operations: GraphOperations,
     options: GraphImportOptions = GraphImportOptions(),
 ): GraphImportReport =
-    jackson3SuspendAdapter.importGraphAwait(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
+    jacksonSuspendAdapter.importGraphAwait(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
 /** Jackson 3 NDJSON OkIO 코루틴 진행 상태 Flow 익스포트 */
 fun Jackson3NdJsonBulkExporter.exportGraphFlow(
@@ -245,7 +244,7 @@ fun Jackson3NdJsonBulkExporter.exportGraphFlow(
     operations: GraphOperations,
     options: GraphExportOptions = GraphExportOptions(),
 ): Flow<GraphExportProgress> =
-    jackson3SuspendAdapter.exportGraph(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)
+    jacksonSuspendAdapter.exportGraph(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
 /** Jackson 3 NDJSON OkIO 코루틴 await 익스포트 */
 suspend fun Jackson3NdJsonBulkExporter.exportGraphAwait(
@@ -253,4 +252,4 @@ suspend fun Jackson3NdJsonBulkExporter.exportGraphAwait(
     operations: GraphOperations,
     options: GraphExportOptions = GraphExportOptions(),
 ): GraphExportReport =
-    jackson3SuspendAdapter.exportGraphAwait(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)
+    jacksonSuspendAdapter.exportGraphAwait(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
@@ -94,6 +94,25 @@ class GraphIoOkioPathsTest {
         invoking { GraphIoOkioPaths.openSink(sink) } shouldThrow IllegalStateException::class
     }
 
+    @Test
+    fun `openSink PathSink createParentDirectories=true creates missing parent`() {
+        val target = "/new/nested/dir/out.txt".toPath()
+        val sink = OkioGraphExportSink.PathSink(target, fakeFs, createParentDirectories = true)
+
+        GraphIoOkioPaths.openSink(sink).use { bs -> bs.writeUtf8("nested write") }
+
+        val result = fakeFs.read(target) { readUtf8() }
+        result shouldBeEqualTo "nested write"
+    }
+
+    @Test
+    fun `openSink PathSink createParentDirectories=false throws when parent missing`() {
+        val target = "/nonexistent/out.txt".toPath()
+        val sink = OkioGraphExportSink.PathSink(target, fakeFs, createParentDirectories = false)
+
+        invoking { GraphIoOkioPaths.openSink(sink) } shouldThrow Exception::class
+    }
+
     // ─── openGzipSink / openGzipSource ────────────────────────────────────────
 
     @Test
@@ -132,5 +151,25 @@ class GraphIoOkioPathsTest {
                 maxDecompressedBytes = 100L,
             ).use { it.readUtf8() }
         } shouldThrow IOException::class
+    }
+
+    @Test
+    fun `BombGuardSource allows reads up to maxBytes exactly without throwing`() {
+        ensureTmpDir()
+        val data = "x".repeat(500)  // exactly 500 bytes
+        val path = "/tmp/exact.gz".toPath()
+
+        GraphIoOkioPaths.openGzipSink(
+            OkioGraphExportSink.PathSink(path, fakeFs)
+        ).use { bs -> bs.writeUtf8(data) }
+
+        // Should succeed with limit == data size
+        val result = GraphIoOkioPaths.openDecompressedSource(
+            source = GraphIoOkioPaths.openSource(OkioGraphImportSource.PathSource(path, fakeFs)),
+            compressor = Compressor.GZIP,
+            maxDecompressedBytes = 500L,
+        ).use { it.readUtf8() }
+
+        result shouldBeEqualTo data
     }
 }

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/bridge/BridgesTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/bridge/BridgesTest.kt
@@ -82,6 +82,28 @@ class BridgesTest {
     }
 
     @Test
+    fun `toReader uses provided charset for non-UTF8 decoding`() {
+        val text = "Hello charset"
+        val bytes = text.toByteArray(Charsets.ISO_8859_1)
+        val bs = Buffer().also { it.write(bytes) }.buffer()
+        val result = bs.toReader(Charsets.ISO_8859_1).use { it.readText() }
+        result shouldBeEqualTo text
+    }
+
+    @Test
+    fun `toWriter writes bytes encoded with provided non-UTF8 charset`() {
+        val baos = ByteArrayOutputStream()
+        val bs = baos.sink().buffer()
+        val writer = bs.toWriter(Charsets.ISO_8859_1)
+        writer.write("Latin text")
+        writer.flush()
+        bs.flush()
+        writer.close()
+        val result = String(baos.toByteArray(), Charsets.ISO_8859_1)
+        result shouldBeEqualTo "Latin text"
+    }
+
+    @Test
     fun `writeAsOutputStream writes bytes through OkIO sink`() {
         val path = "/write-as-os.bin".toPath()
         val expected = "writeAsOutputStream test".toByteArray()

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendAdapterTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendAdapterTest.kt
@@ -119,6 +119,58 @@ class SuspendAdapterTest {
         events.last().exported shouldBeEqualTo 3L  // 2 vertices + 1 edge
     }
 
+    // ─── 다중 포맷 커버리지 ───────────────────────────────────────────────────────
+
+    @Test
+    fun `importGraphAwait with NDJSON_JACKSON2 format returns correct counts`() = runTest {
+        val path = "/await-j2.ndjson".toPath()
+        val src = buildSourceGraph()
+        adapter.exportGraphAwait(OkioGraphExportSink.PathSink(path, fakeFs), GraphIoFormat.NDJSON_JACKSON2, src, exportOptions)
+
+        val report = adapter.importGraphAwait(
+            OkioGraphImportSource.PathSource(path, fakeFs),
+            GraphIoFormat.NDJSON_JACKSON2,
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+        )
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 2L
+        report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `importGraphAwait with GRAPHML format returns correct counts`() = runTest {
+        val path = "/await-graphml.xml".toPath()
+        val src = buildSourceGraph()
+        adapter.exportGraphAwait(OkioGraphExportSink.PathSink(path, fakeFs), GraphIoFormat.GRAPHML, src, exportOptions)
+
+        val report = adapter.importGraphAwait(
+            OkioGraphImportSource.PathSource(path, fakeFs),
+            GraphIoFormat.GRAPHML,
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+        )
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 2L
+        report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `exportGraphAwait with GRAPHML format returns completed report`() = runTest {
+        val path = "/await-export-graphml.xml".toPath()
+        val src = buildSourceGraph()
+
+        val report = adapter.exportGraphAwait(
+            OkioGraphExportSink.PathSink(path, fakeFs),
+            GraphIoFormat.GRAPHML,
+            src,
+            exportOptions,
+        )
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesWritten shouldBeEqualTo 2L
+        report.edgesWritten shouldBeEqualTo 1L
+    }
+
     // ─── 취소 전파 ────────────────────────────────────────────────────────────
 
     @Test

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/CsvOkioExtensionsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/CsvOkioExtensionsTest.kt
@@ -72,8 +72,10 @@ class CsvOkioExtensionsTest {
             tempDir.resolve("graph.csv.gz").toString().toPath(),
             FileSystem.SYSTEM,
         )
-        exporter.exportGraphGzip(gzSink, buildSourceGraph(), exportOptions)
-            .status shouldBeEqualTo GraphIoStatus.COMPLETED
+        val exportReport = exporter.exportGraphGzip(gzSink, buildSourceGraph(), exportOptions)
+        exportReport.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        exportReport.verticesWritten shouldBeEqualTo 2L
+        exportReport.edgesWritten shouldBeEqualTo 1L
 
         val gzSource = OkioGraphImportSource.PathSource(
             tempDir.resolve("graph.csv.gz").toString().toPath(),

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/virtualthread/VirtualThreadGraphIoOkioBulkAdapterTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/virtualthread/VirtualThreadGraphIoOkioBulkAdapterTest.kt
@@ -157,6 +157,30 @@ class VirtualThreadGraphIoOkioBulkAdapterTest {
     }
 
     @Test
+    fun `jackson2 round trip via virtual thread`() {
+        val path = "/vt-graph-j2.ndjson".toPath()
+        val src = buildSourceGraph()
+
+        adapter.exportGraphAsync(
+            OkioGraphExportSink.PathSink(path, fakeFs),
+            GraphIoFormat.NDJSON_JACKSON2,
+            src,
+            exportOptions,
+        ).get()
+
+        val report = adapter.importGraphAsync(
+            OkioGraphImportSource.PathSource(path, fakeFs),
+            GraphIoFormat.NDJSON_JACKSON2,
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+        ).get()
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 2L
+        report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
     fun `export duration is positive`() {
         val path = "/vt-dur.ndjson".toPath()
         val report = adapter.exportGraphAsync(


### PR DESCRIPTION
## 개요

자동화된 스케줄 코드 리뷰 (, 2026-04-30) 결과를 반영한 패치.
5개 리뷰 에이전트(보안, Ops/SRE, 구조, Kotlin idioms/KDoc, 테스트 커버리지)의 CRITICAL/HIGH 항목 전부 수정, MEDIUM 일부 적용.

## 수정 사항

### CRITICAL
- **CsvOkioExtensions.exportGraphGzip**: 그래프를 두 번 순회하여 각 반쪽만 gzip에 쓰는 이중 export 버그 수정 → 두 싱크 동시 오픈 후 단일 패스 export
- **CsvOkioExtensions.importGraphGzip**: `readByteArray()` 두 번 호출로 최대 2×512 MiB 힙 점유 위험 → `toInputStream()` 스트리밍 방식으로 변경

### HIGH
- **StaxGraphMlReader**: `IS_SUPPORTING_EXTERNAL_ENTITIES=false` 누락 추가 (XXE 방어 완성)
- **CsvOkioExtensions**: `toCsvImportSource`/`toCsvExportSink`에 `FileSystem.SYSTEM` 가드 추가

### 코드 품질
- `SuspendGraphIoOkioBulkAdapter`: 오해 유발 빈 `finally { withContext(NonCancellable) {} }` 블록 제거, `KLoggingChannel` → `KLogging`
- `GraphIoOkioPaths`: `KLogging` 추가, `@Volatile` 2개, 예외 삼킴 방지 (warn 로깅)
- `JacksonOkioExtensions`: 중복 어댑터 인스턴스 4개 → 2개 통합

### KDoc / 문서
- `Compressor`: 6개 enum 항목 KDoc 추가
- `OkioGraphExportSink`: factory 함수 `@param`/`@return` 추가
- `README.ko.md`: 보안 섹션 업데이트

## 테스트

- 신규/강화 테스트 +10개 (91개 전체 통과)
- `SuspendAdapterTest`: NDJSON_JACKSON2, GRAPHML 포맷 추가
- `VirtualThreadGraphIoOkioBulkAdapterTest`: Jackson2 round trip 추가
- `BridgesTest`: non-UTF8 charset 커버리지 추가
- `GraphIoOkioPathsTest`: `createParentDirectories`, BombGuard 경계값 추가
- `CsvOkioExtensionsTest`: gzip round trip 수치 검증 강화

## DoD 체크리스트

- [x] CRITICAL 버그 전부 수정
- [x] HIGH 버그 전부 수정
- [x] 보안 취약점 수정 (XXE)
- [x] 테스트 91개 전체 통과
- [x] KDoc 보강 (public API)
- [x] README.ko.md 동기화
- [ ] README.md (영문) — 미수정 (한국어 버전과 내용 동기화 필요, 별도 이슈 검토)