### PR TITLE
fix(ci): artifact 경로 수정 (kosogor 빌드 레이아웃 반영)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results-core
-          path: '**/build/test-results/test/*.xml'
+          path: 'build/*/test-results/test/*.xml'
           retention-days: 7
 
       - name: Upload coverage report
@@ -147,7 +147,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-core
-          path: '**/build/reports/kover/report.xml'
+          path: 'build/*/reports/kover/report.xml'
           retention-days: 7
 
   # ── 4. Spring Boot Starter 테스트 (TinkerGraph 프로파일, Docker 불필요) ──
@@ -192,7 +192,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results-spring-starters
-          path: '**/build/test-results/test/*.xml'
+          path: 'build/*/test-results/test/*.xml'
           retention-days: 7
 
       - name: Upload coverage report
@@ -200,7 +200,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-spring-starters
-          path: '**/build/reports/kover/report.xml'
+          path: 'build/*/reports/kover/report.xml'
           retention-days: 7
 
   # ── 5. 커버리지 집계 ─────────────────────────────────────────────────────


### PR DESCRIPTION
## 원인

이전 PR #55에서 `**/build/...` 로 변경했지만 이 프로젝트는 `kosogor` 플러그인을 사용해 모든 서브모듈 빌드 출력을 `<root>/build/<module-name>/`로 리다이렉트함.

`**/build/reports/kover/report.xml`은 `build/graph-core/reports/kover/report.xml` 구조를 매칭하지 못함.

## 수정

| 위치 | 잘못된 경로 | 올바른 경로 |
|------|-----------|-----------|
| test-results | `**/build/test-results/test/*.xml` | `build/*/test-results/test/*.xml` |
| coverage | `**/build/reports/kover/report.xml` | `build/*/reports/kover/report.xml` |

test-core, test-spring-starters 두 job 모두 수정.