### PR TITLE
test(graph-io-core): 커버리지 65% → 93% 향상

### DIFF
--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoFileRoleTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoFileRoleTest.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.graph.io.report
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.junit.jupiter.api.Test
+
+class GraphIoFileRoleTest {
+
+    @Test
+    fun `GraphIoFileRole has three entries`() {
+        GraphIoFileRole.entries.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `GraphIoFileRole entries contain all expected values`() {
+        val entries = GraphIoFileRole.entries
+        entries shouldContain GraphIoFileRole.VERTICES
+        entries shouldContain GraphIoFileRole.EDGES
+        entries shouldContain GraphIoFileRole.UNIFIED
+    }
+
+    @Test
+    fun `GraphIoFileRole valueOf returns correct enum constant`() {
+        GraphIoFileRole.valueOf("VERTICES") shouldBeEqualTo GraphIoFileRole.VERTICES
+        GraphIoFileRole.valueOf("EDGES") shouldBeEqualTo GraphIoFileRole.EDGES
+        GraphIoFileRole.valueOf("UNIFIED") shouldBeEqualTo GraphIoFileRole.UNIFIED
+    }
+
+    @Test
+    fun `GraphIoFileRole ordinal is stable`() {
+        GraphIoFileRole.VERTICES.ordinal shouldBeEqualTo 0
+        GraphIoFileRole.EDGES.ordinal shouldBeEqualTo 1
+        GraphIoFileRole.UNIFIED.ordinal shouldBeEqualTo 2
+    }
+}

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphProgressTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphProgressTest.kt
@@ -1,0 +1,78 @@
+package io.bluetape4k.graph.io.report
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+
+class GraphProgressTest {
+
+    // ── GraphExportProgress ──────────────────────────────────────────────────
+
+    @Test
+    fun `GraphExportProgress holds all fields`() {
+        val p = GraphExportProgress(exported = 10L, total = 100L, currentLabel = "Person", throughputPerSec = 50.0)
+        p.exported shouldBeEqualTo 10L
+        p.total shouldBeEqualTo 100L
+        p.currentLabel shouldBeEqualTo "Person"
+        p.throughputPerSec shouldBeEqualTo 50.0
+    }
+
+    @Test
+    fun `GraphExportProgress defaults to null optional fields`() {
+        val p = GraphExportProgress(exported = 5L)
+        p.total.shouldBeNull()
+        p.currentLabel.shouldBeNull()
+        p.throughputPerSec.shouldBeNull()
+    }
+
+    @Test
+    fun `GraphExportProgress copy creates modified instance`() {
+        val p = GraphExportProgress(exported = 1L, total = 10L)
+        val copy = p.copy(exported = 2L)
+        copy.exported shouldBeEqualTo 2L
+        copy.total shouldBeEqualTo 10L
+    }
+
+    @Test
+    fun `GraphExportProgress equals and hashCode`() {
+        val a = GraphExportProgress(3L, 30L, "Edge", 100.0)
+        val b = GraphExportProgress(3L, 30L, "Edge", 100.0)
+        (a == b) shouldBeEqualTo true
+        a.hashCode() shouldBeEqualTo b.hashCode()
+    }
+
+    // ── GraphImportProgress ──────────────────────────────────────────────────
+
+    @Test
+    fun `GraphImportProgress holds all fields`() {
+        val p = GraphImportProgress(processed = 20L, total = 200L, currentLabel = "KNOWS", throughputPerSec = 75.0)
+        p.processed shouldBeEqualTo 20L
+        p.total shouldBeEqualTo 200L
+        p.currentLabel shouldBeEqualTo "KNOWS"
+        p.throughputPerSec shouldBeEqualTo 75.0
+    }
+
+    @Test
+    fun `GraphImportProgress defaults to null optional fields`() {
+        val p = GraphImportProgress(processed = 0L)
+        p.total.shouldBeNull()
+        p.currentLabel.shouldBeNull()
+        p.throughputPerSec.shouldBeNull()
+    }
+
+    @Test
+    fun `GraphImportProgress copy creates modified instance`() {
+        val p = GraphImportProgress(processed = 5L, total = 50L)
+        val copy = p.copy(processed = 6L)
+        copy.processed shouldBeEqualTo 6L
+        copy.total shouldBeEqualTo 50L
+    }
+
+    @Test
+    fun `GraphImportProgress equals and hashCode`() {
+        val a = GraphImportProgress(7L, 70L, "Person", 200.0)
+        val b = GraphImportProgress(7L, 70L, "Person", 200.0)
+        (a == b) shouldBeEqualTo true
+        a.hashCode() shouldBeEqualTo b.hashCode()
+    }
+}

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoPathsTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoPathsTest.kt
@@ -3,24 +3,166 @@ package io.bluetape4k.graph.io.support
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.nio.file.Path
 
 class GraphIoPathsTest {
 
+    // ── openReader ───────────────────────────────────────────────────────────
+
     @Test
     fun `openReader honors path source`(@TempDir dir: Path) {
         val file = dir.resolve("a.txt").also { Files.writeString(it, "x\ny") }
-        val src = GraphImportSource.PathSource(file)
-        GraphIoPaths.openReader(src).use { r -> r.readLines().size shouldBeEqualTo 2 }
+        GraphIoPaths.openReader(GraphImportSource.PathSource(file)).use { r ->
+            r.readLines().size shouldBeEqualTo 2
+        }
     }
+
+    @Test
+    fun `openReader with inputStream source closeInput=true reads data`() {
+        val bytes = "hello\nworld".toByteArray()
+        val src = GraphImportSource.InputStreamSource(ByteArrayInputStream(bytes), closeInput = true)
+        GraphIoPaths.openReader(src).use { r ->
+            r.readLines() shouldBeEqualTo listOf("hello", "world")
+        }
+    }
+
+    @Test
+    fun `openReader with inputStream source closeInput=false does not close underlying stream`() {
+        var closed = false
+        val underlying = object : ByteArrayInputStream("line1\nline2".toByteArray()) {
+            override fun close() { closed = true; super.close() }
+        }
+        val src = GraphImportSource.InputStreamSource(underlying, closeInput = false)
+        val reader = GraphIoPaths.openReader(src)
+        reader.readLine() shouldBeEqualTo "line1"
+        reader.close()
+        closed shouldBeEqualTo false
+    }
+
+    // ── openWriter ───────────────────────────────────────────────────────────
 
     @Test
     fun `openWriter creates parent directory for path sink`(@TempDir dir: Path) {
         val nested = dir.resolve("nested/a.txt")
         GraphIoPaths.openWriter(GraphExportSink.PathSink(nested)).use { it.write("hi") }
         Files.exists(nested) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `openWriter appends when PathSink append=true`(@TempDir dir: Path) {
+        val file = dir.resolve("app.txt").also { Files.writeString(it, "first\n") }
+        val sink = GraphExportSink.PathSink(file, append = true)
+        GraphIoPaths.openWriter(sink).use { it.write("second") }
+        Files.readString(file) shouldBeEqualTo "first\nsecond"
+    }
+
+    @Test
+    fun `openWriter truncates when PathSink append=false`(@TempDir dir: Path) {
+        val file = dir.resolve("trunc.txt").also { Files.writeString(it, "old content") }
+        val sink = GraphExportSink.PathSink(file, append = false)
+        GraphIoPaths.openWriter(sink).use { it.write("new") }
+        Files.readString(file) shouldBeEqualTo "new"
+    }
+
+    @Test
+    fun `openWriter with outputStream sink closeOutput=true writes data`() {
+        val out = ByteArrayOutputStream()
+        val sink = GraphExportSink.OutputStreamSink(out, closeOutput = true)
+        GraphIoPaths.openWriter(sink).use { it.write("data") }
+        out.toString() shouldBeEqualTo "data"
+    }
+
+    @Test
+    fun `openWriter with outputStream sink closeOutput=false does not close underlying stream`() {
+        val out = ByteArrayOutputStream()
+        val sink = GraphExportSink.OutputStreamSink(out, closeOutput = false)
+        val writer = GraphIoPaths.openWriter(sink)
+        writer.write("test")
+        writer.close()
+        // stream still usable after writer.close() because closeOutput=false
+        out.write("extra".toByteArray())
+        out.toString() shouldBeEqualTo "testextra"
+    }
+
+    // ── openInputStream ──────────────────────────────────────────────────────
+
+    @Test
+    fun `openInputStream returns buffered stream for path source`(@TempDir dir: Path) {
+        val file = dir.resolve("b.bin").also { Files.write(it, byteArrayOf(1, 2, 3)) }
+        GraphIoPaths.openInputStream(GraphImportSource.PathSource(file)).use { s ->
+            s.readBytes() shouldBeEqualTo byteArrayOf(1, 2, 3)
+        }
+    }
+
+    @Test
+    fun `openInputStream returns underlying stream for inputStream source`() {
+        val data = byteArrayOf(10, 20, 30)
+        val src = GraphImportSource.InputStreamSource(ByteArrayInputStream(data))
+        GraphIoPaths.openInputStream(src).use { s ->
+            s.readBytes() shouldBeEqualTo data
+        }
+    }
+
+    // ── openOutputStream ─────────────────────────────────────────────────────
+
+    @Test
+    fun `openOutputStream writes to path sink append=false`(@TempDir dir: Path) {
+        val file = dir.resolve("out.bin").also { Files.write(it, byteArrayOf(99)) }
+        GraphIoPaths.openOutputStream(GraphExportSink.PathSink(file, append = false)).use { s ->
+            s.write(byteArrayOf(1, 2))
+        }
+        Files.readAllBytes(file) shouldBeEqualTo byteArrayOf(1, 2)
+    }
+
+    @Test
+    fun `openOutputStream appends to path sink append=true`(@TempDir dir: Path) {
+        val file = dir.resolve("app.bin").also { Files.write(it, byteArrayOf(1)) }
+        GraphIoPaths.openOutputStream(GraphExportSink.PathSink(file, append = true)).use { s ->
+            s.write(byteArrayOf(2, 3))
+        }
+        Files.readAllBytes(file) shouldBeEqualTo byteArrayOf(1, 2, 3)
+    }
+
+    @Test
+    fun `openOutputStream with outputStream sink closeOutput=true writes data`() {
+        val out = ByteArrayOutputStream()
+        val sink = GraphExportSink.OutputStreamSink(out, closeOutput = true)
+        GraphIoPaths.openOutputStream(sink).use { s -> s.write(byteArrayOf(5, 6)) }
+        out.toByteArray() shouldBeEqualTo byteArrayOf(5, 6)
+    }
+
+    @Test
+    fun `openOutputStream with outputStream sink closeOutput=false flushes but keeps stream open`() {
+        val out = ByteArrayOutputStream()
+        val sink = GraphExportSink.OutputStreamSink(out, closeOutput = false)
+        val stream = GraphIoPaths.openOutputStream(sink)
+        stream.write(42)
+        stream.close()
+        // underlying stream still writable
+        out.write(99)
+        out.toByteArray() shouldBeEqualTo byteArrayOf(42, 99)
+    }
+
+    // ── describeSource ───────────────────────────────────────────────────────
+
+    @Test
+    fun `describeSource returns path string for path source`(@TempDir dir: Path) {
+        val file = dir.resolve("x.txt")
+        val src = GraphImportSource.PathSource(file)
+        GraphIoPaths.describeSource(src).shouldNotBeNull()
+        GraphIoPaths.describeSource(src) shouldBeEqualTo file.toString()
+    }
+
+    @Test
+    fun `describeSource returns null for inputStream source`() {
+        val src = GraphImportSource.InputStreamSource(ByteArrayInputStream(byteArrayOf()))
+        GraphIoPaths.describeSource(src).shouldBeNull()
     }
 }

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoStopwatchTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoStopwatchTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.graph.io.support
+
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+class GraphIoStopwatchTest {
+
+    @Test
+    fun `elapsed returns non-negative duration`() {
+        val sw = GraphIoStopwatch()
+        val elapsed = sw.elapsed()
+        elapsed.shouldNotBeNull()
+        elapsed.toNanos() shouldBeGreaterOrEqualTo 0L
+    }
+
+    @Test
+    fun `elapsed increases over time`() {
+        val sw = GraphIoStopwatch()
+        val first = sw.elapsed()
+        Thread.sleep(1)
+        val second = sw.elapsed()
+        second.toNanos() shouldBeGreaterOrEqualTo first.toNanos()
+    }
+}

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/VirtualThreadGraphBulkAdapterTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/VirtualThreadGraphBulkAdapterTest.kt
@@ -1,7 +1,10 @@
 package io.bluetape4k.graph.io.support
 
+import io.bluetape4k.graph.io.contract.GraphBulkExporter
 import io.bluetape4k.graph.io.contract.GraphBulkImporter
+import io.bluetape4k.graph.io.options.GraphExportOptions
 import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.report.GraphExportReport
 import io.bluetape4k.graph.io.report.GraphImportReport
 import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.io.report.GraphIoStatus
@@ -16,8 +19,15 @@ import java.util.concurrent.ExecutionException
 
 class VirtualThreadGraphBulkAdapterTest {
 
-    private val stubReport = GraphImportReport(
+    private val stubImportReport = GraphImportReport(
         GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, 0L, 0L, Duration.ZERO
+    )
+    private val stubExportReport = GraphExportReport(
+        status = GraphIoStatus.COMPLETED,
+        format = GraphIoFormat.CSV,
+        verticesWritten = 0L,
+        edgesWritten = 0L,
+        elapsed = Duration.ZERO,
     )
 
     private fun stubImporter(block: (String, GraphOperations, GraphImportOptions) -> GraphImportReport) =
@@ -26,11 +36,27 @@ class VirtualThreadGraphBulkAdapterTest {
                 block(source, operations, options)
         }
 
+    private fun stubExporter(block: (String, GraphOperations, GraphExportOptions) -> GraphExportReport) =
+        object : GraphBulkExporter<String> {
+            override fun exportGraph(sink: String, operations: GraphOperations, options: GraphExportOptions) =
+                block(sink, operations, options)
+        }
+
+    // ── wrapImporter ─────────────────────────────────────────────────────────
+
     @Test
     fun `importAsync wraps sync importer with virtual thread future`() {
-        val importer = stubImporter { _, _, _ -> stubReport }
+        val importer = stubImporter { _, _, _ -> stubImportReport }
         val vt = VirtualThreadGraphBulkAdapter.wrapImporter(importer)
-        vt.importGraphAsync("src", FakeGraphOperations(), GraphImportOptions()).get() shouldBeEqualTo stubReport
+        vt.importGraphAsync("src", FakeGraphOperations(), GraphImportOptions()).get() shouldBeEqualTo stubImportReport
+    }
+
+    @Test
+    fun `importAsync with default options uses interface default parameter`() {
+        val importer = stubImporter { _, _, _ -> stubImportReport }
+        val vt = VirtualThreadGraphBulkAdapter.wrapImporter(importer)
+        // omit options → triggers GraphVirtualThreadBulkImporter DefaultImpls stub
+        vt.importGraphAsync("src", FakeGraphOperations()).get() shouldBeEqualTo stubImportReport
     }
 
     @Test
@@ -40,6 +66,34 @@ class VirtualThreadGraphBulkAdapterTest {
         val vt = VirtualThreadGraphBulkAdapter.wrapImporter(importer)
         val ee = assertThrows<ExecutionException> {
             vt.importGraphAsync("x", FakeGraphOperations(), GraphImportOptions()).get()
+        }
+        ee.cause shouldBeInstanceOf RuntimeException::class
+    }
+
+    // ── wrapExporter ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `exportAsync wraps sync exporter with virtual thread future`() {
+        val exporter = stubExporter { _, _, _ -> stubExportReport }
+        val vt = VirtualThreadGraphBulkAdapter.wrapExporter(exporter)
+        vt.exportGraphAsync("sink", FakeGraphOperations(), GraphExportOptions()).get() shouldBeEqualTo stubExportReport
+    }
+
+    @Test
+    fun `exportAsync with default options uses interface default parameter`() {
+        val exporter = stubExporter { _, _, _ -> stubExportReport }
+        val vt = VirtualThreadGraphBulkAdapter.wrapExporter(exporter)
+        // omit options → triggers GraphVirtualThreadBulkExporter DefaultImpls stub
+        vt.exportGraphAsync("sink", FakeGraphOperations()).get() shouldBeEqualTo stubExportReport
+    }
+
+    @Test
+    fun `exportAsync propagates sync failure`() {
+        val boom = RuntimeException("export boom")
+        val exporter = stubExporter { _, _, _ -> throw boom }
+        val vt = VirtualThreadGraphBulkAdapter.wrapExporter(exporter)
+        val ee = assertThrows<ExecutionException> {
+            vt.exportGraphAsync("sink", FakeGraphOperations(), GraphExportOptions()).get()
         }
         ee.cause shouldBeInstanceOf RuntimeException::class
     }


### PR DESCRIPTION
## 변경 내용

`graph-io-core` 모듈 테스트 커버리지를 **65.35% → 92.94%** 로 개선합니다.

### 추가된 테스트

| 파일 | 내용 |
|------|------|
| `GraphIoPathsTest` | `InputStreamSource`·`OutputStreamSink` 양 `closeXxx` 분기, `PathSink` append 모드, `openInputStream`/`openOutputStream`, `describeSource` |
| `VirtualThreadGraphBulkAdapterTest` | `wrapExporter` 성공/실패, default options 경로 (interface DefaultImpls 커버) |
| `GraphIoStopwatchTest` (신규) | `elapsed()` 비음수·단조 증가 |
| `GraphProgressTest` (신규) | `GraphExportProgress`·`GraphImportProgress` 생성·`copy`·`equals`·`hashCode` |
| `GraphIoFileRoleTest` (신규) | enum `entries`·`valueOf`·`ordinal` |

### 커버리지 변화

| Package | Before | After |
|---------|--------|-------|
| `support` | 39% | 93% |
| `report` | 79% | 100% |
| `contract` | 0% | 33% |
| **TOTAL** | **65.35%** | **92.94%** |