### PR TITLE
fix(graph-io-core): 6-tier 코드 리뷰 수정 사항 적용

### DIFF
--- a/.claude/worktrees/review-graph-core/docs/reviews/2026-04-30-graph-core-6tier-review.md
+++ b/.claude/worktrees/review-graph-core/docs/reviews/2026-04-30-graph-core-6tier-review.md
@@ -1,0 +1,342 @@
+# graph-core 6-Tier 코드 리뷰
+
+- **날짜**: 2026-04-30
+- **대상 모듈**: `graph/graph-core`
+- **브랜치**: `review/graph-core-6tier`
+- **리뷰 방법**: bluetape4k-design Step 6-R (6-Tier 병렬 리뷰)
+
+---
+
+## 리뷰 결과 요약
+
+| Tier | 도구 | CRITICAL | HIGH | MEDIUM | LOW |
+|------|------|----------|------|--------|-----|
+| 1 | autoresearch:security | 0 | 0 | 0 | 1(info) |
+| 2 | Ops/SRE | 0 | 4 | 1 | 2 |
+| 3 | code-review-graph | 2 | 4 | 0 | 1 |
+| 4 | code-reviewer (Kotlin/patterns) | 0 | 5 | 2 | 0 |
+| 5 | pr-review-toolkit | 1 | 3 | 2 | 0 |
+| 6 | 성능/안정성 | 0 | 2 | 0 | 0 |
+| **합계** | | **3** | **18** | **5** | **4** |
+
+> 중복 발견사항 제거 후: **CRITICAL 3, HIGH 15, MEDIUM 5, LOW 3**
+
+---
+
+## CRITICAL (즉시 수정 필요)
+
+### C1. `PageRankCalculatorTest.kt:23` — Tautological Assertion (항상 통과하는 단언)
+**Tier 5 | 신뢰도: 100%**
+
+```kotlin
+// 잘못된 코드 — abs()는 항상 ≥ 0이므로 -0.001보다 항상 크다 → 테스트가 의미 없음
+abs(scores.getValue(id("a")) - 1.0) shouldBeGreaterThan -0.001
+
+// 올바른 코드
+abs(scores.getValue(id("a")) - 1.0) shouldBeLessThan 0.001
+```
+
+PageRank 계산이 완전히 잘못되어도 이 테스트는 통과한다. 즉시 수정 필요.
+
+---
+
+### C2. `GraphVirtualThreadOperations.kt` — 동기 `GraphSession` 직접 상속
+**Tier 3 | 신뢰도: 95%**
+
+```kotlin
+// 현재 (문제)
+interface GraphVirtualThreadOperations:
+    GraphSession,              // ← 블로킹 동기 API가 VT facade에 노출됨
+    GraphVirtualThreadSession,
+    GraphVirtualThreadVertexRepository,
+    ...
+
+// 권고
+interface GraphVirtualThreadOperations:
+    GraphVirtualThreadSession,
+    GraphVirtualThreadVertexRepository,
+    GraphVirtualThreadEdgeRepository,
+    GraphVirtualThreadTraversalRepository,
+    GraphVirtualThreadAlgorithmRepository
+```
+
+VT API 사용자가 블로킹 동기 메서드를 실수로 호출할 수 있다.
+
+---
+
+### C3. `CLAUDE.md` — `GraphOperations` 구성 설명 오류
+**Tier 3 | 신뢰도: 90%**
+
+```markdown
+# 현재 (틀림)
+GraphOperations = GraphSession + GraphVertexRepository + GraphEdgeRepository + GraphTraversalRepository
+
+# 올바른 내용
+GraphOperations = GraphSession + GraphVertexRepository + GraphEdgeRepository + GraphGenericRepository
+                  (GraphGenericRepository = GraphTraversalRepository + GraphAlgorithmRepository)
+```
+
+`GraphAlgorithmRepository` 전체가 누락되어 있어, 이 문서를 참고하여 backend를 구현하면 pageRank, bfs, dfs, connectedComponents, detectCycles 등이 빠진 불완전한 구현이 만들어진다.
+
+---
+
+## HIGH (병합 전 수정 권고)
+
+### H1. `CycleDetector.kt:82` — 재귀 DFS StackOverflowError 위험
+**Tier 2 | 신뢰도: 90%**
+
+`CycleDetector.dfs`가 재귀 호출. `maxDepth`가 크거나 밀집 그래프에서 JVM 스택 오버플로우 가능.
+형제 클래스 `BfsDfsRunner`는 이미 반복형(iterative) 구현 사용.
+
+**권고**: 재귀 DFS를 명시적 스택 반복 루프로 전환하거나, `require(maxDepth <= N)` 가드 추가.
+
+---
+
+### H2. `AStarRunner.kt:74-77`, `DijkstraRunner.kt:71-74` — maxVisited 소진 시 DEBUG 로그만
+**Tier 2 | 신뢰도: 88%**
+
+```kotlin
+// 현재 — debug로 기록됨. 운영 환경에서 보이지 않음
+log.debug { "maxVisited=${options.maxVisited} reached; aborting" }
+return null  // "경로 없음"과 구분 불가
+
+// 권고 — warn으로 변경
+log.warn { "A* maxVisited=${options.maxVisited} reached from $fromId → $toId" }
+```
+
+---
+
+### H3. `PathReconstructor.kt:33,39` — fetchVertex 실패 시 WARN 없이 null 반환
+**Tier 2 | 신뢰도: 85%**
+
+경로 탐색 성공 후 경로 재구성 중 `fetchVertex`가 null을 반환하면 로그 없이 null 반환. "경로 없음"과 구분 불가.
+
+```kotlin
+// 권고
+val vertex = vertexLookup(currentId) ?: run {
+    log.warn { "PathReconstructor: vertex $currentId not found mid-reconstruction" }
+    return null
+}
+```
+
+---
+
+### H4. `PageRankCalculator.kt:32-38` — 파라미터 검증 없음
+**Tier 2 | 신뢰도: 82%**
+
+```kotlin
+// 권고: 함수 진입 시 검증 추가
+require(iterations > 0) { "iterations must be > 0, was $iterations" }
+require(dampingFactor in 0.0..1.0) { "dampingFactor must be in (0,1), was $dampingFactor" }
+require(tolerance > 0.0) { "tolerance must be > 0.0, was $tolerance" }
+```
+
+`iterations <= 0`이면 반복 없이 초기 균등 분포를 결과로 반환. 음수 dampingFactor는 음수 PageRank 생성.
+
+---
+
+### H5. `DijkstraRunner.kt:85`, `AStarRunner.kt:88,91` — fetchVertex 루프 내 N번 호출
+**Tier 5/6 | 신뢰도: 90%**
+
+```kotlin
+// 현재 (문제) — for 루프 내 매 edge마다 동일한 currentId로 fetchVertex 호출
+for (edge in edges.sortedBy { it.id.value }) {
+    ...
+    val currentVertex = fetchVertex(currentId) ?: continue  // N번 backend 쿼리
+    cameFrom[neighborId] = currentVertex to edge
+}
+
+// 권고 — 루프 밖으로 호이스팅
+val currentVertex = fetchVertex(currentId) ?: continue@outer
+for (edge in edges.sortedBy { it.id.value }) {
+    ...
+    cameFrom[neighborId] = currentVertex to edge
+}
+```
+
+out-degree N인 vertex에서 N번 backend 쿼리 발생. Neo4j/AGE/FalkorDB 백엔드에서 심각한 성능 저하.
+
+---
+
+### H6. `ShortestPathFallback.kt:87` — `Direction.BOTH` self-loop 엣지 중복
+**Tier 5 | 신뢰도: 88%**
+
+```kotlin
+// 현재 (문제)
+Direction.BOTH -> (ops.findEdgesByStartId(id, edgeLabel) + ops.findEdgesByEndId(id, edgeLabel))
+    .sortedBy { it.id.value }
+
+// 권고
+Direction.BOTH -> (ops.findEdgesByStartId(id, edgeLabel) + ops.findEdgesByEndId(id, edgeLabel))
+    .distinctBy { it.id }
+    .sortedBy { it.id.value }
+```
+
+self-loop 엣지(`startId == endId`)가 두 번 포함되어 phantom duplicate 엣지로 알고리즘에 전달됨.
+
+---
+
+### H7. `ShortestPathFallbackTest.kt` 누락
+**Tier 5 | 신뢰도: 82%**
+
+`ShortestPathFallback`에 대한 직접 테스트 파일 없음. `DijkstraRunnerTest`/`AStarRunnerTest`는 lambda를 직접 주입하므로 `ShortestPathFallback`의 `fetchIncident` 코드 경로(Direction.BOTH 포함)를 전혀 실행하지 않음.
+
+**권고**: `ShortestPathFallbackTest.kt` 추가, mock `GraphOperations`로 OUTGOING/INCOMING/BOTH + self-loop 케이스 커버.
+
+---
+
+### H8. `PageRankCalculator.kt:52-53` — dangling node set 매 iteration 재계산
+**Tier 6 | 신뢰도: 85%**
+
+```kotlin
+// 현재 (문제) — 매 iteration마다 O(V) filter + List 할당
+repeat(iterations) {
+    val danglingMass = vertices.filter { outAdjacency[it].isNullOrEmpty() }
+        .sumOf { ranks.getOrDefault(it, 0.0) }
+}
+
+// 권고 — 루프 밖에서 1회 계산
+val danglingNodes = vertices.filter { outAdjacency[it].isNullOrEmpty() }
+repeat(iterations) {
+    val danglingMass = danglingNodes.sumOf { ranks.getOrDefault(it, 0.0) }
+}
+```
+
+---
+
+### H9. `CompletableFutureNullableSupport.kt` — 잘못된 패키지 위치
+**Tier 4 | 신뢰도: 90%**
+
+`graph-core` 모듈에 있으나 `package io.bluetape4k.concurrent.virtualthread` 선언. 이 네임스페이스는 `bluetape4k-virtualthread-jdk25` 라이브러리 소속.
+
+**권고**: `bluetape4k-virtualthread-jdk25`에 `virtualFutureOfNullable` PR 제출 후 이 파일 삭제. 불가능하면 패키지를 `io.bluetape4k.graph.vt`로 변경.
+
+---
+
+### H10. `VirtualThreadAlgorithmAdapter.kt:22-24` — KDoc과 구현 불일치
+**Tier 4 | 신뢰도: 95%**
+
+KDoc에 "여러 작업 병렬 실행 시 `StructuredTaskScopes.all { }` 사용"이라고 명시되어 있으나, 실제 구현에는 `StructuredTaskScope` 사용 코드 없음. 모든 override가 단일 `virtualFutureOf { }` 호출.
+
+**권고**: KDoc에서 `StructuredTaskScopes.all` 언급 삭제하거나, 실제 병렬 실행 구현 추가.
+
+---
+
+### H11. `AStarRunner.kt:101-113`, `DijkstraRunner.kt:95-107` — `neighbourId` 함수 완전 중복
+**Tier 4 | 신뢰도: 97%**
+
+`private fun neighbourId(currentId, edge, direction)` 함수가 두 파일에 완전히 동일하게 존재.
+
+**권고**: `algo/` 패키지 내 `GraphAlgoUtils.kt` 파일에 `internal` 함수로 추출.
+
+---
+
+### H12. `VertexLabel.kt:42-118`, `EdgeLabel.kt:47-126` — DSL 메서드 9개 완전 중복
+**Tier 3/4 | 신뢰도: 97%**
+
+`string`, `integer`, `long`, `boolean`, `stringList`, `json`, `localDate`, `localDateTime`, `enum` — 동일 코드 중복.
+
+**권고**:
+```kotlin
+abstract class PropertyHolder {
+    private val _properties = mutableListOf<PropertyDef<*>>()
+    val properties: List<PropertyDef<*>> get() = _properties.toList()
+    fun string(name: String) = PropertyDef<String>(name).also { _properties.add(it) }
+    // ... 나머지 DSL 메서드
+}
+abstract class VertexLabel(val label: String) : PropertyHolder()
+abstract class EdgeLabel(val label: String, val from: VertexLabel, val to: VertexLabel) : PropertyHolder()
+```
+
+---
+
+### H13. `GraphSuspendTraversalRepository` 등 — `fun` vs `suspend fun` 혼용
+**Tier 3 | 신뢰도: 85%**
+
+`suspend` 인터페이스 내에서 `Flow<T>` 반환 메서드는 `fun`으로, `suspend` 반환 메서드는 `suspend fun`으로 선언. 네이밍 컨벤션 없이 혼용되어 구현자가 혼란.
+
+**권고**: Flow-returning 메서드에 KDoc 추가 — "이 함수는 cold Flow 팩토리; 어느 컨텍스트에서나 호출 가능, collect는 코루틴 내에서."
+
+---
+
+### H14. `vt/` 패키지 확장 함수 네이밍 불일치
+**Tier 4 | 신뢰도: 85%**
+
+| 함수 | 현재 |
+|------|------|
+| `VirtualThreadVertexAdapter.kt:66` | `asVirtualThreadVertexRepository()` |
+| `VirtualThreadEdgeAdapter.kt:57` | `asVirtualThreadEdge()` |
+| `VirtualThreadTraversalAdapter.kt:60` | `asVirtualThreadTraversal()` |
+| `VirtualThreadSessionAdapter.kt:35` | `asVirtualThreadSession()` |
+| `VirtualThreadOperationsExt.kt:17` | `asVirtualThread()` |
+
+3가지 네이밍 패턴 혼재. **권고**: 하나의 컨벤션으로 통일.
+
+---
+
+## MEDIUM (고려 사항)
+
+### M1. `PageRankCalculator.kt:71` — 수렴 실패 시 로깅 없음
+반복 cap에 걸려 종료 시 수렴 여부를 알 수 없음. `log.warn { "PageRank did not converge after $iterations iterations" }` 추가 권고.
+
+### M2. `GraphPath.of(vararg vertices)` — `length == 0` 의미론적 오해
+엣지 없는 경로 팩토리라 `length == 0`. 3-hop 경로 모킹 시 혼란. `vertexChainOf()`로 이름 변경 권고.
+
+### M3. `GraphCycleTest.kt:88-93` — `toCycle()` 비순환 path silent failure
+비순환 path로 `toCycle()` 호출해도 예외 없음. 테스트가 이 silent failure를 검증하는 게 아니라 그냥 허용. 테스트 이름 또는 동작 명확화 필요.
+
+### M4. `GraphTraversalOptionsTest.kt` — `PathOptions` 핵심 필드 기본값 미테스트
+`weightProperty`, `missingWeightPolicy`, `maxVisited` 기본값 회귀 테스트 없음.
+
+### M5. `GraphElementId` 기본 생성자 검증 없음
+`GraphElementId("")` 생성 가능. `init { require(value.isNotBlank()) }` 추가 권고.
+
+---
+
+## LOW (정보성)
+
+### L1. `WeightExtractor.kt` — `IllegalArgumentException` 대신 `GraphException` 계층 사용 권고
+도메인 실패를 `GraphException` 서브클래스로 throw하면 경계에서 catch 용이.
+
+### L2. `VirtualThreadOperationsAdapter.kt:43-45` — `close()` no-op KDoc 누락
+`ops.asVirtualThread().use { }` 패턴으로 사용 시 delegate가 닫히지 않음. KDoc에 명시 필요.
+
+### L3. `GraphProperties.toCypherProps` — property key 인터폴레이션 (정보성)
+신뢰된 입력만 사용하도록 KDoc에 이미 명시됨. Backend 콜사이트에서 user-controlled key가 들어오지 않는지 확인 필요.
+
+---
+
+## Anti-Skip Verification
+
+| Task | Status |
+|------|--------|
+| Tier 1 autoresearch:security | ✅ completed |
+| Tier 2 Ops/SRE | ✅ completed |
+| Tier 3 code-review-graph | ✅ completed |
+| Tier 4 code-reviewer | ✅ completed |
+| Tier 5 pr-review-toolkit | ✅ completed |
+| Tier 6 성능/안정성 | ✅ completed |
+| **Final: CRITICAL 3, HIGH 14, MEDIUM 5** | **수정 작업 필요** |
+
+---
+
+## 우선순위별 수정 로드맵
+
+### 즉시 수정 (CRITICAL)
+1. `PageRankCalculatorTest.kt:23` — `shouldBeGreaterThan -0.001` → `shouldBeLessThan 0.001`
+2. `GraphVirtualThreadOperations.kt` — `GraphSession` 상속 제거
+3. `CLAUDE.md` — GraphOperations 구성 설명 수정
+
+### 병합 전 수정 (HIGH — 알고리즘 정확성)
+4. `DijkstraRunner.kt:85`, `AStarRunner.kt:88` — `fetchVertex` 루프 밖 호이스팅 + WARN 로그 추가
+5. `ShortestPathFallback.kt:87` — `.distinctBy { it.id }` 추가
+6. `PageRankCalculator.kt` — 파라미터 검증 + dangling nodes 사전 계산
+7. `CycleDetector.kt` — 재귀 DFS → iterative 전환
+
+### 코드 품질 개선 (HIGH — 구조/패턴)
+8. `ShortestPathFallbackTest.kt` 신규 작성
+9. `CompletableFutureNullableSupport.kt` 패키지 이동
+10. `VertexLabel/EdgeLabel` DSL 중복 → `PropertyHolder` 추출
+11. `AStarRunner/DijkstraRunner` `neighbourId` 함수 → `GraphAlgoUtils.kt` 추출
+12. `VirtualThreadAlgorithmAdapter` KDoc 수정
+13. VT 확장 함수 네이밍 통일

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphBulkExporter.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphBulkExporter.kt
@@ -37,7 +37,10 @@ import io.bluetape4k.graph.io.report.GraphExportReport
  * @see GraphSuspendBulkExporter 코루틴 suspend 변형
  * @see GraphVirtualThreadBulkExporter Virtual Thread 비동기 변형
  */
-interface GraphBulkExporter<T : Any> {
+interface GraphBulkExporter<T : Any> : AutoCloseable {
+
+    override fun close() {}
+
 
     /**
      * 주어진 [sink]로 그래프 데이터를 동기 방식으로 익스포트한다.

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphBulkImporter.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphBulkImporter.kt
@@ -46,7 +46,10 @@ import io.bluetape4k.graph.io.report.GraphImportReport
  * @see GraphSuspendBulkImporter 코루틴 suspend 변형
  * @see GraphVirtualThreadBulkImporter Virtual Thread 비동기 변형
  */
-interface GraphBulkImporter<S : Any> {
+interface GraphBulkImporter<S : Any> : AutoCloseable {
+
+    override fun close() {}
+
 
     /**
      * 주어진 [source]로부터 그래프 데이터를 동기 방식으로 임포트한다.

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphSuspendBulkExporter.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphSuspendBulkExporter.kt
@@ -34,7 +34,10 @@ import io.bluetape4k.graph.io.report.GraphExportReport
  * @see GraphBulkExporter 동기 변형
  * @see GraphVirtualThreadBulkExporter Virtual Thread 비동기 변형
  */
-interface GraphSuspendBulkExporter<T : Any> {
+interface GraphSuspendBulkExporter<T : Any> : AutoCloseable {
+
+    override fun close() {}
+
 
     /**
      * 주어진 [sink]로 그래프 데이터를 코루틴 방식으로 익스포트한다.

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphSuspendBulkImporter.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphSuspendBulkImporter.kt
@@ -34,7 +34,10 @@ import io.bluetape4k.graph.io.report.GraphImportReport
  * @see GraphBulkImporter 동기 변형
  * @see GraphVirtualThreadBulkImporter Virtual Thread 비동기 변형
  */
-interface GraphSuspendBulkImporter<S : Any> {
+interface GraphSuspendBulkImporter<S : Any> : AutoCloseable {
+
+    override fun close() {}
+
 
     /**
      * 주어진 [source]로부터 그래프 데이터를 코루틴 방식으로 임포트한다.

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphVirtualThreadBulkExporter.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphVirtualThreadBulkExporter.kt
@@ -36,7 +36,10 @@ import java.util.concurrent.CompletableFuture
  * @see GraphBulkExporter 동기 변형
  * @see GraphSuspendBulkExporter 코루틴 suspend 변형
  */
-interface GraphVirtualThreadBulkExporter<T : Any> {
+interface GraphVirtualThreadBulkExporter<T : Any> : AutoCloseable {
+
+    override fun close() {}
+
 
     /**
      * 주어진 [sink]로 그래프 데이터를 Virtual Thread에서 비동기로 익스포트한다.

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphVirtualThreadBulkImporter.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/contract/GraphVirtualThreadBulkImporter.kt
@@ -35,7 +35,10 @@ import java.util.concurrent.CompletableFuture
  * @see GraphBulkImporter 동기 변형
  * @see GraphSuspendBulkImporter 코루틴 suspend 변형
  */
-interface GraphVirtualThreadBulkImporter<S : Any> {
+interface GraphVirtualThreadBulkImporter<S : Any> : AutoCloseable {
+
+    override fun close() {}
+
 
     /**
      * 주어진 [source]로부터 그래프 데이터를 Virtual Thread에서 비동기로 임포트한다.

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphExportReport.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphExportReport.kt
@@ -15,6 +15,13 @@ data class GraphExportReport(
     val elapsed: Duration,
     val failures: List<GraphIoFailure> = emptyList(),
 ) : Serializable {
+    init {
+        require(verticesWritten >= 0) { "verticesWritten must be >= 0" }
+        require(edgesWritten >= 0) { "edgesWritten must be >= 0" }
+        require(skippedVertices >= 0) { "skippedVertices must be >= 0" }
+        require(skippedEdges >= 0) { "skippedEdges must be >= 0" }
+    }
+
     companion object : KLogging() {
         private const val serialVersionUID: Long = 1L
     }

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphImportReport.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphImportReport.kt
@@ -12,11 +12,20 @@ data class GraphImportReport(
     val verticesCreated: Long,
     val edgesRead: Long,
     val edgesCreated: Long,
-    val skippedVertices: Long,
-    val skippedEdges: Long,
+    val skippedVertices: Long = 0,
+    val skippedEdges: Long = 0,
     val elapsed: Duration,
     val failures: List<GraphIoFailure> = emptyList(),
 ) : Serializable {
+    init {
+        require(verticesRead >= 0) { "verticesRead must be >= 0" }
+        require(verticesCreated >= 0) { "verticesCreated must be >= 0" }
+        require(edgesRead >= 0) { "edgesRead must be >= 0" }
+        require(edgesCreated >= 0) { "edgesCreated must be >= 0" }
+        require(skippedVertices >= 0) { "skippedVertices must be >= 0" }
+        require(skippedEdges >= 0) { "skippedEdges must be >= 0" }
+    }
+
     companion object : KLogging() {
         private const val serialVersionUID: Long = 1L
     }

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt
@@ -16,6 +16,15 @@ class GraphIoExternalIdMap(
 
     fun contains(externalId: String): Boolean = mapping.containsKey(externalId)
 
+    /**
+     * 이미 [putFirstOrFail]로 등록된 외부 ID의 백엔드 ID를 덮어쓴다.
+     *
+     * 임포터의 2단계 패턴에서 사용된다:
+     * 1. [putFirstOrFail] — 중복 정책 게이트 통과 후 임시 ID를 등록한다.
+     * 2. [put] — 백엔드가 실제 ID를 발급한 뒤 최종 ID로 교체한다.
+     *
+     * 이 메서드는 [putFirstOrFail] 이후에만 호출해야 하며, 신규 삽입용으로 사용하면 안 된다.
+     */
     fun put(externalId: String, backendId: GraphElementId) {
         mapping[externalId] = backendId
     }

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt
@@ -20,9 +20,9 @@ object GraphIoPaths {
         is GraphImportSource.PathSource ->
             Files.newBufferedReader(source.path, source.charset)
         is GraphImportSource.InputStreamSource -> {
-            val reader = BufferedReader(InputStreamReader(source.input, source.charset))
-            if (source.closeInput) reader
-            else object : BufferedReader(reader) {
+            val isr = InputStreamReader(source.input, source.charset)
+            if (source.closeInput) BufferedReader(isr)
+            else object : BufferedReader(isr) {
                 override fun close() { /* caller owns the stream */ }
             }
         }
@@ -38,9 +38,9 @@ object GraphIoPaths {
             Files.newBufferedWriter(sink.path, sink.charset, *opts)
         }
         is GraphExportSink.OutputStreamSink -> {
-            val writer = BufferedWriter(OutputStreamWriter(sink.output, sink.charset))
-            if (sink.closeOutput) writer
-            else object : BufferedWriter(writer) {
+            val osw = OutputStreamWriter(sink.output, sink.charset)
+            if (sink.closeOutput) BufferedWriter(osw)
+            else object : BufferedWriter(osw) {
                 override fun close() { flush() /* caller owns the stream */ }
             }
         }

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
@@ -51,6 +51,39 @@ class GraphIoReportTest {
     }
 
     @Test
+    fun `GraphImportReport rejects negative counts`() {
+        { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `GraphExportReport rejects negative counts`() {
+        { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `GraphImportReport defaults skipped counts to zero`() {
+        val report = GraphImportReport(
+            status = GraphIoStatus.COMPLETED,
+            format = GraphIoFormat.CSV,
+            verticesRead = 10L,
+            verticesCreated = 10L,
+            edgesRead = 5L,
+            edgesCreated = 5L,
+            elapsed = Duration.ofMillis(100),
+        )
+        report.skippedVertices shouldBeEqualTo 0L
+        report.skippedEdges shouldBeEqualTo 0L
+    }
+
+    @Test
     fun `GraphImportReport with failures reflects PARTIAL status`() {
         val failure = GraphIoFailure(
             phase = GraphIoPhase.READ_EDGE,

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
@@ -32,4 +32,37 @@ class GraphIoExternalIdMapTest {
         map.putFirstOrFail("v1", GraphElementId("b")) shouldBeEqualTo GraphIoExternalIdMap.PutResult.SKIPPED
         map.resolve("v1") shouldBeEqualTo first
     }
+
+    @Test
+    fun `put overwrites existing backend id`() {
+        val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+        map.putFirstOrFail("v1", GraphElementId("temp"))
+        map.put("v1", GraphElementId("real"))
+        map.resolve("v1") shouldBeEqualTo GraphElementId("real")
+    }
+
+    @Test
+    fun `contains returns true after putFirstOrFail`() {
+        val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+        map.putFirstOrFail("v1", GraphElementId("a"))
+        map.contains("v1") shouldBeEqualTo true
+        map.contains("v2") shouldBeEqualTo false
+    }
+
+    @Test
+    fun `size reflects number of distinct entries`() {
+        val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+        map.size() shouldBeEqualTo 0
+        map.putFirstOrFail("v1", GraphElementId("a"))
+        map.putFirstOrFail("v2", GraphElementId("b"))
+        map.size() shouldBeEqualTo 2
+        map.put("v1", GraphElementId("a2"))
+        map.size() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `resolve returns null for unknown externalId`() {
+        val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+        map.resolve("nonexistent") shouldBeEqualTo null
+    }
 }

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/testsupport/FakeGraphOperations.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/testsupport/FakeGraphOperations.kt
@@ -30,7 +30,7 @@ class FakeGraphOperations: GraphOperations {
     override fun createGraph(name: String): Unit = error("not used in this test")
     override fun dropGraph(name: String): Unit = error("not used in this test")
     override fun graphExists(name: String): Boolean = error("not used in this test")
-    override fun close(): Unit = error("not used in this test")
+    override fun close(): Unit = Unit
 
     // --- GraphVertexRepository ---
     override fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex =


### PR DESCRIPTION
## 변경 개요

graph-io-core 모듈에 대한 6-tier 코드 리뷰(Logic/API/Type/Test/Concurrency/Performance) 결과를 적용한다.

## 수정 항목

### 정확성 / 버그 픽스
- **`GraphIoPaths` double-buffering 제거**: `InputStreamSource(closeInput=false)` 브랜치에서 `BufferedReader(InputStreamReader(...))`를 다시 `object : BufferedReader(reader)`로 감싸던 이중 버퍼 제거 → ISR 직접 래핑으로 변경 (openWriter도 동일)
- **`FakeGraphOperations.close()` 트랩 제거**: `error()` → `Unit`으로 변경하여 `use {}` 블록과 호환되도록 수정

### API 설계 개선
- **6개 bulk-IO 인터페이스에 `AutoCloseable` 추가**: `GraphBulkImporter/Exporter`, `GraphSuspendBulkImporter/Exporter`, `GraphVirtualThreadBulkImporter/Exporter` 모두 `AutoCloseable` 구현 (기본 no-op `close() {}`)

### 타입 불변식 강화
- **`GraphImportReport` init 검증**: 모든 카운트 필드(verticesRead/Created, edgesRead/Created, skippedVertices/Edges) 음수 거부
- **`GraphImportReport` skipped 기본값**: `skippedVertices = 0`, `skippedEdges = 0` 기본값 추가 (GraphExportReport와 일관성)
- **`GraphExportReport` init 검증**: 카운트 필드 음수 거부

### 문서화
- **`GraphIoExternalIdMap.put()` KDoc**: 임포터의 2단계 패턴(putFirstOrFail → createVertex → put) 설명 추가

### 테스트 커버리지
- **`GraphIoExternalIdMapTest`**: `put()` 덮어쓰기, `contains()`, `size()`, `resolve(null)` 테스트 추가 (4건)
- **`GraphIoReportTest`**: 음수 카운트 거부 + GraphImportReport 기본값 테스트 추가 (3건)

## 테스트 결과

```
./gradlew :graph-io-core:test
72 passing (1.7s)
```

하위 모듈(csv, jackson2, jackson3, graphml, okio) 컴파일 확인 완료.

## 미적용 항목 (다음 PR 또는 별도 이슈)

- `importGraphSuspending` → `importGraph` 리네임 (breaking change, 다른 모듈 영향)
- `DuplicateVertexPolicy.SKIP` → `SKIP_VERTEX` 리네임 (breaking change)
- `Jackson2NdJsonBulkImporter` createVertex-before-putFirstOrFail 순서 이슈 (graph-io/jackson2 모듈)