### PR TITLE
fix/perf/test/docs: 스케줄 코드 리뷰 — AStarRunner 성능·불변식·테스트 보강 (#62)

### DIFF
--- a/graph-io/core/README.ko.md
+++ b/graph-io/core/README.ko.md
@@ -81,9 +81,9 @@ data class GraphImportReport(
     val status: GraphIoStatus,                // COMPLETED | PARTIAL | FAILED
     val format: GraphIoFormat,                // CSV | NDJSON_JACKSON2 | NDJSON_JACKSON3 | GRAPHML
     val verticesRead: Long,
-    val verticesCreated: Long,
+    val verticesCreated: Long,                // invariant: verticesCreated <= verticesRead
     val edgesRead: Long,
-    val edgesCreated: Long,
+    val edgesCreated: Long,                   // invariant: edgesCreated <= edgesRead
     val skippedVertices: Long,
     val skippedEdges: Long,
     val elapsed: Duration,

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphExportReport.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphExportReport.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.graph.io.report
 
-import io.bluetape4k.logging.KLogging
 import java.io.Serializable
 import java.time.Duration
 
@@ -41,7 +40,7 @@ data class GraphExportReport(
         require(skippedEdges >= 0) { "skippedEdges must be >= 0" }
     }
 
-    companion object : KLogging() {
+    companion object {
         private const val serialVersionUID: Long = 1L
     }
 }

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphImportReport.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/report/GraphImportReport.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.graph.io.report
 
-import io.bluetape4k.logging.KLogging
 import java.io.Serializable
 import java.time.Duration
 
@@ -45,9 +44,15 @@ data class GraphImportReport(
         require(edgesCreated >= 0) { "edgesCreated must be >= 0" }
         require(skippedVertices >= 0) { "skippedVertices must be >= 0" }
         require(skippedEdges >= 0) { "skippedEdges must be >= 0" }
+        require(verticesCreated <= verticesRead) {
+            "verticesCreated ($verticesCreated) must be <= verticesRead ($verticesRead)"
+        }
+        require(edgesCreated <= edgesRead) {
+            "edgesCreated ($edgesCreated) must be <= edgesRead ($edgesRead)"
+        }
     }
 
-    companion object : KLogging() {
+    companion object {
         private const val serialVersionUID: Long = 1L
     }
 }

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt
@@ -43,6 +43,18 @@ class GraphIoExternalIdMap(
         mapping[externalId] = backendId
     }
 
+    /**
+     * 외부 ID를 처음 등록하거나 중복 정책을 적용한다.
+     *
+     * - 신규 ID: 맵에 삽입하고 [PutResult.CREATED]를 반환한다.
+     * - 중복 ID + [DuplicateVertexPolicy.SKIP]: [PutResult.SKIPPED]를 반환한다.
+     * - 중복 ID + [DuplicateVertexPolicy.FAIL]: 예외를 던진다.
+     *
+     * @param externalId 등록할 외부 ID.
+     * @param backendId 백엔드가 발급한 초기 ID.
+     * @return [PutResult.CREATED] (신규 삽입) 또는 [PutResult.SKIPPED] (중복, Skip 정책).
+     * @throws IllegalStateException [DuplicateVertexPolicy.FAIL]이고 동일 [externalId]가 이미 등록된 경우.
+     */
     fun putFirstOrFail(externalId: String, backendId: GraphElementId): PutResult {
         val existing = mapping[externalId]
         if (existing == null) {
@@ -64,9 +76,7 @@ class GraphIoExternalIdMap(
     fun resolve(externalId: String): GraphElementId? = mapping[externalId]
 
     /**
-     * 현재 등록된 외부 ID 수를 반환한다.
-     *
-     * @return 외부 ID 기준 매핑 항목 수.
+     * 현재 등록된 외부 ID 수.
      */
-    fun size(): Int = mapping.size
+    val size: Int get() = mapping.size
 }

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt
@@ -6,6 +6,7 @@ import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.BufferedReader
 import java.io.BufferedWriter
+import java.io.FilterInputStream
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.OutputStream
@@ -83,10 +84,9 @@ object GraphIoPaths {
         is GraphImportSource.PathSource -> BufferedInputStream(Files.newInputStream(source.path))
         is GraphImportSource.InputStreamSource ->
             if (source.closeInput) source.input
-            else object : InputStream() {
-                override fun read(): Int = source.input.read()
-                override fun read(b: ByteArray, off: Int, len: Int) = source.input.read(b, off, len)
-                override fun available() = source.input.available()
+            // FilterInputStream이 skip/mark/reset/available 등을 자동 위임하므로
+            // close()만 억제하면 된다.
+            else object : FilterInputStream(source.input) {
                 override fun close() { /* caller owns the stream */ }
             }
     }

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
@@ -52,12 +52,12 @@ class GraphIoExternalIdMapTest {
     @Test
     fun `size reflects number of distinct entries`() {
         val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
-        map.size() shouldBeEqualTo 0
+        map.size shouldBeEqualTo 0
         map.putFirstOrFail("v1", GraphElementId("a"))
         map.putFirstOrFail("v2", GraphElementId("b"))
-        map.size() shouldBeEqualTo 2
+        map.size shouldBeEqualTo 2
         map.put("v1", GraphElementId("a2"))
-        map.size() shouldBeEqualTo 2
+        map.size shouldBeEqualTo 2
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoPathsTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoPathsTest.kt
@@ -128,6 +128,15 @@ class GraphIoPathsTest {
     // ── openOutputStream ─────────────────────────────────────────────────────
 
     @Test
+    fun `openOutputStream creates parent directory for path sink`(@TempDir dir: Path) {
+        val nested = dir.resolve("sub/dir/out.bin")
+        GraphIoPaths.openOutputStream(GraphExportSink.PathSink(nested, append = false)).use { s ->
+            s.write(byteArrayOf(1))
+        }
+        Files.exists(nested) shouldBeEqualTo true
+    }
+
+    @Test
     fun `openOutputStream writes to path sink append=false`(@TempDir dir: Path) {
         val file = dir.resolve("out.bin").also { Files.write(it, byteArrayOf(99)) }
         GraphIoPaths.openOutputStream(GraphExportSink.PathSink(file, append = false)).use { s ->

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
@@ -29,6 +29,14 @@ class AStarRunner(
 ) {
     companion object : KLogging()
 
+    /** PriorityQueue 엔트리 — Triple 대비 박싱 2회 절감 */
+    private data class AStarNode(val f: Double, val g: Double, val id: GraphElementId) : Comparable<AStarNode> {
+        override fun compareTo(other: AStarNode): Int {
+            val cmp = f.compareTo(other.f)
+            return if (cmp != 0) cmp else id.value.compareTo(other.id.value)
+        }
+    }
+
     /**
      * A* 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.
      *
@@ -48,18 +56,15 @@ class AStarRunner(
         }
         val extractor = WeightExtractor(weightProperty, options.missingWeightPolicy)
 
-        // f = g + h; tie-break: vertexId 사전순
-        val pq = PriorityQueue(
-            compareBy<Triple<Double, Double, GraphElementId>> { it.first }
-                .thenComparing { a, b -> a.third.value.compareTo(b.third.value) }
-        )
+        // f = g + h; AStarNode: Comparable — Comparator 불필요
+        val pq = PriorityQueue<AStarNode>()
         val gScore = mutableMapOf<GraphElementId, Double>()
         val cameFrom = mutableMapOf<GraphElementId, Pair<GraphVertex, GraphEdge>>()
 
         gScore[fromId] = 0.0
         val startVertex = fetchVertex(fromId) ?: return null
         val h0 = heuristic(startVertex)
-        pq.add(Triple(h0, 0.0, fromId))
+        pq.add(AStarNode(h0, 0.0, fromId))
         var visited = 0
 
         outer@ while (pq.isNotEmpty()) {
@@ -92,9 +97,12 @@ class AStarRunner(
                     gScore[neighborId] = tentativeG
                     cameFrom[neighborId] = currentVertex to edge
 
-                    val neighbor = fetchVertex(neighborId) ?: continue
+                    val neighbor = fetchVertex(neighborId) ?: run {
+                        log.warn { "A*: fetchVertex($neighborId) returned null — neighbor dropped from frontier" }
+                        continue
+                    }
                     val f = tentativeG + heuristic(neighbor)
-                    pq.add(Triple(f, tentativeG, neighborId))
+                    pq.add(AStarNode(f, tentativeG, neighborId))
                 }
             }
         }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
@@ -26,7 +26,12 @@ class DijkstraRunner(
     private val fetchEdges: (GraphElementId) -> List<GraphEdge>,
     private val fetchVertex: (GraphElementId) -> GraphVertex?,
 ) {
-    companion object : KLogging()
+    companion object : KLogging() {
+        /** (cost, vertexId) PriorityQueue 비교자 — run() 호출마다 재생성 방지 */
+        private val NODE_ORDER: Comparator<Pair<Double, GraphElementId>> =
+            compareBy<Pair<Double, GraphElementId>> { it.first }
+                .thenComparing { a, b -> a.second.value.compareTo(b.second.value) }
+    }
 
     /**
      * Dijkstra 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.
@@ -48,10 +53,7 @@ class DijkstraRunner(
         val extractor = WeightExtractor(weightProperty, options.missingWeightPolicy)
 
         // (cost, vertexId) — tie-break은 vertexId 사전순
-        val pq = PriorityQueue(
-            compareBy<Pair<Double, GraphElementId>> { it.first }
-                .thenComparing { a, b -> a.second.value.compareTo(b.second.value) }
-        )
+        val pq = PriorityQueue(NODE_ORDER)
         val dist = mutableMapOf<GraphElementId, Double>()
         val cameFrom = mutableMapOf<GraphElementId, Pair<GraphVertex, GraphEdge>>()
 

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculator.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculator.kt
@@ -25,12 +25,17 @@ import kotlin.math.abs
  */
 object PageRankCalculator : KLogging() {
 
+    private const val HASH_LOAD_FACTOR = 0.75
+
     /**
+     * 정규화된 PageRank 점수를 계산한다.
+     *
      * @param vertices 전체 정점 ID 집합.
-     * @param outAdjacency out-edge 인접 리스트.
-     * @param iterations 최대 반복 횟수.
-     * @param dampingFactor 감쇠 계수 (보통 0.85).
-     * @param tolerance L1-norm 수렴 허용치.
+     * @param outAdjacency out-edge 인접 리스트. 집합에 없는 정점을 참조해서는 안 된다.
+     * @param iterations 최대 반복 횟수. 양수여야 한다.
+     * @param dampingFactor 감쇠 계수. [0.0, 1.0] 범위. 보통 0.85.
+     * @param tolerance 조기 종료 L1-norm 허용치. 양수여야 한다.
+     * @return 정점별 PageRank 점수 맵. 합계 ≈ 1.0.
      */
     fun compute(
         vertices: Set<GraphElementId>,
@@ -46,8 +51,8 @@ object PageRankCalculator : KLogging() {
         if (vertices.isEmpty()) return emptyMap()
 
         val n = vertices.size
-        // HashMap rehash 방지: loadFactor(0.75) 기준으로 초기 용량 설정
-        val mapCapacity = ((n / 0.75f) + 1).toInt()
+        // HashMap rehash 방지: Double 나눗셈으로 정밀도 확보 (0.75f 는 n≥25M 에서 under-provision)
+        val mapCapacity = ((n / HASH_LOAD_FACTOR) + 1).toInt()
         val initial = 1.0 / n
         var ranks = HashMap<GraphElementId, Double>(mapCapacity)
         vertices.forEach { ranks[it] = initial }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.graph.algo
 
+import io.bluetape4k.graph.model.Direction
 import io.bluetape4k.graph.model.GraphEdge
 import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.GraphVertex
@@ -162,12 +163,50 @@ class AStarRunnerTest {
         path.totalWeight.shouldBeNear(2.0, 0.001)
     }
 
-    // ─── weightProperty 필수 ─────────────────────────────────────────────────────
+    // ─── weightProperty 필수 ──────────────────────────────────────────────────���──
 
     @Test
     fun `weightProperty 없으면 IllegalArgumentException 발생`() {
         val block: () -> Unit = { runner().run(id("A"), id("C"), PathOptions()) }
         block shouldThrow IllegalArgumentException::class
+    }
+
+    // ─── Direction.BOTH ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `Direction BOTH에서 역방향 경로 탐색`() {
+        // C→A 방향으로 탐색: 단방향 그래프이므로 역방향 간선을 제공
+        val bothRunner = AStarRunner(
+            fetchEdges = { id ->
+                val outgoing = mainGraph[id.value] ?: emptyList()
+                val incoming = mainGraph.values.flatten().filter { it.endId == id }
+                (outgoing + incoming).distinctBy { it.id }
+            },
+            fetchVertex = { vid -> vertices[vid.value] },
+            heuristic = { v -> euclidean(v, "A") },
+        )
+        val opts = PathOptions(weightProperty = "cost", direction = Direction.BOTH)
+        // C에서 A로 역방향: BOTH 모드에서는 B→A 역방향 간선을 활용
+        val path = bothRunner.run(id("C"), id("A"), opts).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(2.0, 0.001)
+    }
+
+    // ─── null neighbor mid-traversal ───────────────────────────────────────────
+
+    @Test
+    fun `이웃 정점이 없으면 해당 이웃을 건너뛰고 대체 경로 탐색`() {
+        // B를 fetchVertex에서 제외 → A→B 경로 사용 불가, A→C(직선)만 사용
+        val partialVertices = mapOf("A" to vertex("A"), "C" to vertex("C"))
+        val partialRunner = AStarRunner(
+            fetchEdges = { vid -> mainGraph[vid.value] ?: emptyList() },
+            fetchVertex = { vid -> partialVertices[vid.value] },
+            heuristic = { v -> euclidean(v, "C") },
+        )
+        val path = partialRunner.run(id("A"), id("C"), options()).shouldNotBeNull()
+
+        // A→B 경로에서 B 정점을 찾지 못하므로 A→C 직선 경로(cost=3.0)만 유효
+        path.totalWeight.shouldBeNear(3.0, 0.001)
     }
 
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────────

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculatorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculatorTest.kt
@@ -114,4 +114,19 @@ class PageRankCalculatorTest {
         val scores = compute(vertices = outAdj.keys, outAdjacency = outAdj)
         scores.getValue(id("b")) shouldBeGreaterThan scores.getValue(id("a"))
     }
+
+    // ─── 비수렴 경계 케이스 ────────────────────────────────────────────────────────
+
+    @Test
+    fun `반복 횟수 소진 시 부분 결과를 반환한다`() {
+        val verts = setOf(id("a"), id("b"))
+        val outAdj = mapOf(id("a") to listOf(id("b")), id("b") to listOf(id("a")))
+        // iterations=1, tolerance=극소 → 1회 반복으로 수렴 불가
+        val scores = compute(vertices = verts, outAdjacency = outAdj, iterations = 1, tolerance = 1e-12)
+
+        // 수렴 없어도 결과 맵은 반환됨
+        scores.size shouldBeEqualTo 2
+        val sum = scores.values.sum()
+        abs(sum - 1.0) shouldBeLessThan 0.01 // 아직 완전 정규화 전이라도 합≈1
+    }
 }


### PR DESCRIPTION
## 작업 배경

스케줄 코드 리뷰 (2026-05-02) — 지난 24시간 변경분(3e21eda) 대상 6-tier 코드 리뷰 결과 반영.

## 변경 내용

### 성능 개선 (HIGH)
- **AStarRunner Triple→AStarNode 교체**: PriorityQueue 엔트리당 박싱 3→1회로 절감
- **DijkstraRunner Comparator 캐싱**: `NODE_ORDER` companion val으로 run() 호출마다 재생성 방지
- **PageRankCalculator `0.75f`→`0.75` 수정**: Float 정밀도 부족으로 n≥25M에서 HashMap under-provision 버그 수정, `HASH_LOAD_FACTOR` 상수 추출

### 버그 수정 (HIGH)
- **AStarRunner 이웃 null 경고 누락**: line 95 `neighbor ?: continue` 에 `log.warn` 추가 (currentVertex 처리와 대칭)

### 코드 품질 (MEDIUM)
- **GraphIoPaths.openInputStream**: anonymous InputStream → `FilterInputStream` 교체 (skip/mark/reset 자동 위임)
- **GraphIoExternalIdMap.size()**: 함수 → `val size` 프로퍼티
- **GraphImportReport 불변식**: `verticesCreated <= verticesRead`, `edgesCreated <= edgesRead` 검증 추가
- **GraphExportReport/GraphImportReport**: 미사용 `KLogging` companion 제거

### KDoc 강화 (MEDIUM)
- `PageRankCalculator.compute()` — 독립 KDoc 블록 분리, `@return` 추가
- `GraphIoExternalIdMap.putFirstOrFail` — `@param/@return/@throws` 추가

### 테스트 보강 (HIGH)
- `AStarRunnerTest`: Direction.BOTH 역방향 경로 + null neighbor mid-traversal 케이스 추가
- `PageRankCalculatorTest`: 비수렴(반복 소진) 케이스 추가
- `GraphIoPathsTest`: openOutputStream 부모 디렉토리 생성 테스트 추가
- `GraphIoExternalIdMapTest`: `size()` → `size` 프로퍼티 호출 업데이트

### README 최신화
- graph-io-core/README.ko.md: GraphImportReport 불변식 주석 추가

## 테스트 결과

| 모듈 | 통과 | 실패 |
|------|------|------|
| graph-core | 249 | 0 |
| graph-io-core | 74 | 0 |

## 6-Tier 코드 리뷰 요약

| Tier | 도구 | 주요 발견 | 조치 |
|------|------|----------|------|
| Tier 1 Security | autoresearch:security | HIGH: PageRankCalculator HashMap capacity overflow (0.75f); MEDIUM: maxVisited 미검증 | ✅ 0.75f→0.75 수정 |
| Tier 2 Ops/SRE | Ops Agent | MEDIUM: AStarRunner null neighbor 무로그; MEDIUM: close() 예외 처리 | ✅ 경고 로그 추가 |
| Tier 3 구조적 영향 | code-review-graph | N/A (그래프 미빌드) | ⏭️ 스킵 |
| Tier 4 Kotlin 패턴 | code-reviewer | HIGH: AStarRunner Triple PQ 박싱; MEDIUM: size() 함수 → 프로퍼티 | ✅ 모두 수정 |
| Tier 5 테스트 품질 | pr-review-toolkit | HIGH: Direction.BOTH 테스트 누락; MEDIUM: null neighbor 테스트 | ✅ 테스트 추가 |
| Tier 6 성능 | perf agent | HIGH: Float precision bug; HIGH: Triple 박싱 | ✅ 모두 수정 |
| **종합** | | **CRITICAL 0, HIGH 0** | **✅ 준비 완료** |

## 커밋

```
58c8b9a fix/perf/test/docs: 스케줄 코드 리뷰 — 성능·불변식·테스트 보강 (#62)
```