### PR TITLE
fix/docs/test: 스케줄 코드 리뷰 — put 무결성 가드, KDoc 예제 보강

### DIFF
--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt
@@ -10,6 +10,26 @@ import io.bluetape4k.graph.model.GraphElementId
  * 임포트 작업 중 외부 소스의 ID를 백엔드 그래프 DB가 발급한 실제 ID에 매핑하기 위해 사용된다.
  * 단일 스레드 임포트 컨텍스트에서만 사용해야 한다.
  *
+ * ### 사용 예제 — 임포터의 2단계 패턴
+ *
+ * ```kotlin
+ * val idMap = GraphIoExternalIdMap(DuplicateVertexPolicy.SKIP)
+ *
+ * for (record in vertexRecords) {
+ *     val externalId = record.id
+ *     // 1) 중복 정책 게이트 — 임시 ID(externalId 자체)로 등록
+ *     val result = idMap.putFirstOrFail(externalId, GraphElementId(externalId))
+ *     if (result == GraphIoExternalIdMap.PutResult.SKIPPED) continue
+ *
+ *     // 2) 백엔드에서 실제 ID 발급 후 매핑 갱신
+ *     val created = operations.createVertex(record.label, record.properties)
+ *     idMap.put(externalId, created.id)
+ * }
+ *
+ * // 엣지 패스에서 외부 ID → 실제 백엔드 ID 해소
+ * val backendId = idMap.resolve(externalIdFromEdge)
+ * ```
+ *
  * @param duplicatePolicy 동일 외부 ID가 두 번 이상 등장할 때의 처리 정책.
  */
 class GraphIoExternalIdMap(
@@ -38,8 +58,14 @@ class GraphIoExternalIdMap(
      * 2. [put] — 백엔드가 실제 ID를 발급한 뒤 최종 ID로 교체한다.
      *
      * 이 메서드는 [putFirstOrFail] 이후에만 호출해야 하며, 신규 삽입용으로 사용하면 안 된다.
+     *
+     * @throws IllegalStateException [externalId]가 [putFirstOrFail]로 등록되지 않은 경우.
+     *   [DuplicateVertexPolicy]를 우회하는 무결성 위반을 조기에 감지하기 위함.
      */
     fun put(externalId: String, backendId: GraphElementId) {
+        check(mapping.containsKey(externalId)) {
+            "put('$externalId', ...) called before putFirstOrFail() — duplicate policy bypass risk"
+        }
         mapping[externalId] = backendId
     }
 

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt
@@ -20,6 +20,30 @@ import java.nio.file.StandardOpenOption
  *
  * 모든 `close*` 플래그가 `false`인 경우, 반환된 스트림/리더/라이터를 닫아도
  * underlying 스트림이 닫히지 않는다. 스트림 소유권은 호출자가 유지한다.
+ *
+ * ### 사용 예제
+ *
+ * ```kotlin
+ * // PathSource 읽기 — Files.newBufferedReader 위임 + 호출자가 close 책임
+ * val source = GraphImportSource.PathSource(Path.of("vertices.csv"))
+ * GraphIoPaths.openReader(source).use { reader ->
+ *     reader.lineSequence().forEach { println(it) }
+ * }
+ *
+ * // PathSink 쓰기 — 부모 디렉터리 자동 생성, append 모드 지원
+ * val sink = GraphExportSink.PathSink(
+ *     path = Path.of("out/2026/data.ndjson"),  // out/2026 자동 생성
+ *     append = false,
+ * )
+ * GraphIoPaths.openOutputStream(sink).use { os ->
+ *     os.write(payload)
+ * }
+ *
+ * // OutputStreamSink with closeOutput=false — 호출자가 스트림 소유권 유지
+ * val external = ByteArrayOutputStream()
+ * val sink2 = GraphExportSink.OutputStreamSink(external, closeOutput = false)
+ * GraphIoPaths.openWriter(sink2).use { it.write("data") }  // flush only, external 미닫음
+ * ```
  */
 object GraphIoPaths {
 

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
@@ -65,4 +65,22 @@ class GraphIoExternalIdMapTest {
         val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
         map.resolve("nonexistent") shouldBeEqualTo null
     }
+
+    @Test
+    fun `put without putFirstOrFail throws IllegalStateException`() {
+        val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+        val action = { map.put("never-registered", GraphElementId("real")) }
+        action shouldThrow IllegalStateException::class
+    }
+
+    @Test
+    fun `put after SKIPPED entry still allowed because mapping retains the first id`() {
+        val map = GraphIoExternalIdMap(DuplicateVertexPolicy.SKIP)
+        map.putFirstOrFail("v1", GraphElementId("first"))
+        // SKIPPED 호출은 매핑을 변경하지 않지만 v1은 putFirstOrFail로 이미 등록됨
+        map.putFirstOrFail("v1", GraphElementId("ignored")) shouldBeEqualTo GraphIoExternalIdMap.PutResult.SKIPPED
+        // put은 v1이 등록되어 있으므로 안전
+        map.put("v1", GraphElementId("backend"))
+        map.resolve("v1") shouldBeEqualTo GraphElementId("backend")
+    }
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
@@ -18,6 +18,30 @@ import java.util.*
  * - 허용 가능(admissible) 휴리스틱: `h(n) <= 실제_비용(n, goal)`. 위반 시 최적성 보장 불가.
  * - tie-break은 DijkstraRunner와 동일하게 vertexId 사전순.
  *
+ * ### 사용 예제
+ *
+ * ```kotlin
+ * // 좌표 기반 유클리드 휴리스틱 — 2D 격자에서 admissible
+ * val coords: Map<String, Pair<Double, Double>> = ...
+ * val goalId = "C"
+ *
+ * val runner = AStarRunner(
+ *     fetchEdges = { id -> ops.outgoingEdges(id) },
+ *     fetchVertex = { id -> ops.findVertex(id) },
+ *     heuristic = { v ->
+ *         val (vx, vy) = coords[v.id.value] ?: (0.0 to 0.0)
+ *         val (gx, gy) = coords[goalId] ?: (0.0 to 0.0)
+ *         sqrt((vx - gx).pow(2) + (vy - gy).pow(2))
+ *     },
+ * )
+ *
+ * val path: GraphPath? = runner.run(
+ *     fromId = GraphElementId("A"),
+ *     toId = GraphElementId(goalId),
+ *     options = PathOptions(weightProperty = "cost", maxVisited = 100_000),
+ * )
+ * ```
+ *
  * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수.
  * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
  * @param heuristic 목표 정점까지의 예상 비용 함수. 반드시 허용 가능해야 한다.

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
@@ -19,6 +19,27 @@ import java.util.*
  * - **maxVisited 보호**: 무한 그래프에서의 무한 확장을 방지한다.
  * - **Direction 지원**: OUTGOING, INCOMING, BOTH 모두 지원한다.
  *
+ * ### 사용 예제
+ *
+ * ```kotlin
+ * val runner = DijkstraRunner(
+ *     fetchEdges = { id -> ops.outgoingEdges(id) },
+ *     fetchVertex = { id -> ops.findVertex(id) },
+ * )
+ *
+ * val path: GraphPath? = runner.run(
+ *     fromId = GraphElementId("A"),
+ *     toId = GraphElementId("Z"),
+ *     options = PathOptions(
+ *         weightProperty = "cost",
+ *         missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0),
+ *         maxVisited = 100_000,
+ *     ),
+ * )
+ *
+ * path?.let { println("총 비용=${it.totalWeight}, 경로 길이=${it.steps.size}") }
+ * ```
+ *
  * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수. [Direction]은 호출 전 적용되어야 한다.
  * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
  */


### PR DESCRIPTION
## 요약

지난 24시간(`982670d`, `c0a4dff`) 변경에 대한 스케줄 코드 리뷰 후속 보강. PR #62가 이미 성능/불변식/테스트 갭을 처리한 상태이므로, 이번 리뷰에서는 잔여 [MEDIUM-HIGH] 항목 2건만 수정한다.

## 변경 내용

### 🐛 버그 수정 — `GraphIoExternalIdMap.put` 무결성 가드 (HIGH)

**문제.** `put`은 \"`putFirstOrFail` 이후에만 호출\"되는 두 단계 패턴의 두 번째 단계인데, 사전조건이 코드로 강제되지 않아 신규 키에 대해 호출하면 `DuplicateVertexPolicy` 게이트를 우회한 채 매핑에 삽입되었다. 무결성 위반이 임포트 후의 잘못된 데이터로만 표면화되는 위험.

**수정.**
\`\`\`kotlin
fun put(externalId: String, backendId: GraphElementId) {
    check(mapping.containsKey(externalId)) {
        \"put('\$externalId', ...) called before putFirstOrFail() — duplicate policy bypass risk\"
    }
    mapping[externalId] = backendId
}
\`\`\`

기존 임포터 4종(`CsvGraphBulkImporter`, `Jackson2NdJsonBulkImporter`, `Jackson3NdJsonBulkImporter`, `GraphMlBulkImporter` + 각 Suspend 변형)은 모두 \`putFirstOrFail → put\` 순서를 지키므로 영향 없음.

### 📚 KDoc 사용 예제 보강 (MEDIUM)

`PageRankCalculator`의 \`### 사용 예제\` 패턴을 다음 4곳으로 확산:

| 파일 | 추가 예제 |
|------|----------|
| `graph-core/AStarRunner.kt` | 좌표 기반 유클리드 admissible 휴리스틱 |
| `graph-core/DijkstraRunner.kt` | `PathOptions` + `MissingWeightPolicy.UseDefault` |
| `graph-io-core/GraphIoExternalIdMap.kt` | 임포터의 2단계 패턴 (putFirstOrFail → createVertex → put) |
| `graph-io-core/GraphIoPaths.kt` | PathSource 읽기, PathSink 쓰기(부모 디렉터리 자동 생성), closeOutput=false 호출자 소유권 |

### ✅ 테스트 보강 (HIGH)

`GraphIoExternalIdMapTest`에 사전조건 위반 케이스 2개 추가:
- \`put without putFirstOrFail throws IllegalStateException\`
- \`put after SKIPPED entry still allowed\` — 첫 \`putFirstOrFail\` 후 SKIPPED 호출 시에도 매핑이 등록 상태이므로 \`put\` 안전성 검증

## 검증

- \`./gradlew :graph-core:test --rerun-tasks\` — **249 tests SUCCESS**
- \`./gradlew :graph-io-core:test\` — **76 tests SUCCESS**

## 변경 파일

\`\`\`
graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMap.kt   | 26 ++++
graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/support/GraphIoPaths.kt           | 24 ++
graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt | 18 +
graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt               | 24 ++
graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt            | 21 +
\`\`\`

## 리뷰 요청 항목

이번 변경은 **public API 동작을 보존**한다 — `put`의 사전조건은 기존 호출 시퀀스(`putFirstOrFail → put`)에서 이미 만족됨. 다만 외부 사용자가 직접 `put`을 신규 삽입에 쓰던 경우(문서상 금지였으나 정책상 허용됐음)에는 명시적 실패로 변경된다.