### PR TITLE
docs: KDoc API 이름 정정 + README 2단계 패턴 보강

### DIFF
--- a/graph-io/core/README.md
+++ b/graph-io/core/README.md
@@ -117,7 +117,7 @@ data class GraphIoFailure(
 ### Support Helpers (`io.bluetape4k.graph.io.support`)
 
 - **`GraphIoPaths`** — opens `BufferedReader`/`BufferedWriter`/`InputStream`/`OutputStream` for any `GraphImportSource`/`GraphExportSink`, auto-creates parent directories for `PathSink`, honours the `closeInput`/`closeOutput` flag for caller-owned streams.
-- **`GraphIoExternalIdMap`** — tracks external ID → backend `GraphElementId` mappings during import and enforces `DuplicateVertexPolicy` (`FAIL` or `SKIP`).
+- **`GraphIoExternalIdMap`** — tracks external ID → backend `GraphElementId` mappings during import and enforces `DuplicateVertexPolicy` (`FAIL` or `SKIP`). Importers follow a 2-step pattern: `putFirstOrFail()` gates the duplicate policy with a temporary ID, then `put()` overwrites with the backend-issued ID. Calling `put()` before `putFirstOrFail()` throws `IllegalStateException` to surface duplicate-policy bypass at the caller site.
 - **`GraphIoStopwatch`** — millisecond-precision timer used by format importers/exporters to populate `report.elapsed`.
 - **`VirtualThreadGraphBulkAdapter`** — wraps a sync `GraphBulkImporter`/`GraphBulkExporter` as a Virtual-Thread-backed async variant via `CompletableFuture`.
 

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
@@ -26,8 +26,8 @@ import java.util.*
  * val goalId = "C"
  *
  * val runner = AStarRunner(
- *     fetchEdges = { id -> ops.outgoingEdges(id) },
- *     fetchVertex = { id -> ops.findVertex(id) },
+ *     fetchEdges = { id -> ops.findEdgesByStartId(id) },
+ *     fetchVertex = { id -> ops.findVertexById(id) },
  *     heuristic = { v ->
  *         val (vx, vy) = coords[v.id.value] ?: (0.0 to 0.0)
  *         val (gx, gy) = coords[goalId] ?: (0.0 to 0.0)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
@@ -23,8 +23,8 @@ import java.util.*
  *
  * ```kotlin
  * val runner = DijkstraRunner(
- *     fetchEdges = { id -> ops.outgoingEdges(id) },
- *     fetchVertex = { id -> ops.findVertex(id) },
+ *     fetchEdges = { id -> ops.findEdgesByStartId(id) },
+ *     fetchVertex = { id -> ops.findVertexById(id) },
  * )
  *
  * val path: GraphPath? = runner.run(


### PR DESCRIPTION
## Summary

스케줄 코드 리뷰(`bluetape4k-graph-code-review`) 후속 — 지난 24시간 내 변경(PR #64) 검토 결과 발견한 문서 결함을 수정한다.

## Changes

### 1. `AStarRunner` / `DijkstraRunner` KDoc 예제 수정
`comment-analyzer` 에이전트가 PR #64에서 추가된 KDoc 예제의 메서드명 오류 발견. `GraphOperations`에 존재하지 않는 메서드를 참조하고 있어 사용자가 복붙 시 `unresolved reference` 발생.

| Before | After |
|--------|-------|
| `ops.outgoingEdges(id)` | `ops.findEdgesByStartId(id)` |
| `ops.findVertex(id)` | `ops.findVertexById(id)` |

실제 API: `GraphEdgeRepository.findEdgesByStartId(GraphElementId, String?)`, `GraphVertexRepository.findVertexById(GraphElementId)`.

### 2. `graph-io/core/README.md` — `GraphIoExternalIdMap` 설명 보강
PR #64에서 도입된 `put()` 무결성 가드를 사용자 문서에 1줄로 반영:
- 임포터의 2단계 패턴(`putFirstOrFail` → `put`) 명시
- `put()` 선행 호출 누락 시 `IllegalStateException` 발생을 명시 — duplicate-policy bypass를 호출 시점에 발견

## Verification

- `pr-review-toolkit:silent-failure-hunter`: clean (PR #64 변경 모두 양호)
- `pr-review-toolkit:comment-analyzer`: 위 메서드명 오류만 발견, 그 외 KDoc 정확성 OK
- `./gradlew :graph-io-core:test --tests GraphIoExternalIdMapTest` — 9 tests PASSED
- `./gradlew :graph-core:compileKotlin` — BUILD SUCCESSFUL

## Test Plan

- [x] 단위 테스트 통과
- [x] graph-core 컴파일 통과
- [x] CI green (PR 생성 후 확인)

🤖 Generated by scheduled task `bluetape4k-graph-code-review`