### PR TITLE
chore: CI paths-filter 적용 및 Docker jobs + retry=3 추가 (#67)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ on:
       - 'LICENSE'
       - '.omc/**'
       - '.claude/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,12 +66,54 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4
 
-  # ── 2. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
+  # ── 2. paths-filter ───────────────────────────────────────────────────────
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: validate-wrapper
+    outputs:
+      graph-core: ${{ steps.filter.outputs.graph-core }}
+      graph-neo4j: ${{ steps.filter.outputs.graph-neo4j }}
+      graph-memgraph: ${{ steps.filter.outputs.graph-memgraph }}
+      graph-age: ${{ steps.filter.outputs.graph-age }}
+      graph-falkordb: ${{ steps.filter.outputs.graph-falkordb }}
+      graph-spring-boot: ${{ steps.filter.outputs.graph-spring-boot }}
+      common: ${{ steps.filter.outputs.common }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            graph-core:
+              - 'graph/graph-core/**'
+              - 'graph/graph-tinkerpop/**'
+              - 'graph-io/**'
+            graph-neo4j:
+              - 'graph/graph-neo4j/**'
+            graph-memgraph:
+              - 'graph/graph-memgraph/**'
+            graph-age:
+              - 'graph/graph-age/**'
+            graph-falkordb:
+              - 'graph/graph-falkordb/**'
+            graph-spring-boot:
+              - 'spring-boot3/**'
+              - 'spring-boot4/**'
+            common:
+              - 'buildSrc/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'settings.gradle.kts'
+              - '.github/workflows/ci.yml'
+
+  # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
   build:
     name: Build (compile only)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: validate-wrapper
+    needs: [validate-wrapper, changes]
     steps:
       - uses: actions/checkout@v4
 
@@ -89,12 +132,16 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-  # ── 3. Core + TinkerGraph 테스트 (Docker 불필요) ──────────────────────────
+  # ── 4. Core + TinkerGraph 테스트 (Docker 불필요) ──────────────────────────
   test-core:
     name: Test / Core & TinkerGraph
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: build
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 
@@ -110,16 +157,20 @@ jobs:
 
       - name: Test graph-core & graph-tinkerpop & graph-io
         run: |
-          ./gradlew \
-            :graph-core:test \
-            :graph-tinkerpop:test \
-            :graph-io-core:test \
-            :graph-io-csv:test \
-            :graph-io-jackson2:test \
-            :graph-io-jackson3:test \
-            :graph-io-graphml:test \
-            :graph-io-okio:test \
-            --no-daemon --continue
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :graph-core:test \
+              :graph-tinkerpop:test \
+              :graph-io-core:test \
+              :graph-io-csv:test \
+              :graph-io-jackson2:test \
+              :graph-io-jackson3:test \
+              :graph-io-graphml:test \
+              :graph-io-okio:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
@@ -154,12 +205,21 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 4. Spring Boot Starter 테스트 (TinkerGraph 프로파일, Docker 불필요) ──
+  # ── 5. Spring Boot Starter 테스트 (TinkerGraph 프로파일, Docker 불필요) ──
   test-spring-starters:
     name: Test / Spring Boot Starters (TinkerGraph)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: build
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-spring-boot'] == 'true' ||
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs['graph-neo4j'] == 'true' ||
+      needs.changes.outputs['graph-memgraph'] == 'true' ||
+      needs.changes.outputs['graph-age'] == 'true' ||
+      needs.changes.outputs['graph-falkordb'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 
@@ -175,10 +235,14 @@ jobs:
 
       - name: Test Spring Boot 3/4 starters
         run: |
-          ./gradlew \
-            :graph-spring-boot3-starter:test \
-            :graph-spring-boot4-starter:test \
-            --no-daemon
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :graph-spring-boot3-starter:test \
+              :graph-spring-boot4-starter:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           SPRING_PROFILES_ACTIVE: tinkergraph
@@ -208,12 +272,246 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 5. 커버리지 집계 ─────────────────────────────────────────────────────
+  # ── 6. Neo4j (Testcontainers) ─────────────────────────────────────────────
+  test-graph-neo4j:
+    name: Test / Neo4j (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-neo4j'] == 'true' ||
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test graph-neo4j
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-neo4j:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :graph-neo4j:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-neo4j
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-neo4j
+          path: '**/build/reports/kover/report.xml'
+          retention-days: 7
+
+  # ── 7. Memgraph (Testcontainers) ──────────────────────────────────────────
+  test-graph-memgraph:
+    name: Test / Memgraph (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-memgraph'] == 'true' ||
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test graph-memgraph
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-memgraph:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :graph-memgraph:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-memgraph
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-memgraph
+          path: '**/build/reports/kover/report.xml'
+          retention-days: 7
+
+  # ── 8. Apache AGE (Testcontainers) ────────────────────────────────────────
+  test-graph-age:
+    name: Test / Apache AGE (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-age'] == 'true' ||
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test graph-age
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-age:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :graph-age:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-age
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-age
+          path: '**/build/reports/kover/report.xml'
+          retention-days: 7
+
+  # ── 9. FalkorDB (Testcontainers) ──────────────────────────────────────────
+  test-graph-falkordb:
+    name: Test / FalkorDB (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-falkordb'] == 'true' ||
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test graph-falkordb
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-falkordb:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :graph-falkordb:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-falkordb
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-falkordb
+          path: '**/build/reports/kover/report.xml'
+          retention-days: 7
+
+  # ── 10. 커버리지 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test-core, test-spring-starters]
+    needs:
+      - test-core
+      - test-spring-starters
+      - test-graph-neo4j
+      - test-graph-memgraph
+      - test-graph-age
+      - test-graph-falkordb
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -252,16 +550,21 @@ jobs:
           path: coverage-artifacts/
           retention-days: 14
 
-  # ── 6. 결과 집계 ──────────────────────────────────────────────────────────
+  # ── 11. 결과 집계 ──────────────────────────────────────────────────────────
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
       - gitleaks
+      - changes
       - build
       - test-core
       - test-spring-starters
+      - test-graph-neo4j
+      - test-graph-memgraph
+      - test-graph-age
+      - test-graph-falkordb
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
   test-core:
     name: Test / Core & TinkerGraph
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -75,16 +75,20 @@ jobs:
 
       - name: Test graph-core & graph-tinkerpop & graph-io
         run: |
-          ./gradlew \
-            :graph-core:test \
-            :graph-tinkerpop:test \
-            :graph-io-core:test \
-            :graph-io-csv:test \
-            :graph-io-jackson2:test \
-            :graph-io-jackson3:test \
-            :graph-io-graphml:test \
-            :graph-io-okio:test \
-            --no-daemon
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :graph-core:test \
+              :graph-tinkerpop:test \
+              :graph-io-core:test \
+              :graph-io-csv:test \
+              :graph-io-jackson2:test \
+              :graph-io-jackson3:test \
+              :graph-io-graphml:test \
+              :graph-io-okio:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
@@ -118,7 +122,7 @@ jobs:
   test-spring-starters:
     name: Test / Spring Boot Starters (TinkerGraph)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -135,10 +139,14 @@ jobs:
 
       - name: Test Spring Boot 3/4 starters
         run: |
-          ./gradlew \
-            :graph-spring-boot3-starter:test \
-            :graph-spring-boot4-starter:test \
-            --no-daemon
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :graph-spring-boot3-starter:test \
+              :graph-spring-boot4-starter:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           SPRING_PROFILES_ACTIVE: tinkergraph
@@ -172,7 +180,7 @@ jobs:
   test-graph-neo4j:
     name: Test / Neo4j (Testcontainers)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -188,7 +196,12 @@ jobs:
           cache-read-only: true
 
       - name: Test graph-neo4j
-        run: ./gradlew :graph-neo4j:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-neo4j:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -219,7 +232,7 @@ jobs:
   test-graph-memgraph:
     name: Test / Memgraph (Testcontainers)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -235,7 +248,12 @@ jobs:
           cache-read-only: true
 
       - name: Test graph-memgraph
-        run: ./gradlew :graph-memgraph:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-memgraph:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -266,7 +284,7 @@ jobs:
   test-graph-age:
     name: Test / Apache AGE (Testcontainers)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -282,7 +300,12 @@ jobs:
           cache-read-only: true
 
       - name: Test graph-age
-        run: ./gradlew :graph-age:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-age:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -313,7 +336,7 @@ jobs:
   test-graph-falkordb:
     name: Test / FalkorDB (Testcontainers)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -329,7 +352,12 @@ jobs:
           cache-read-only: true
 
       - name: Test graph-falkordb
-        run: ./gradlew :graph-falkordb:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :graph-falkordb:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -360,7 +388,7 @@ jobs:
   test-examples:
     name: Test / Examples (Testcontainers)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -377,10 +405,14 @@ jobs:
 
       - name: Test example modules
         run: |
-          ./gradlew \
-            :code-graph-examples:test \
-            :linkedin-graph-examples:test \
-            --no-daemon
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :code-graph-examples:test \
+              :linkedin-graph-examples:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"


### PR DESCRIPTION
## 변경 내용

Closes #67

### ci.yml

- **changes job 추가**: `dorny/paths-filter@v3` 기반 7개 filter key (graph-core, graph-neo4j, graph-memgraph, graph-age, graph-falkordb, graph-spring-boot, common)
- **신규 Docker test jobs**: `test-graph-neo4j`, `test-graph-memgraph`, `test-graph-age`, `test-graph-falkordb` (Testcontainers, RYUK disabled)
- **paths-filter 조건**:
  - 각 job은 자신의 모듈 변경 OR `graph-core` 변경 OR `common` 변경 OR `workflow_dispatch` 시 실행
  - `test-spring-starters`: 모든 백엔드 모듈 변경 시 트리거 (starters가 testImplementation으로 전체 백엔드 의존)
- **retry loop=3**: 모든 test job의 `run:` 명령을 retry(3회, 10초 간격) 적용, `--continue` 유지
- **timeout**: test jobs 10분 → 30분
- **workflow_dispatch** 트리거 추가 (수동 실행 시 paths-filter 우회)
- **coverage-report needs**: 신규 4개 Docker job 추가
- **ci-status needs**: `changes` + 신규 4개 Docker job 추가

### nightly.yml

- 모든 test job에 retry loop(3회, 10초 간격) 적용, `--continue` 추가
- timeout: test jobs 10분 → 30분

## 검증 포인트

- `graph-core` 변경 시 모든 test job 트리거
- `graph-neo4j` 만 변경 시 `test-graph-neo4j` + `test-spring-starters` 만 실행
- `buildSrc` 변경 시 (common) 전체 실행
- `workflow_dispatch` 시 모든 job 실행