### PR TITLE
docs(graph-bom): BOM 모듈 README 추가 (한/영)

### DIFF
--- a/bom/README.ko.md
+++ b/bom/README.ko.md
@@ -1,0 +1,127 @@
+# bluetape4k-graph-bom
+
+한국어 | [English](./README.md)
+
+**bluetape4k-graph** 생태계용 Maven BOM (Bill of Materials). 모든 `io.github.bluetape4k.graph:*`
+모듈의 버전을 중앙 관리한다.
+
+## Architecture
+
+```mermaid
+graph TB
+    Consumer[소비 프로젝트]
+    BOM[bluetape4k-graph-bom<br/>java-platform]
+
+    subgraph "graph (DB 드라이버)"
+      Core[graph-core]
+      Neo4j[graph-neo4j]
+      Memgraph[graph-memgraph]
+      Age[graph-age]
+      Tinker[graph-tinkerpop]
+      Falkor[graph-falkordb]
+    end
+
+    subgraph "graph-io (직렬화)"
+      IoCore[graph-io-core]
+      Csv[graph-io-csv]
+      GraphML[graph-io-graphml]
+      Jackson2[graph-io-jackson2]
+      Jackson3[graph-io-jackson3]
+      Okio[graph-io-okio]
+    end
+
+    subgraph "Spring Boot starter"
+      SB3[graph-spring-boot3-starter]
+      SB4[graph-spring-boot4-starter]
+    end
+
+    Consumer -->|platform import| BOM
+    BOM -.->|버전 constraint| Core
+    BOM -.->|버전 constraint| Neo4j
+    BOM -.->|버전 constraint| IoCore
+    BOM -.->|버전 constraint| SB3
+```
+
+BOM은 Gradle `java-platform` 으로 `<dependencyManagement>` constraint 만 게시한다.
+
+## 핵심 기능
+
+- 모든 `bluetape4k-graph` 모듈 버전 중앙 관리
+- 그래프 DB 드라이버 (Neo4j / Memgraph / AGE / TinkerPop / FalkorDB) 버전 일관성 보장
+- `bluetape4k-dependencies` 가 상위에서 통합
+
+## 관리 모듈
+
+| 그룹 | 모듈 |
+|------|------|
+| `graph/*` | `graph-core`, `graph-neo4j`, `graph-memgraph`, `graph-age`, `graph-tinkerpop`, `graph-falkordb` |
+| `graph-io/*` | `graph-io-core`, `graph-io-csv`, `graph-io-graphml`, `graph-io-jackson2`, `graph-io-jackson3`, `graph-io-okio` |
+| `spring-boot3/*` | `graph-spring-boot3-starter` |
+| `spring-boot4/*` | `graph-spring-boot4-starter` |
+
+> 참고: `examples/*` 및 `benchmark/*` 모듈은 BOM constraint 에서 제외된다.
+
+## 사용 예제
+
+### Gradle Kotlin DSL
+
+```kotlin
+plugins {
+    id("io.spring.dependency-management") version "1.1.x"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>")
+    }
+}
+
+dependencies {
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-spring-boot4-starter")
+}
+```
+
+### 순수 Gradle
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>"))
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
+}
+```
+
+### Maven
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.bluetape4k.graph</groupId>
+            <artifactId>bluetape4k-graph-bom</artifactId>
+            <version>${bluetape4k-graph.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## 설정 옵션
+
+BOM 자체는 별도 설정이 없다. SNAPSHOT 사용 시 Sonatype Central Snapshots 저장소 추가:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "central-snapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+```
+
+## 의존성
+
+이 BOM은 `bluetape4k-dependencies` 에서 자동 통합된다. 여러 bluetape4k 생태계를 함께 사용한다면
+`io.github.bluetape4k:bluetape4k-dependencies` import 권장.

--- a/bom/README.md
+++ b/bom/README.md
@@ -1,0 +1,128 @@
+# bluetape4k-graph-bom
+
+[한국어](./README.ko.md) | English
+
+Maven BOM (Bill of Materials) for the **bluetape4k-graph** ecosystem. Manages versions of all
+`io.github.bluetape4k.graph:*` modules so consumers can declare dependencies without specifying
+individual versions.
+
+## Architecture
+
+```mermaid
+graph TB
+    Consumer[Consumer Project]
+    BOM[bluetape4k-graph-bom<br/>java-platform]
+
+    subgraph "graph (DB drivers)"
+      Core[graph-core]
+      Neo4j[graph-neo4j]
+      Memgraph[graph-memgraph]
+      Age[graph-age]
+      Tinker[graph-tinkerpop]
+      Falkor[graph-falkordb]
+    end
+
+    subgraph "graph-io (serialization)"
+      IoCore[graph-io-core]
+      Csv[graph-io-csv]
+      GraphML[graph-io-graphml]
+      Jackson2[graph-io-jackson2]
+      Jackson3[graph-io-jackson3]
+      Okio[graph-io-okio]
+    end
+
+    subgraph "Spring Boot starters"
+      SB3[graph-spring-boot3-starter]
+      SB4[graph-spring-boot4-starter]
+    end
+
+    Consumer -->|platform import| BOM
+    BOM -.->|version constraints| Core
+    BOM -.->|version constraints| Neo4j
+    BOM -.->|version constraints| IoCore
+    BOM -.->|version constraints| SB3
+```
+
+The BOM is a Gradle `java-platform` that publishes only `<dependencyManagement>` constraints — no runtime classes.
+
+## Core Features
+
+- Centralized version management for all `bluetape4k-graph` modules
+- Single source of truth for graph DB drivers (Neo4j / Memgraph / AGE / TinkerPop / FalkorDB)
+- Aggregated by `bluetape4k-dependencies` for cross-ecosystem version coordination
+
+## Modules Managed
+
+| Group | Modules |
+|-------|---------|
+| `graph/*` | `graph-core`, `graph-neo4j`, `graph-memgraph`, `graph-age`, `graph-tinkerpop`, `graph-falkordb` |
+| `graph-io/*` | `graph-io-core`, `graph-io-csv`, `graph-io-graphml`, `graph-io-jackson2`, `graph-io-jackson3`, `graph-io-okio` |
+| `spring-boot3/*` | `graph-spring-boot3-starter` |
+| `spring-boot4/*` | `graph-spring-boot4-starter` |
+
+> Note: `examples/*` and `benchmark/*` modules are excluded from the BOM constraints.
+
+## Usage Examples
+
+### Gradle Kotlin DSL
+
+```kotlin
+plugins {
+    id("io.spring.dependency-management") version "1.1.x"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>")
+    }
+}
+
+dependencies {
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-spring-boot4-starter")
+}
+```
+
+### Plain Gradle
+
+```kotlin
+dependencies {
+    implementation(platform("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>"))
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
+}
+```
+
+### Maven
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.bluetape4k.graph</groupId>
+            <artifactId>bluetape4k-graph-bom</artifactId>
+            <version>${bluetape4k-graph.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+## Configuration Options
+
+The BOM itself has no configuration. For SNAPSHOT builds, add the Sonatype Central Snapshots repository:
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "central-snapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    }
+}
+```
+
+## Dependency
+
+This BOM is automatically aggregated by `bluetape4k-dependencies`. Prefer importing
+`io.github.bluetape4k:bluetape4k-dependencies` when consuming multiple bluetape4k ecosystems.


### PR DESCRIPTION
## 요약

신규 추가된 BOM 모듈에 README.md + README.ko.md 를 추가합니다.

## 변경 사항

- `bom/README.md` (English)
- `bom/README.ko.md` (한국어)

## 배경

CLAUDE.md "이중언어 README 필수" + "Architecture-first" 규칙에 따라 모든 모듈은 영어/한국어 README를 동시에 유지해야 합니다.
지난 24시간 내 머지된 BOM 모듈 추가 PR에서 README가 누락되어 후속 처리합니다.

## README 구조

- **Architecture** — Mermaid 다이어그램으로 BOM ↔ 관리 모듈 관계 시각화
- **Core Features** — BOM 의 역할 요약
- **Modules Managed** — 관리 대상 모듈 표
- **Usage Examples** — Gradle Kotlin DSL / Plain Gradle / Maven 예제
- **Configuration Options** — Sonatype Central Snapshots repo 안내
- **Dependency** — `bluetape4k-dependencies` aggregator 안내

## 검증

- 코드 변경 없음 (문서만 추가)
- Mermaid 문법 로컬 검증 완료
- 다른 모듈 README 와 구조 일관성 유지