### PR TITLE
docs: align graph Java baseline guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ FalkorDB. Provides paired synchronous and coroutine APIs plus Spring Boot 3.5
 and 4.0 auto-configuration.
 
 - Kotlin: 2.3
-- Java: 25 with preview enabled
-- Dependency versions: `buildSrc/src/main/kotlin/Libs.kt`
+- Java: 21 with preview enabled
+- Dependency versions: `gradle/libs.versions.toml`
 
 ## Layout
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -240,7 +240,7 @@ driver.close()
 
 ## 요구 사항
 
-- Java 25 (preview 기능 활성화)
+- Java 21 (preview 기능 활성화)
 - Kotlin 2.3
 - Docker (통합 테스트용)
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Concrete classes only need to implement `ops` (`GraphOperations` or `GraphSuspen
 
 ## Requirements
 
-- Java 25 (with preview features enabled)
+- Java 21 (with preview features enabled)
 - Kotlin 2.3
 - Docker (for integration tests)
 


### PR DESCRIPTION
## DoD Completion Report - Daily bug scan graph baseline docs

### Related Issue

N/A - daily automation scan of recent `develop` changes.

### Work Done

- Updated README/README.ko requirements from Java 25 to Java 21 after the recent Java 21 baseline change.
- Updated AGENTS.md so future agents follow the Java 21 toolchain and the current `gradle/libs.versions.toml` version catalog.

### Test Results

Repository: `bluetape4k-graph`
Result: Gradle project loading passed.
Date: 2026-05-10

### Pre-PR Required Checks

| Item | Status |
|------|--------|
| Worktree used | PASS |
| 6-R Tier 1 security review | PASS |
| 6-R Tier 2 Ops/SRE review | PASS |
| 6-R Tier 3 structural review | PASS |
| 6-R Tier 4 Kotlin/code quality review | PASS |
| 6-R Tier 5 tests/types/silent failure review | PASS |
| 6-R Tier 6 performance/stability review | PASS |
| README.md + README.ko.md updated | PASS |
| AGENTS.md updated | PASS |
| `git diff --check` | PASS |

### Verification

- `./gradlew help --no-daemon`
- `git diff --check`

### Commits

- `b13c007 Keep graph documentation on the Java 21 baseline`
