### PR TITLE
docs: Document Kover coverage policy

### DIFF
--- a/docs/governance/kover-coverage-policy.md
+++ b/docs/governance/kover-coverage-policy.md
@@ -1,0 +1,24 @@
+# Kover Coverage Policy
+
+## Current Status
+
+`bluetape4k-graph` aggregates Kover reports from production modules and excludes
+benchmark/example modules from coverage aggregation.
+
+## Policy
+
+Status: report-only transition.
+
+Graph database backends require external runtimes and have different coverage
+profiles from pure graph-io modules. Coverage gates should be module-level.
+
+## Threshold Plan
+
+- Gate graph-io/core and pure serialization modules first, targeting 80%.
+- Gate graph DB backends only after backend-specific baseline runs.
+- Keep benchmark and example modules outside production coverage gates.
+
+## CI/Nightly Contract
+
+Nightly uploads coverage artifacts. Add `koverVerify` for individual modules
+after thresholds are introduced.


### PR DESCRIPTION
## 요약
- repo-local Kover coverage policy를 추가했습니다.
- 현재 상태를 enforced/report-only/exception으로 명시했습니다.
- failing `koverVerify` gate는 baseline 측정 후 module-level로 추가한다는 threshold plan을 남겼습니다.

## 검증
- `git diff --check`

Related to bluetape4k/.github#1.