### PR TITLE
chore: keep Dependabot updates unassigned

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 8
-    assignees:
-      - "debop"
     groups:
       kotlin:
         patterns:
@@ -40,8 +38,6 @@ updates:
       time: "06:30"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
-    assignees:
-      - "debop"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary
- Remove default Dependabot assignee configuration to avoid weekly assignment notification bursts.
- Keep the dependency governance baseline in place for Gradle and GitHub Actions.

## Verification
- Dependabot YAML parsed with Ruby YAML.

Refs bluetape4k/.github#9