### PR TITLE
build: Fory Kotlin 버전을 중앙 기준에 맞춤

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -168,7 +168,7 @@ findbugs = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }  # 
 guava = { module = "com.google.guava:guava", version = "33.4.8-jre" }  # https://mvnrepository.com/artifact/com.google.guava/guava
 
 kryo5 = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
-fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.17.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
+fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.15.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
 
 # Spring Boot
 spring-boot4-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot4" }


### PR DESCRIPTION
## 변경
- fory-kotlin 버전을 bluetape4k-dependencies source-of-truth 기준인 0.15.0으로 맞췄습니다.

## 검증
- ./gradlew tasks --all --no-daemon