### PR TITLE
chore: Kover 강제 게이트 정책 제거

### DIFF
--- a/docs/governance/kover-coverage-policy.md
+++ b/docs/governance/kover-coverage-policy.md
@@ -14,11 +14,15 @@ profiles from pure graph-io modules. Coverage gates should be module-level.
 
 ## Threshold Plan
 
-- Gate graph-io/core and pure serialization modules first, targeting 80%.
-- Gate graph DB backends only after backend-specific baseline runs.
+- Treat Kover as a trend signal, not a build gate.
+- Use Nightly XML reports and existing coverage artifact uploads to identify
+  coverage regressions.
+- Open a focused issue when a module needs coverage repair; do not introduce a
+  failing threshold as the default enforcement mechanism.
 - Keep benchmark and example modules outside production coverage gates.
 
 ## CI/Nightly Contract
 
-Nightly uploads coverage artifacts. Add `koverVerify` for individual modules
-after thresholds are introduced.
+Nightly uploads coverage artifacts and keeps trend visibility. CI and Nightly
+must not fail solely because a module is below a fixed coverage percentage
+unless a future issue explicitly reintroduces that gate.


### PR DESCRIPTION
## Summary
- Kover coverage를 fixed threshold gate가 아니라 report-only trend signal로 문서화
- CI/Nightly가 고정 커버리지 퍼센트 미달만으로 실패하지 않도록 정책 정리
- koverXmlReport 스타일의 coverage visibility는 유지

## Verification
- git diff --check
- workspace rg: non-leader active workflows contain no koverVerify/minBound/Verify Kover threshold steps

Not-tested: 문서 전용 변경이라 Gradle build는 실행하지 않았습니다.

Co-authored-by: OmX <omx@oh-my-codex.dev>