### PR TITLE
docs: graph-core capability 문서 정합성 확보

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `GraphCycleTest`: `toCycle()`, `length`, 동등 비교 7개 케이스
 - **`graph-core` README 모델 빌더 유틸리티 섹션** (`graph/graph-core/README.md`, `README.ko.md`)
 - **Transaction DSL first slice**: `GraphOperations.transaction { }` 확장과 capability contract를 추가하고 Neo4j, Memgraph, AGE, TinkerGraph 동기 백엔드에 1차 구현을 연결했습니다. suspend transaction capability도 동일 백엔드에 연결하고, FalkorDB는 중간 결과를 즉시 반환해야 하는 repository DSL 특성상 명시적 미지원으로 고정했습니다.
+- **`graph-core` capability docs**: `SchemaManager`, `GraphMergeOperations`, `GraphTransactionScope` / `GraphSuspendTransactionScope` 사용 예제를 root README, backend README, KDoc에 동기화했습니다.
 
 ### Fixed
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -94,6 +94,36 @@ val edges = ops.createEdges(
 
 동기, suspend, Virtual Thread 어댑터 모두 같은 계약(`createVertices`, `createEdges`, `createVerticesAsync`, `createEdgesAsync`)을 제공합니다. 1만 건 삽입 smoke 근거는 [2026-05 테스트 로그](docs/testlogs/2026-05.md)에 기록되어 있습니다.
 
+### Schema, Merge, Transaction capabilities
+
+`graph-core`는 base `GraphOperations` source contract를 깨지 않으면서 backend가 더 강한 write-time guarantee를
+제공할 수 있도록 optional capability interfaces를 정의한다.
+
+| Capability | API | 목적 |
+|------------|-----|------|
+| Schema manager | `ops.schemaManager()` / `suspendOps.schemaManager()` | 공통 metadata model로 index와 constraint 생성·조회·삭제 |
+| Merge / Upsert | `ops.mergeVertex(...)`, `ops.mergeEdge(...)` | 안정적인 `matchProperties` 기반 idempotent vertex/edge write |
+| Transaction DSL | `ops.transaction { }`, `suspendOps.suspendTransaction { }` | repository-style vertex/edge work block을 atomic하게 실행 |
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+import io.bluetape4k.graph.schema.schemaManager
+
+ops.schemaManager().createIndex("Person", "email")
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ## 벌크 임포트/익스포트 (`graph-io`)
 
 `graph-io` 패밀리는 포맷 독립적인 대용량 I/O를 세 가지 실행 모델(Sync, VirtualThread, Coroutine)로 제공한다.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,36 @@ val edges = ops.createEdges(
 
 The same contract is exposed on sync, suspend, and virtual-thread adapters (`createVertices`, `createEdges`, `createVerticesAsync`, `createEdgesAsync`). Smoke evidence for 10k-row inserts is tracked in [2026-05 test logs](docs/testlogs/2026-05.md).
 
+### Schema, Merge, and Transaction Capabilities
+
+`graph-core` also defines optional capability interfaces that backends implement when they can provide stronger
+write-time guarantees without changing the base `GraphOperations` source contract.
+
+| Capability | API | Purpose |
+|------------|-----|---------|
+| Schema manager | `ops.schemaManager()` / `suspendOps.schemaManager()` | Create/list/drop indexes and constraints through common metadata models |
+| Merge / Upsert | `ops.mergeVertex(...)`, `ops.mergeEdge(...)` | Idempotent vertex and edge writes using stable `matchProperties` |
+| Transaction DSL | `ops.transaction { }`, `suspendOps.suspendTransaction { }` | Atomic repository-style vertex/edge work blocks |
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+import io.bluetape4k.graph.schema.schemaManager
+
+ops.schemaManager().createIndex("Person", "email")
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ## Bulk Import / Export (`graph-io`)
 
 The `graph-io` family provides format-independent bulk I/O with three execution models (Sync, VirtualThread, Coroutine).

--- a/graph/graph-age/README.ko.md
+++ b/graph/graph-age/README.ko.md
@@ -792,6 +792,41 @@ GraphVertex(
 )
 ```
 
+## Schema / Index Management
+
+`AgeGraphOperations`는 `schemaManager()`를 노출하지만, AGE-specific index DDL은 아직 portable하게 제공하지 않는다.
+따라서 mutation API는 silent no-op 대신 `UnsupportedOperationException`으로 명시적으로 실패한다.
+
+```kotlin
+import io.bluetape4k.graph.schema.schemaManager
+
+val schema = ops.schemaManager()
+schema.listIndexes() // empty
+schema.createIndex("Person", "email") // UnsupportedOperationException
+```
+
+## Merge / Upsert and Transaction DSL
+
+AGE backend는 native `ON CREATE SET` / `ON MATCH SET` 지원이 제한된 환경을 고려해 transactional
+match/update/create fallback으로 `GraphMergeOperations`를 제공한다. `Transaction DSL`은 Exposed transaction 위에서
+vertex/edge work block을 atomic하게 실행한다.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ## 캐싱 데코레이터
 
 `CachingAgeGraphOperations`는 `AgeGraphOperations`를 `ConcurrentHashMap` 기반 캐시로 감싸는 데코레이터입니다.

--- a/graph/graph-age/README.md
+++ b/graph/graph-age/README.md
@@ -111,6 +111,28 @@ schema.listIndexes() // empty
 schema.createIndex("Person", "email") // UnsupportedOperationException
 ```
 
+## Merge / Upsert and Transaction DSL
+
+AGE supports `GraphMergeOperations` through a transactional match/update/create fallback because the current test image
+does not support `ON CREATE SET` / `ON MATCH SET`. The `Transaction DSL` runs vertex and edge work inside the Exposed
+transaction used by `AgeGraphOperations`.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ## Caching Decorator
 
 `CachingAgeGraphOperations` wraps an `AgeGraphOperations` instance and memoizes all read results using `ConcurrentHashMap` (~5 ns lookup). It is designed for read-heavy workloads such as benchmarks or repeated graph traversals.

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphSchemaModels.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphSchemaModels.kt
@@ -4,6 +4,10 @@ import java.io.Serializable
 
 /**
  * 그래프 스키마 객체가 적용되는 엔티티 종류.
+ *
+ * ```kotlin
+ * val target = GraphSchemaEntityType.VERTEX
+ * ```
  */
 enum class GraphSchemaEntityType {
     /** 정점/노드 레이블에 적용되는 스키마 객체. */
@@ -18,6 +22,10 @@ enum class GraphSchemaEntityType {
 
 /**
  * 그래프 제약조건 종류.
+ *
+ * ```kotlin
+ * val type = GraphConstraintType.UNIQUE
+ * ```
  */
 enum class GraphConstraintType {
     /** 특정 레이블과 속성 조합의 값이 유일해야 함을 나타낸다. */
@@ -38,6 +46,14 @@ enum class GraphConstraintType {
  * @property property 인덱스 속성 이름. label-only 인덱스는 `null`일 수 있다.
  * @property entityType 인덱스 대상 엔티티 종류.
  * @property unique 인덱스가 유니크 제약조건을 뒷받침하는지 여부.
+ *
+ * ```kotlin
+ * val index = GraphIndex(
+ *     name = "bt4k_idx_Person_email",
+ *     label = "Person",
+ *     property = "email",
+ * )
+ * ```
  */
 data class GraphIndex(
     val name: String,
@@ -59,6 +75,15 @@ data class GraphIndex(
  * @property property 제약조건 속성 이름.
  * @property type 공통 제약조건 종류.
  * @property entityType 제약조건 대상 엔티티 종류.
+ *
+ * ```kotlin
+ * val constraint = GraphConstraint(
+ *     name = "bt4k_uc_Person_email",
+ *     label = "Person",
+ *     property = "email",
+ *     type = GraphConstraintType.UNIQUE,
+ * )
+ * ```
  */
 data class GraphConstraint(
     val name: String,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphMergeOperations.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphMergeOperations.kt
@@ -11,6 +11,19 @@ import io.bluetape4k.support.requireNotBlank
  *
  * [matchProperties]는 요소를 찾는 안정적인 식별자이고, [setProperties]는 생성되었거나
  * 이미 존재하는 요소에 적용할 갱신 속성이다.
+ *
+ * ## 동작/계약
+ * - [matchProperties]의 값은 `null`일 수 없다. null identity key는 backend별 query 의미가
+ *   달라질 수 있기 때문이다.
+ * - [setProperties]는 [matchProperties]와 같은 key를 덮어쓸 수 없다.
+ *
+ * ```kotlin
+ * val props = GraphMergeValidation.validateVertex(
+ *     label = "Person",
+ *     matchProperties = mapOf("email" to "alice@example.com"),
+ *     setProperties = mapOf("name" to "Alice"),
+ * )
+ * ```
  */
 data class GraphMergeProperties(
     val matchProperties: Map<String, Any?>,
@@ -21,6 +34,21 @@ data class GraphMergeProperties(
  * merge/upsert API가 모든 백엔드에서 공유하는 입력 검증 규칙.
  *
  * 백엔드 구현체는 쿼리 문자열을 만들기 전에 이 검증을 먼저 호출해야 한다.
+ *
+ * ## 동작/계약
+ * - label과 property key는 backend query에 안전한 identifier여야 한다.
+ * - vertex merge는 [validateVertex]에서 non-empty [matchProperties]를 요구한다.
+ * - edge merge는 endpoint id와 label이 identity를 이루므로 empty [matchProperties]를 허용한다.
+ *
+ * ```kotlin
+ * val validated = GraphMergeValidation.validateEdge(
+ *     fromId = GraphElementId("1"),
+ *     toId = GraphElementId("2"),
+ *     label = "KNOWS",
+ *     matchProperties = emptyMap(),
+ *     setProperties = mapOf("since" to 2026),
+ * )
+ * ```
  */
 object GraphMergeValidation {
 
@@ -92,6 +120,20 @@ object GraphMergeValidation {
  * 동기 그래프 구현체가 merge/upsert 기능을 제공할 때 구현하는 capability interface.
  *
  * [GraphOperations] 자체에 멤버를 추가하지 않아 기존 구현체와 테스트 fake의 source compatibility를 유지한다.
+ *
+ * ## 동작/계약
+ * - 구현체는 [GraphMergeValidation]으로 입력을 검증한 뒤 backend-native `MERGE` 또는
+ *   transactional match/update/create path를 사용해야 한다.
+ * - unsupported backend는 이 interface를 구현하지 않고 extension function에서
+ *   [UnsupportedOperationException]으로 fail fast 하도록 둔다.
+ *
+ * ```kotlin
+ * val alice = ops.mergeVertex(
+ *     label = "Person",
+ *     matchProperties = mapOf("email" to "alice@example.com"),
+ *     setProperties = mapOf("name" to "Alice"),
+ * )
+ * ```
  */
 interface GraphMergeOperations {
 
@@ -119,6 +161,18 @@ interface GraphMergeOperations {
 
 /**
  * 코루틴 그래프 구현체가 merge/upsert 기능을 제공할 때 구현하는 capability interface.
+ *
+ * ## 동작/계약
+ * - [GraphMergeOperations]와 같은 identity/set semantics를 suspend API로 제공한다.
+ * - cancellation은 backend implementation에서 삼키지 않아야 한다.
+ *
+ * ```kotlin
+ * val alice = suspendOps.mergeVertex(
+ *     label = "Person",
+ *     matchProperties = mapOf("email" to "alice@example.com"),
+ *     setProperties = mapOf("name" to "Alice"),
+ * )
+ * ```
  */
 interface GraphSuspendMergeOperations {
 
@@ -144,6 +198,16 @@ interface GraphSuspendMergeOperations {
  *
  * 구현체가 [GraphMergeOperations]를 구현하지 않으면 read-then-write fallback을 사용하지 않고
  * 명시적으로 [UnsupportedOperationException]을 던진다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.mergeVertex
+ *
+ * val vertex = ops.mergeVertex(
+ *     "Person",
+ *     matchProperties = mapOf("email" to "alice@example.com"),
+ *     setProperties = mapOf("name" to "Alice"),
+ * )
+ * ```
  */
 fun GraphOperations.mergeVertex(
     label: String,
@@ -161,6 +225,17 @@ fun GraphOperations.mergeVertex(
  * [GraphOperations]에서 간선 merge/upsert를 실행한다.
  *
  * 구현체가 [GraphMergeOperations]를 구현하지 않으면 명시적으로 [UnsupportedOperationException]을 던진다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.mergeEdge
+ *
+ * val edge = ops.mergeEdge(
+ *     fromId = alice.id,
+ *     toId = bob.id,
+ *     label = "KNOWS",
+ *     setProperties = mapOf("since" to 2026),
+ * )
+ * ```
  */
 fun GraphOperations.mergeEdge(
     fromId: GraphElementId,
@@ -178,6 +253,15 @@ fun GraphOperations.mergeEdge(
 
 /**
  * [GraphSuspendOperations]에서 코루틴 정점 merge/upsert를 실행한다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.mergeVertex
+ *
+ * val vertex = suspendOps.mergeVertex(
+ *     "Person",
+ *     matchProperties = mapOf("email" to "alice@example.com"),
+ * )
+ * ```
  */
 suspend fun GraphSuspendOperations.mergeVertex(
     label: String,
@@ -193,6 +277,12 @@ suspend fun GraphSuspendOperations.mergeVertex(
 
 /**
  * [GraphSuspendOperations]에서 코루틴 간선 merge/upsert를 실행한다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.mergeEdge
+ *
+ * val edge = suspendOps.mergeEdge(alice.id, bob.id, "KNOWS")
+ * ```
  */
 suspend fun GraphSuspendOperations.mergeEdge(
     fromId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/GraphSchemaManager.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/GraphSchemaManager.kt
@@ -14,6 +14,20 @@ import kotlinx.coroutines.withContext
  *
  * 구현체는 백엔드 DDL 차이를 숨기되, 지원하지 않는 제약조건을 성공한 것처럼 처리하지 않고
  * 명시적으로 [UnsupportedOperationException]을 던져야 한다.
+ *
+ * ## 동작/계약
+ * - label과 property는 backend query에 안전한 identifier여야 한다.
+ * - 지원하지 않는 schema DDL은 silent no-op 대신 [UnsupportedOperationException]으로 실패해야 한다.
+ * - [listIndexes]와 [listConstraints]는 backend metadata를 공통 모델로 변환해 반환한다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.schema.schemaManager
+ *
+ * val schema = ops.schemaManager()
+ * schema.createIndex("Person", "email")
+ * schema.createUniqueConstraint("Person", "email")
+ * val indexes = schema.listIndexes()
+ * ```
  */
 interface GraphSchemaManager {
 
@@ -54,6 +68,18 @@ interface GraphSchemaManager {
 
 /**
  * 그래프 백엔드의 인덱스와 제약조건을 관리하는 코루틴 API.
+ *
+ * ## 동작/계약
+ * - [GraphSchemaManager]와 같은 schema metadata semantics를 suspend API로 제공한다.
+ * - blocking backend adapter는 [BlockingGraphSuspendSchemaManager]를 통해 [Dispatchers.IO]에서 실행한다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.schema.schemaManager
+ *
+ * val schema = suspendOps.schemaManager()
+ * schema.createIndex("Person", "email")
+ * val constraints = schema.listConstraints()
+ * ```
  */
 interface GraphSuspendSchemaManager {
 
@@ -75,6 +101,11 @@ interface GraphSuspendSchemaManager {
 
 /**
  * 동기 그래프 구현체가 스키마 관리 기능을 제공할 때 구현하는 capability interface.
+ *
+ * ```kotlin
+ * val schema = ops.schemaManager()
+ * schema.dropIndex("Person", "email")
+ * ```
  */
 interface GraphSchemaManagementOperations {
     /** 이 그래프 구현체의 스키마 관리자를 반환한다. */
@@ -83,6 +114,11 @@ interface GraphSchemaManagementOperations {
 
 /**
  * 코루틴 그래프 구현체가 스키마 관리 기능을 제공할 때 구현하는 capability interface.
+ *
+ * ```kotlin
+ * val schema = suspendOps.schemaManager()
+ * schema.listIndexes()
+ * ```
  */
 interface GraphSuspendSchemaManagementOperations {
     /** 이 그래프 구현체의 코루틴 스키마 관리자를 반환한다. */
@@ -91,6 +127,11 @@ interface GraphSuspendSchemaManagementOperations {
 
 /**
  * 동기 스키마 관리자를 [Dispatchers.IO]에서 실행하는 코루틴 어댑터.
+ *
+ * ```kotlin
+ * val suspendSchema = ops.schemaManager().asSuspendSchemaManager()
+ * suspendSchema.createIndex("Person", "email")
+ * ```
  */
 class BlockingGraphSuspendSchemaManager(
     private val delegate: GraphSchemaManager,
@@ -127,12 +168,25 @@ class BlockingGraphSuspendSchemaManager(
 
 /**
  * 동기 스키마 관리자를 코루틴 API로 노출한다.
+ *
+ * ```kotlin
+ * val schema = ops.schemaManager().asSuspendSchemaManager()
+ * ```
  */
 fun GraphSchemaManager.asSuspendSchemaManager(): GraphSuspendSchemaManager =
     BlockingGraphSuspendSchemaManager(this)
 
 /**
  * 백엔드가 현재 schema DDL을 안전하게 지원하지 않을 때 사용하는 명시적 실패 관리자.
+ *
+ * ## 동작/계약
+ * - [listIndexes]와 [listConstraints]는 빈 목록을 반환한다.
+ * - mutation API는 identifier validation 후 [UnsupportedOperationException]을 던진다.
+ *
+ * ```kotlin
+ * val schema = UnsupportedGraphSchemaManager("AGE", "portable AGE index DDL is not available")
+ * schema.listIndexes() // emptyList()
+ * ```
  */
 class UnsupportedGraphSchemaManager(
     private val backendName: String,
@@ -167,6 +221,13 @@ class UnsupportedGraphSchemaManager(
  *
  * 구현체가 [GraphSchemaManagementOperations]를 구현하지 않으면 auto no-op fallback을 사용하지 않고
  * 명시적으로 [UnsupportedOperationException]을 던진다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.schema.schemaManager
+ *
+ * val schema = ops.schemaManager()
+ * schema.createIndex("Person", "email")
+ * ```
  */
 fun GraphOperations.schemaManager(): GraphSchemaManager {
     val management = this as? GraphSchemaManagementOperations
@@ -181,6 +242,13 @@ fun GraphOperations.schemaManager(): GraphSchemaManager {
  *
  * 구현체가 [GraphSuspendSchemaManagementOperations]를 구현하지 않으면 명시적으로
  * [UnsupportedOperationException]을 던진다.
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.schema.schemaManager
+ *
+ * val schema = suspendOps.schemaManager()
+ * schema.listConstraints()
+ * ```
  */
 fun GraphSuspendOperations.schemaManager(): GraphSuspendSchemaManager {
     val management = this as? GraphSuspendSchemaManagementOperations
@@ -216,6 +284,11 @@ suspend fun GraphSuspendSchemaManager.dropIndex(label: VertexLabel, property: Pr
 
 /**
  * 공통 스키마 객체 이름을 생성한다.
+ *
+ * ```kotlin
+ * val index = GraphSchemaNames.indexName("Person", "email")
+ * val constraint = GraphSchemaNames.uniqueConstraintName("Person", "email")
+ * ```
  */
 object GraphSchemaNames {
 

--- a/graph/graph-falkordb/README.ko.md
+++ b/graph/graph-falkordb/README.ko.md
@@ -2,6 +2,8 @@
 
 bluetape4k-graph의 FalkorDB 그래프 데이터베이스 백엔드 모듈.
 
+> 🇺🇸 [English](README.md)
+
 ## 개요
 
 [FalkorDB](https://falkordb.com/)는 Redis 모듈 기반 그래프 데이터베이스로 openCypher 쿼리를 지원합니다.
@@ -58,6 +60,48 @@ ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024))
 
 val count = ops.countVertices("Person")  // 2
 driver.close()
+```
+
+## Schema / Index Management
+
+FalkorDB는 Cypher를 통해 range index를 지원한다. Unique constraint는 raw Redis
+`GRAPH.CONSTRAINT CREATE` command 경로가 필요하므로, 현재 manager는 unique constraint를 명시적으로 실패시킨다.
+
+```kotlin
+import io.bluetape4k.graph.schema.schemaManager
+
+val schema = ops.schemaManager()
+schema.createIndex("Person", "email")
+val indexes = schema.listIndexes()
+schema.dropIndex("Person", "email")
+```
+
+## Merge / Upsert and Transaction DSL
+
+FalkorDB backend는 native Cypher `MERGE` 기반 `GraphMergeOperations`를 지원한다.
+다만 Redis `MULTI`는 graph query result를 `EXEC`까지 지연시키므로, 같은 block 안에서 생성된 vertex id를
+즉시 사용해야 하는 repository-style `Transaction DSL`은 명시적으로 지원하지 않는다.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeEdge
+import io.bluetape4k.graph.repository.mergeVertex
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val bob = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "bob@example.com"),
+)
+
+val edge = ops.mergeEdge(
+    fromId = alice.id,
+    toId = bob.id,
+    label = "KNOWS",
+)
 ```
 
 ### 코루틴 (Suspend) API

--- a/graph/graph-falkordb/README.md
+++ b/graph/graph-falkordb/README.md
@@ -2,6 +2,8 @@
 
 FalkorDB graph database backend for bluetape4k-graph.
 
+> 🇰🇷 [한국어 문서](README.ko.md)
+
 ## Overview
 
 [FalkorDB](https://falkordb.com/) is a Redis-module based graph database supporting openCypher queries.
@@ -73,6 +75,34 @@ val schema = ops.schemaManager()
 schema.createIndex("Person", "email")
 val indexes = schema.listIndexes()
 schema.dropIndex("Person", "email")
+```
+
+## Merge / Upsert and Transaction DSL
+
+FalkorDB supports `GraphMergeOperations` with native Cypher `MERGE` for vertices and relationships.
+It does not expose the repository-style `Transaction DSL` because Redis `MULTI` defers graph query results until
+`EXEC`, while the DSL needs created vertex IDs immediately inside the same block.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeEdge
+import io.bluetape4k.graph.repository.mergeVertex
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val bob = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "bob@example.com"),
+)
+
+val edge = ops.mergeEdge(
+    fromId = alice.id,
+    toId = bob.id,
+    label = "KNOWS",
+)
 ```
 
 ### Coroutine (Suspend) API

--- a/graph/graph-memgraph/README.ko.md
+++ b/graph/graph-memgraph/README.ko.md
@@ -16,6 +16,7 @@ Memgraph 그래프 데이터베이스를 위한 `GraphOperations` / `GraphSuspen
 | `MemgraphGraphOperations` | 동기(blocking) 방식 그래프 연산 |
 | `MemgraphGraphSuspendOperations` | 코루틴(suspend/Flow) 방식 그래프 연산 |
 | `CachingMemgraphGraphOperations` | `ConcurrentHashMap` 기반 캐싱 데코레이터 |
+| `MemgraphGraphSchemaManager` | Memgraph index와 unique constraint용 SchemaManager |
 
 ## 사용법
 
@@ -29,6 +30,40 @@ val vertex = ops.createVertex("Person", mapOf("name" to "Alice"))
 // 코루틴 방식
 val suspendOps = MemgraphGraphSuspendOperations(driver)
 val vertex = suspendOps.createVertex("Person", mapOf("name" to "Alice"))
+```
+
+## Schema / Index Management
+
+`MemgraphGraphOperations`는 `schemaManager()`를 통해 index와 unique constraint를 생성·조회·삭제할 수 있다.
+
+```kotlin
+import io.bluetape4k.graph.schema.schemaManager
+
+val schema = ops.schemaManager()
+schema.createIndex("Person", "email")
+schema.createUniqueConstraint("Person", "email")
+val indexes = schema.listIndexes()
+```
+
+## Merge / Upsert and Transaction DSL
+
+Memgraph backend는 Cypher `MERGE` 기반 `GraphMergeOperations`와 repository-style `Transaction DSL`을 지원한다.
+`matchProperties`는 vertex identity key로 사용되며, `transaction { }` block은 실패 시 rollback되어야 한다.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
 ```
 
 ## Neo4j와의 차이점

--- a/graph/graph-memgraph/README.md
+++ b/graph/graph-memgraph/README.md
@@ -50,6 +50,27 @@ schema.dropIndex("Person", "email")
 Memgraph uses `CREATE INDEX ON :Label(property)`, `SHOW INDEX INFO`,
 `CREATE CONSTRAINT ON (n:Label) ASSERT n.property IS UNIQUE`, and `SHOW CONSTRAINT INFO`.
 
+## Merge / Upsert and Transaction DSL
+
+Memgraph supports `GraphMergeOperations` through Cypher `MERGE` and the repository-style `Transaction DSL`.
+Use `matchProperties` as stable vertex identity keys and keep mutable values in `setProperties`.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ## Differences from Neo4j
 
 | Item | Neo4j | Memgraph |

--- a/graph/graph-neo4j/README.ko.md
+++ b/graph/graph-neo4j/README.ko.md
@@ -674,6 +674,40 @@ val driver = GraphDatabase.driver("bolt://localhost:7687")
 val graphOps = Neo4jGraphOperations(driver, database = "neo4j")
 ```
 
+### Schema / Index Management
+
+`Neo4jGraphOperations`는 Neo4j `CREATE INDEX`와 `CREATE CONSTRAINT`를 공통 `SchemaManager` API로 노출한다.
+
+```kotlin
+import io.bluetape4k.graph.schema.schemaManager
+
+val schema = graphOps.schemaManager()
+schema.createIndex("Person", "email")
+schema.createUniqueConstraint("Person", "email")
+val constraints = schema.listConstraints()
+```
+
+### Merge / Upsert and Transaction DSL
+
+Neo4j backend는 native Cypher `MERGE` 기반 `GraphMergeOperations`와 driver transaction 기반
+`Transaction DSL`을 지원한다. endpoint lookup은 Neo4j 5.x `elementId()`를 사용한다.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = graphOps.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = graphOps.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ### createVertex 예시
 
 ```kotlin

--- a/graph/graph-neo4j/README.md
+++ b/graph/graph-neo4j/README.md
@@ -83,6 +83,27 @@ val driver = GraphDatabase.driver("bolt://localhost:7687")
 val graphOps = Neo4jGraphOperations(driver, database = "neo4j")
 ```
 
+### Merge / Upsert and Transaction DSL
+
+Neo4j supports `GraphMergeOperations` with native Cypher `MERGE` and repository-style `Transaction DSL` backed by
+driver transactions. Relationship merge uses Neo4j 5.x `elementId()` for endpoint lookup.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = graphOps.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+val edge = graphOps.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ### createVertex Example
 
 ```kotlin

--- a/graph/graph-tinkerpop/README.ko.md
+++ b/graph/graph-tinkerpop/README.ko.md
@@ -15,6 +15,7 @@ TinkerGraph(in-memory JVM 그래프 DB)를 사용하여 `graph-core` 인터페�
 |--------|------|
 | `TinkerGraphOperations` | 동기(blocking) 방식 구현 |
 | `TinkerGraphSuspendOperations` | 코루틴(suspend + Flow) 방식 구현 |
+| `TinkerGraphSchemaManager` | 테스트 친화적인 in-memory schema/index metadata manager |
 | `GremlinRecordMapper` | TinkerPop Vertex/Edge/Path -> GraphVertex/GraphEdge/GraphPath 변환 |
 
 ## 의존성
@@ -43,6 +44,40 @@ ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024L))
 val neighbors = ops.neighbors(alice.id, NeighborOptions(edgeLabel = "KNOWS"))
 
 ops.close()
+```
+
+## Schema / Index Management
+
+TinkerGraph는 durable schema DDL이 없지만 `schemaManager()`가 현재 `TinkerGraphOperations` instance 안에
+index metadata를 기록한다. Unique constraint는 강제할 수 없으므로 명시적으로 실패한다.
+
+```kotlin
+import io.bluetape4k.graph.schema.schemaManager
+
+val schema = ops.schemaManager()
+schema.createIndex("Person", "email")
+val indexes = schema.listIndexes()
+```
+
+## Merge / Upsert and Transaction DSL
+
+TinkerGraph backend는 Gremlin get-or-create/update 방식의 `GraphMergeOperations`와 in-memory `Transaction DSL`을
+제공한다. 외부 DB transaction은 없지만, 테스트와 local prototype에서 동일한 API surface를 검증할 수 있다.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
 ```
 
 ## 그래프 알고리즘

--- a/graph/graph-tinkerpop/README.md
+++ b/graph/graph-tinkerpop/README.md
@@ -60,6 +60,27 @@ schema.createIndex("Person", "email")
 schema.listIndexes()
 ```
 
+## Merge / Upsert and Transaction DSL
+
+TinkerGraph supports `GraphMergeOperations` with Gremlin get-or-create/update semantics and an in-memory
+`Transaction DSL`. This keeps tests and local prototypes on the same API surface as server-backed modules.
+
+```kotlin
+import io.bluetape4k.graph.repository.mergeVertex
+import io.bluetape4k.graph.repository.transaction
+
+val alice = ops.mergeVertex(
+    label = "Person",
+    matchProperties = mapOf("email" to "alice@example.com"),
+    setProperties = mapOf("name" to "Alice"),
+)
+
+ops.transaction {
+    val bob = createVertex("Person", mapOf("email" to "bob@example.com"))
+    createEdge(alice.id, bob.id, "KNOWS")
+}
+```
+
 ## Graph Algorithms
 
 TinkerPop uses native Gremlin traversals for all 6 algorithms — no JVM fallback needed.


### PR DESCRIPTION
## Summary

- root README 한/영에 `SchemaManager`, `Merge / Upsert`, `Transaction DSL` capability 섹션 추가
- backend README 한/영에 `schemaManager()`, `mergeVertex()`, `transaction { }` usage 동기화
- `GraphMergeOperations`, `GraphSchemaManager`, schema metadata model KDoc에 Kotlin usage example 추가
- CHANGELOG에 graph-core capability docs 동기화 항목 추가

## Verification

```bash
./gradlew :graph-core:compileKotlin --no-daemon
git diff --check
```

README capability grep count도 확인했습니다. 모든 `graph/*/README*.md`, root README 한/영, CHANGELOG에서 관련 capability mention이 존재합니다.

Closes #75
