### PR TITLE
test: suspend weighted path 통합 검증 추가

### DIFF
--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeSuspendWeightedPathTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeSuspendWeightedPathTest.kt
@@ -1,0 +1,127 @@
+package io.bluetape4k.graph.age
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.assertions.shouldBeNear
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AgeSuspendWeightedPathTest {
+
+    companion object : KLogging()
+
+    private lateinit var dataSource: HikariDataSource
+    private lateinit var database: Database
+    private lateinit var ops: AgeGraphSuspendOperations
+    private val graphName = "weighted_suspend_test"
+
+    @BeforeAll
+    fun setup() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        database = Database.connect(dataSource)
+        ops = AgeGraphSuspendOperations(graphName)
+    }
+
+    @AfterAll
+    fun teardown() {
+        dataSource.close()
+    }
+
+    @BeforeEach
+    fun resetGraph() = runSuspendIO {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        ops.createGraph(graphName)
+    }
+
+    @Test
+    fun `Dijkstra 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 경로에서 제외한다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val isolated = ops.createVertex("City", mapOf("name" to "Z"))
+
+        ops.shortestPath(
+            a.id,
+            isolated.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `AStar 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.aStarPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { _ -> 0.0 }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    private suspend fun createWeightedRoadGraph(): WeightedRoadGraph {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+        return WeightedRoadGraph(a, b, c)
+    }
+
+    private data class WeightedRoadGraph(val a: GraphVertex, val b: GraphVertex, val c: GraphVertex)
+}

--- a/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBSuspendWeightedPathTest.kt
+++ b/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBSuspendWeightedPathTest.kt
@@ -1,0 +1,102 @@
+package io.bluetape4k.graph.falkordb
+
+import io.bluetape4k.assertions.shouldBeNear
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FalkorDBSuspendWeightedPathTest : AbstractFalkorDBTest() {
+
+    companion object : KLogging()
+
+    private lateinit var ops: FalkorDBGraphSuspendOperations
+
+    @BeforeAll
+    override fun setupAll() {
+        super.setupAll()
+        ops = FalkorDBGraphSuspendOperations(driver, graphName)
+    }
+
+    @BeforeEach
+    fun cleanup() = runSuspendIO {
+        ops.dropGraph(graphName)
+    }
+
+    @Test
+    fun `Dijkstra 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 경로에서 제외한다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val isolated = ops.createVertex("City", mapOf("name" to "Z"))
+
+        ops.shortestPath(
+            a.id,
+            isolated.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `AStar 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.aStarPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { _ -> 0.0 }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    private suspend fun createWeightedRoadGraph(): WeightedRoadGraph {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+        return WeightedRoadGraph(a, b, c)
+    }
+
+    private data class WeightedRoadGraph(val a: GraphVertex, val b: GraphVertex, val c: GraphVertex)
+}

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphSuspendWeightedPathTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphSuspendWeightedPathTest.kt
@@ -1,0 +1,113 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.assertions.shouldBeNear
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MemgraphSuspendWeightedPathTest {
+
+    companion object : KLogging()
+
+    private lateinit var driver: Driver
+    private lateinit var ops: MemgraphGraphSuspendOperations
+
+    @BeforeAll
+    fun setup() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+
+    @BeforeEach
+    fun clearGraph() = runSuspendIO {
+        ops.dropGraph("default")
+    }
+
+    @Test
+    fun `Dijkstra 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 경로에서 제외한다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val isolated = ops.createVertex("City", mapOf("name" to "Z"))
+
+        ops.shortestPath(
+            a.id,
+            isolated.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `AStar 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.aStarPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { _ -> 0.0 }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    private suspend fun createWeightedRoadGraph(): WeightedRoadGraph {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+        return WeightedRoadGraph(a, b, c)
+    }
+
+    private data class WeightedRoadGraph(val a: GraphVertex, val b: GraphVertex, val c: GraphVertex)
+}

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jSuspendWeightedPathTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jSuspendWeightedPathTest.kt
@@ -1,0 +1,117 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.assertions.shouldBeNear
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * Neo4j `GraphSuspendOperations` 가중치 최단 경로(Dijkstra/A*) 통합 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jSuspendWeightedPathTest {
+
+    companion object : KLogging()
+
+    private lateinit var driver: Driver
+    private lateinit var ops: Neo4jGraphSuspendOperations
+
+    @BeforeAll
+    fun setup() {
+        val server = Neo4jServer.Launcher.neo4j
+        driver = GraphDatabase.driver(server.boltUrl, AuthTokens.none())
+        ops = Neo4jGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+
+    @BeforeEach
+    fun clearGraph() = runSuspendIO {
+        ops.dropGraph("default")
+    }
+
+    @Test
+    fun `Dijkstra 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 경로에서 제외한다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val isolated = ops.createVertex("City", mapOf("name" to "Z"))
+
+        ops.shortestPath(
+            a.id,
+            isolated.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `AStar 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.aStarPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { _ -> 0.0 }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    private suspend fun createWeightedRoadGraph(): WeightedRoadGraph {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+        return WeightedRoadGraph(a, b, c)
+    }
+
+    private data class WeightedRoadGraph(val a: GraphVertex, val b: GraphVertex, val c: GraphVertex)
+}

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendWeightedPathTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendWeightedPathTest.kt
@@ -1,0 +1,101 @@
+package io.bluetape4k.graph.tinkerpop
+
+import io.bluetape4k.assertions.shouldBeNear
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.MissingWeightPolicy
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TinkerGraphSuspendWeightedPathTest {
+
+    companion object : KLogging()
+
+    private val ops = TinkerGraphSuspendOperations()
+
+    @AfterAll
+    fun teardown() {
+        ops.close()
+    }
+
+    @BeforeEach
+    fun reset() = runSuspendIO {
+        ops.dropGraph("default")
+    }
+
+    @Test
+    fun `Dijkstra 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    @Test
+    fun `Skip 정책에서 weight 없는 간선은 경로에서 제외한다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD")
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+
+        ops.shortestPath(
+            a.id,
+            c.id,
+            PathOptions(
+                weightProperty = "cost",
+                edgeLabel = "ROAD",
+                missingWeightPolicy = MissingWeightPolicy.Skip,
+            ),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `연결되지 않으면 가중치 경로는 null이다`() = runSuspendIO {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val isolated = ops.createVertex("City", mapOf("name" to "Z"))
+
+        ops.shortestPath(
+            a.id,
+            isolated.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun `AStar 최단 경로 A에서 C까지는 A-B-C이다`() = runSuspendIO {
+        val (a, _, c) = createWeightedRoadGraph()
+
+        val path = ops.aStarPath(
+            a.id,
+            c.id,
+            PathOptions(weightProperty = "cost", edgeLabel = "ROAD"),
+        ) { _ -> 0.0 }.shouldNotBeNull()
+
+        path.totalWeight.shouldBeNear(3.0, 0.001)
+    }
+
+    private suspend fun createWeightedRoadGraph(): WeightedRoadGraph {
+        val a = ops.createVertex("City", mapOf("name" to "A"))
+        val b = ops.createVertex("City", mapOf("name" to "B"))
+        val c = ops.createVertex("City", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "ROAD", mapOf("cost" to 1.0))
+        ops.createEdge(b.id, c.id, "ROAD", mapOf("cost" to 2.0))
+        ops.createEdge(a.id, c.id, "ROAD", mapOf("cost" to 5.0))
+        return WeightedRoadGraph(a, b, c)
+    }
+
+    private data class WeightedRoadGraph(val a: GraphVertex, val b: GraphVertex, val c: GraphVertex)
+}


### PR DESCRIPTION
## Summary

- `GraphSuspendOperations` weighted shortest path integration tests 추가
- Neo4j, Memgraph, AGE, TinkerGraph, FalkorDB 각각에 suspend 전용 test class 추가
- 각 backend에서 다음 scenario 검증
  - Dijkstra weighted shortest path: A→B→C, totalWeight=3.0
  - `MissingWeightPolicy.Skip`: weight 없는 edge 제외 후 path 없음
  - disconnected vertex: null 반환
  - A* zero heuristic path: A→B→C, totalWeight=3.0

## Verification

```bash
./gradlew :graph-neo4j:compileTestKotlin :graph-memgraph:compileTestKotlin :graph-age:compileTestKotlin :graph-tinkerpop:compileTestKotlin :graph-falkordb:compileTestKotlin --no-daemon
./gradlew \
  :graph-tinkerpop:test --tests "*.TinkerGraphSuspendWeightedPathTest" \
  :graph-neo4j:test --tests "*.Neo4jSuspendWeightedPathTest" \
  :graph-memgraph:test --tests "*.MemgraphSuspendWeightedPathTest" \
  :graph-age:test --tests "*.AgeSuspendWeightedPathTest" \
  :graph-falkordb:test --tests "*.FalkorDBSuspendWeightedPathTest" \
  --no-daemon
git diff --check
```

Targeted test 결과: 5 backend × 4 tests = 20 passing.

Closes #40
