### PR TITLE
docs: merged PR lessons 정리

### DIFF
--- a/docs/lessons/2026-05-12-issue-96-graph-ktor.md
+++ b/docs/lessons/2026-05-12-issue-96-graph-ktor.md
@@ -1,4 +1,12 @@
-# Issue #96 graph-ktor Lessons
+# PR #100 graph-ktor Lessons
+
+## Context
+
+- PR: #100 `feat: graph-ktor Ktor plugin module 추가`
+- Issue: #96
+- Merge commit: `3a883f25ccea0bb3588de7775cfc360312d9abd9`
+- Scope: `ktor/graph-ktor` module, `examples/ktor-graph-examples`, backend helper functions, Ktor route accessors, README/BOM/CHANGELOG/superpowers docs.
+- Verification used in PR: `./gradlew projects --no-daemon`, targeted `graph-ktor` backend smoke tests, `:graph-ktor:test`, `:ktor-graph-examples:test`, module builds, `git diff --check`, GitHub CI.
 
 ## Lessons & Learns
 

--- a/docs/lessons/2026-05-12-pr-97-graph-core-capability-docs.md
+++ b/docs/lessons/2026-05-12-pr-97-graph-core-capability-docs.md
@@ -1,0 +1,50 @@
+# PR #97 graph-core capability docs Lessons
+
+## Context
+
+- PR: #97 `docs: graph-core capability 문서 정합성 확보`
+- Issue: #75
+- Merge commit: `22faa1f7a9628ea9b579158918f2abf916a4c168`
+- Scope: root README 한/영, backend README 한/영, `GraphMergeOperations`, `GraphSchemaManager`, schema metadata model KDoc, CHANGELOG.
+- Verification used in PR: `./gradlew :graph-core:compileKotlin --no-daemon`, `git diff --check`, README capability mention grep.
+
+## Decision or Finding
+
+- Lesson: capability documentation은 root README만 고치면 끝나지 않는다.
+  - Evidence: `SchemaManager`, `Merge / Upsert`, `Transaction DSL` capability는 root README, `graph-core` README, backend README, public KDoc에 모두 노출되어야 사용자가 backend별 지원 범위와 unsupported behavior를 같은 방식으로 이해할 수 있다.
+  - Future guard: cross-backend capability를 문서화할 때는 root README, `graph-core` README, backend README 한/영, public KDoc, CHANGELOG를 하나의 sync set으로 취급한다.
+
+- Lesson: "지원하지 않음"도 documented capability다.
+  - Evidence: AGE schema DDL, FalkorDB transaction처럼 backend 특성 때문에 제한되는 API는 silent omission보다 explicit unsupported contract가 더 안전하다.
+  - Future guard: backend별 capability table에는 supported path뿐 아니라 explicit unsupported path와 이유를 함께 기록한다.
+
+- Lesson: capability docs는 compile verification과 grep verification을 함께 써야 한다.
+  - Evidence: KDoc code example은 compile 대상이고, README sync는 compile로 잡히지 않는다. PR에서는 `:graph-core:compileKotlin`과 README grep count를 함께 확인했다.
+  - Future guard: docs-only처럼 보여도 public API KDoc이 바뀌면 affected module compile을 실행하고, bilingual README sync는 grep 또는 structured checklist로 확인한다.
+
+## Outcome
+
+- Root README 한/영에 `SchemaManager`, `Merge / Upsert`, `Transaction DSL` overview가 추가됐다.
+- Backend README 한/영에 backend-specific schema/merge/transaction semantics가 동기화됐다.
+- `GraphMergeOperations`, `GraphSchemaManager`, schema metadata model KDoc에 usage example이 추가됐다.
+- CHANGELOG에 graph-core capability docs sync가 기록됐다.
+
+## Verification
+
+- PR #97 CI는 모두 pass 후 merge됐다.
+- Merge 후 `develop`은 `3a883f2`까지 fast-forward sync됐다.
+- Local sync 후 open PR이 없는 상태를 확인했다.
+
+## Future Guidance
+
+- New graph-core capability가 추가되면 다음 문서 set을 한 번에 갱신한다:
+  - `README.md`
+  - `README.ko.md`
+  - `graph/graph-core/README.md`
+  - `graph/graph-core/README.ko.md`
+  - affected backend `README.md`
+  - affected backend `README.ko.md`
+  - public API KDoc
+  - `CHANGELOG.md`
+- Bilingual docs에서는 technical terms를 영문으로 유지하고 설명 문장만 한국어로 작성한다.
+- Backend support matrix를 작성할 때는 "not supported"를 누락이 아니라 명시적 contract로 다룬다.

--- a/docs/lessons/2026-05-12-pr-98-suspend-weighted-path-tests.md
+++ b/docs/lessons/2026-05-12-pr-98-suspend-weighted-path-tests.md
@@ -1,0 +1,54 @@
+# PR #98 suspend weighted path tests Lessons
+
+## Context
+
+- PR: #98 `test: suspend weighted path 통합 검증 추가`
+- Issue: #40
+- Merge commit: `a9517b73c9037ec29d12a27232a864f7bb083161`
+- Scope: `GraphSuspendOperations` weighted shortest path integration tests for Neo4j, Memgraph, Apache AGE, TinkerGraph, FalkorDB.
+- Verification used in PR: backend compileTestKotlin tasks, targeted backend tests, `git diff --check`.
+
+## Decision or Finding
+
+- Lesson: sync path coverage가 있어도 suspend path parity는 별도 integration test가 필요하다.
+  - Evidence: PR #98은 backend별 `*SuspendWeightedPathTest`를 추가해 Dijkstra, `MissingWeightPolicy.Skip`, disconnected vertex, A* zero heuristic을 suspend API로 직접 검증했다.
+  - Future guard: sync API에 이미 test가 있더라도 suspend facade가 별도 implementation 또는 adapter를 거치면 backend별 suspend test를 추가한다.
+
+- Lesson: weighted path test는 happy path만으로 부족하다.
+  - Evidence: totalWeight=3.0 happy path 외에 missing weight skip, disconnected vertex null, A* zero heuristic을 함께 검증해야 edge filtering과 no-path semantics가 유지된다.
+  - Future guard: path algorithm tests는 at least success, filtered no-path, disconnected no-path, alternative algorithm path를 포함한다.
+
+- Lesson: backend별 graph reset 방식은 test stability의 일부다.
+  - Evidence: TinkerGraph는 in-memory reset, Neo4j/Memgraph는 `dropGraph("default")`, AGE/FalkorDB는 graphName lifecycle과 container fixture를 각각 따른다.
+  - Future guard: shared abstract test를 만들기 전에 backend별 cleanup/lifecycle 차이를 먼저 확인한다. 동일 scenario라도 reset primitive는 backend-local로 둔다.
+
+- Lesson: Testcontainers-backed algorithm tests는 targeted command를 PR body에 명시해야 한다.
+  - Evidence: PR #98은 5 backend x 4 tests = 20 passing을 targeted command로 검증했다. 이 정보가 없으면 CI matrix failure와 local reproduction path를 연결하기 어렵다.
+  - Future guard: backend matrix test PR은 compile command, targeted test command, expected test count를 PR body와 lesson에 남긴다.
+
+## Outcome
+
+- 다음 test classes가 추가됐다:
+  - `AgeSuspendWeightedPathTest`
+  - `FalkorDBSuspendWeightedPathTest`
+  - `MemgraphSuspendWeightedPathTest`
+  - `Neo4jSuspendWeightedPathTest`
+  - `TinkerGraphSuspendWeightedPathTest`
+- 각 backend에서 suspend weighted shortest path behavior가 같은 scenario set으로 검증된다.
+
+## Verification
+
+- PR #98 CI는 모두 pass 후 merge됐다.
+- PR body 기준 targeted test 결과는 5 backend x 4 tests = 20 passing이다.
+- Merge 후 `develop`은 `3a883f2`까지 fast-forward sync됐다.
+
+## Future Guidance
+
+- Graph algorithm behavior를 추가하거나 수정할 때는 sync/suspend API parity를 별도 checklist로 둔다.
+- Backend-specific cleanup은 공통화하기 전에 lifecycle 차이를 조사한다.
+- Weighted path scenario set은 다음을 기본으로 유지한다:
+  - Dijkstra weighted shortest path
+  - `MissingWeightPolicy.Skip`
+  - disconnected vertex
+  - A* with zero heuristic
+- Testcontainers를 쓰는 backend test는 expected test count와 targeted command를 PR body에 남긴다.

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -2,6 +2,10 @@
 
 Store durable bluetape4k-graph lessons in this directory.
 
+Create or update a lesson after every completed PR or work item, even when the
+change is small. Keep it short for small work, but still record the context,
+verification, and one reusable guardrail.
+
 Use this structure for each lesson:
 
 - Context


### PR DESCRIPTION
## Summary

- PR #97 graph-core capability docs lesson 추가
- PR #98 suspend weighted path tests lesson 추가
- PR #100 graph-ktor lesson에 PR/merge metadata와 verification context 보강
- `docs/lessons/README.md`에 completed PR/work item마다 lesson을 작성하도록 명시

## Verification

```bash
git diff --check
```

Gradle tests는 실행하지 않았습니다. docs-only 변경입니다.