### PR TITLE
ci: graph-ktor Nightly 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       graph-age: ${{ steps.filter.outputs.graph-age }}
       graph-falkordb: ${{ steps.filter.outputs.graph-falkordb }}
       graph-spring-boot: ${{ steps.filter.outputs.graph-spring-boot }}
+      graph-ktor: ${{ steps.filter.outputs.graph-ktor }}
       common: ${{ steps.filter.outputs.common }}
     steps:
       - uses: actions/checkout@v6
@@ -100,6 +101,9 @@ jobs:
               - 'graph/graph-falkordb/**'
             graph-spring-boot:
               - 'spring-boot4/**'
+            graph-ktor:
+              - 'ktor/graph-ktor/**'
+              - 'examples/ktor-graph-examples/**'
             common:
               - 'buildSrc/**'
               - 'gradle/**'
@@ -269,7 +273,71 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 6. Neo4j (Testcontainers) ─────────────────────────────────────────────
+  # ── 6. Ktor Graph (Testcontainers + TinkerGraph example) ─────────────────
+  test-graph-ktor:
+    name: Test / Ktor Graph (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-ktor'] == 'true' ||
+      needs.changes.outputs['graph-core'] == 'true' ||
+      needs.changes.outputs['graph-neo4j'] == 'true' ||
+      needs.changes.outputs['graph-memgraph'] == 'true' ||
+      needs.changes.outputs['graph-age'] == 'true' ||
+      needs.changes.outputs['graph-falkordb'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test graph-ktor and Ktor example
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :graph-ktor:test \
+              :ktor-graph-examples:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :graph-ktor:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-ktor
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-ktor
+          path: '**/build/reports/kover/report.xml'
+          retention-days: 7
+
+  # ── 7. Neo4j (Testcontainers) ─────────────────────────────────────────────
   test-graph-neo4j:
     name: Test / Neo4j (Testcontainers)
     runs-on: ubuntu-latest
@@ -326,7 +394,7 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 7. Memgraph (Testcontainers) ──────────────────────────────────────────
+  # ── 8. Memgraph (Testcontainers) ──────────────────────────────────────────
   test-graph-memgraph:
     name: Test / Memgraph (Testcontainers)
     runs-on: ubuntu-latest
@@ -383,7 +451,7 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 8. Apache AGE (Testcontainers) ────────────────────────────────────────
+  # ── 9. Apache AGE (Testcontainers) ────────────────────────────────────────
   test-graph-age:
     name: Test / Apache AGE (Testcontainers)
     runs-on: ubuntu-latest
@@ -440,7 +508,7 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 9. FalkorDB (Testcontainers) ──────────────────────────────────────────
+  # ── 10. FalkorDB (Testcontainers) ─────────────────────────────────────────
   test-graph-falkordb:
     name: Test / FalkorDB (Testcontainers)
     runs-on: ubuntu-latest
@@ -497,7 +565,7 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 10. 커버리지 집계 ─────────────────────────────────────────────────────
+  # ── 11. 커버리지 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
@@ -505,6 +573,7 @@ jobs:
     needs:
       - test-core
       - test-spring-starters
+      - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph
       - test-graph-age
@@ -547,7 +616,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 14
 
-  # ── 11. 결과 집계 ──────────────────────────────────────────────────────────
+  # ── 12. 결과 집계 ──────────────────────────────────────────────────────────
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
@@ -558,6 +627,7 @@ jobs:
       - build
       - test-core
       - test-spring-starters
+      - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph
       - test-graph-age

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -184,7 +184,64 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 4. Neo4j (Testcontainers) ─────────────────────────────────────────────
+  # ── 4. Ktor Graph (Testcontainers + TinkerGraph example) ─────────────────
+  test-graph-ktor:
+    name: Test / Ktor Graph (Testcontainers)
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test graph-ktor and Ktor example
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :graph-ktor:test \
+              :ktor-graph-examples:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :graph-ktor:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-ktor
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-ktor
+          path: '**/build/reports/kover/'
+          retention-days: 14
+
+  # ── 5. Neo4j (Testcontainers) ─────────────────────────────────────────────
   test-graph-neo4j:
     name: Test / Neo4j (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -238,7 +295,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 5. Memgraph (Testcontainers) ──────────────────────────────────────────
+  # ── 6. Memgraph (Testcontainers) ──────────────────────────────────────────
   test-graph-memgraph:
     name: Test / Memgraph (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -292,7 +349,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 6. Apache AGE (Testcontainers) ────────────────────────────────────────
+  # ── 7. Apache AGE (Testcontainers) ────────────────────────────────────────
   test-graph-age:
     name: Test / Apache AGE (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -346,7 +403,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 7. FalkorDB (Testcontainers) ──────────────────────────────────────────
+  # ── 8. FalkorDB (Testcontainers) ──────────────────────────────────────────
   test-graph-falkordb:
     name: Test / FalkorDB (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -400,7 +457,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 8. Examples (Testcontainers) ──────────────────────────────────────────
+  # ── 9. Examples (Testcontainers) ──────────────────────────────────────────
   test-examples:
     name: Test / Examples (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -444,7 +501,7 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
-  # ── 9. 커버리지 집계 ──────────────────────────────────────────────────────
+  # ── 10. 커버리지 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
 
@@ -453,6 +510,7 @@ jobs:
     needs:
       - test-core
       - test-spring-starters
+      - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph
       - test-graph-age
@@ -495,7 +553,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 30
 
-  # ── 10. 결과 집계 ─────────────────────────────────────────────────────────
+  # ── 11. 결과 집계 ─────────────────────────────────────────────────────────
   nightly-status:
     name: Nightly Status
     runs-on: ubuntu-latest
@@ -504,6 +562,7 @@ jobs:
       - build
       - test-core
       - test-spring-starters
+      - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph
       - test-graph-age

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,7 @@ Schema DSL uses Exposed Table-style declarations through `VertexLabel` and
   `.github/workflows/nightly.yml` so the module's tests run in the appropriate
   CI/Nightly scope. Container-backed module tests should usually have a
   dedicated full Nightly job instead of being hidden inside the daily smoke job.
+- When `.github/workflows/nightly.yml` is changed, explicitly run the Nightly
+  workflow with `workflow_dispatch` before DoD and record the run URL/result.
+  For module coverage changes, use `scope=full` unless the change is strictly
+  smoke-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,7 @@ Schema DSL uses Exposed Table-style declarations through `VertexLabel` and
 - Example modules use abstract test classes for shared logic and concrete
   backend classes for `ops` and server lifecycle.
 - `testMutex` BuildService serializes container-heavy tests to avoid conflicts.
+- When adding a new module, update both `.github/workflows/ci.yml` and
+  `.github/workflows/nightly.yml` so the module's tests run in the appropriate
+  CI/Nightly scope. Container-backed module tests should usually have a
+  dedicated full Nightly job instead of being hidden inside the daily smoke job.

--- a/docs/lessons/2026-05-12-pr-100-graph-ktor-nightly-gap.md
+++ b/docs/lessons/2026-05-12-pr-100-graph-ktor-nightly-gap.md
@@ -1,0 +1,39 @@
+# PR #100 graph-ktor Nightly Gap Lessons
+
+## Context
+
+- PR #100 added `ktor/graph-ktor` and `examples/ktor-graph-examples`.
+- The PR verified `:graph-ktor:test` and `:ktor-graph-examples:test` locally and in the PR body.
+- CI/Nightly workflow updates missed the new module-specific test task.
+
+## Decision or Finding
+
+- Lesson: adding a module is not complete until CI and Nightly task lists include it.
+  - Evidence: `.github/workflows/nightly.yml` did not contain `:graph-ktor:test` or `:ktor-graph-examples:test` after PR #100 was merged.
+  - Future guard: every new module plan must include a workflow grep for the module path and Gradle task name.
+
+- Lesson: integration module tests belong in their own workflow job when their runtime cost differs from surrounding modules.
+  - Evidence: `graph-ktor:test` includes lightweight Ktor tests plus backend Testcontainers smoke for Neo4j, Memgraph, AGE, and FalkorDB. Putting it into the daily in-memory core job would make smoke Nightly unexpectedly pull containers.
+  - Future guard: keep `graph-ktor` in a dedicated Ktor Graph Testcontainers job and run it on full Nightly / relevant CI changes.
+
+## Outcome
+
+- `AGENTS.md` now explicitly requires CI and Nightly updates when a new module is added.
+- CI path filtering now has a `graph-ktor` category for:
+  - `ktor/graph-ktor/**`
+  - `examples/ktor-graph-examples/**`
+- CI now has `Test / Ktor Graph (Testcontainers)` for `:graph-ktor:test` and `:ktor-graph-examples:test`.
+- Nightly full now has the same Ktor Graph Testcontainers job.
+- Coverage aggregation now includes `coverage-ktor`.
+
+## Verification
+
+- `git diff --check`
+- `./gradlew :graph-ktor:test :ktor-graph-examples:test --no-daemon`
+
+## Future Guidance
+
+- For every new module, search workflow coverage before PR close:
+  - `rg "<module-name>|:<module-name>:test" .github/workflows`
+- If a module contains Testcontainers smoke, do not hide it inside an in-memory smoke job.
+- Add a lesson immediately when workflow coverage was missed.

--- a/docs/lessons/2026-05-12-pr-100-graph-ktor-nightly-gap.md
+++ b/docs/lessons/2026-05-12-pr-100-graph-ktor-nightly-gap.md
@@ -31,8 +31,10 @@
 
 - `git diff --check`
 - `./gradlew :graph-ktor:test :ktor-graph-examples:test --no-daemon`
-- Nightly full dispatch was started for branch `ci/graph-ktor-nightly`:
+- Nightly full dispatch for branch `ci/graph-ktor-nightly` completed successfully:
   - https://github.com/bluetape4k/bluetape4k-graph/actions/runs/25705115469
+  - `Test / Ktor Graph (Testcontainers)` passed.
+  - `Nightly Status` passed.
 
 ## Future Guidance
 

--- a/docs/lessons/2026-05-12-pr-100-graph-ktor-nightly-gap.md
+++ b/docs/lessons/2026-05-12-pr-100-graph-ktor-nightly-gap.md
@@ -19,6 +19,7 @@
 ## Outcome
 
 - `AGENTS.md` now explicitly requires CI and Nightly updates when a new module is added.
+- `AGENTS.md` now requires explicit `workflow_dispatch` execution when Nightly workflow changes.
 - CI path filtering now has a `graph-ktor` category for:
   - `ktor/graph-ktor/**`
   - `examples/ktor-graph-examples/**`
@@ -30,10 +31,13 @@
 
 - `git diff --check`
 - `./gradlew :graph-ktor:test :ktor-graph-examples:test --no-daemon`
+- Nightly full dispatch was started for branch `ci/graph-ktor-nightly`:
+  - https://github.com/bluetape4k/bluetape4k-graph/actions/runs/25705115469
 
 ## Future Guidance
 
 - For every new module, search workflow coverage before PR close:
   - `rg "<module-name>|:<module-name>:test" .github/workflows`
 - If a module contains Testcontainers smoke, do not hide it inside an in-memory smoke job.
+- If `nightly.yml` changes, trigger Nightly manually and wait for the relevant jobs before reporting DoD.
 - Add a lesson immediately when workflow coverage was missed.


### PR DESCRIPTION
## Summary

- `graph-ktor` / `ktor-graph-examples` path filter를 CI에 추가
- `Test / Ktor Graph (Testcontainers)` job을 CI에 추가
- 동일한 Ktor Graph Testcontainers job을 Full Nightly에 추가
- coverage aggregation에 `coverage-ktor` 포함
- 신규 모듈 생성 시 CI/Nightly test coverage를 반드시 갱신하도록 `AGENTS.md` 지침 추가
- Nightly workflow 변경 시 `workflow_dispatch` 실행과 run URL/result 기록을 DoD로 요구
- PR #100에서 Nightly 누락을 놓친 내용을 `docs/lessons`로 기록

## Verification

```bash
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/nightly.yml
./gradlew :graph-ktor:test :ktor-graph-examples:test --no-daemon
git diff --check
```

Manual CI dispatch:

- Run: https://github.com/bluetape4k/bluetape4k-graph/actions/runs/25705363899
- Result: passed
- `Test / Ktor Graph (Testcontainers)`: passed
- `CI Status`: passed

Nightly full dispatch:

- Run: https://github.com/bluetape4k/bluetape4k-graph/actions/runs/25705115469
- Result: passed
- `Test / Ktor Graph (Testcontainers)`: passed
- `Nightly Status`: passed

## Notes

`graph-ktor:test`에는 Neo4j/Memgraph/AGE/FalkorDB Testcontainers smoke가 포함되어 있으므로 daily smoke가 아니라 Full Nightly 전용 job으로 추가했습니다.