### PR TITLE
[codex] Preserve issue 96 docs after completion

### DIFF
--- a/docs/superpowers/plans/2026-05-12-issue-96-graph-ktor-plan.md
+++ b/docs/superpowers/plans/2026-05-12-issue-96-graph-ktor-plan.md
@@ -1,6 +1,6 @@
 # Issue #96 graph-ktor Implementation Plan
 
-> Spec: [2026-05-12-issue-96-graph-ktor-design.md](../specs/2026-05-12-issue-96-graph-ktor-design.md)  
+> Spec: [2026-05-12-issue-96-graph-ktor-design.md](../specs/2026-05-12-issue-96-graph-ktor-design.md)
 > Related issue: [#96](https://github.com/bluetape4k/bluetape4k-graph/issues/96)
 
 ## Plan Summary

--- a/docs/superpowers/specs/2026-05-12-issue-96-graph-ktor-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-96-graph-ktor-design.md
@@ -1,6 +1,6 @@
 # Issue #96 graph-ktor Design
 
-> Language: Korean with English technical terms.  
+> Language: Korean with English technical terms.
 > Related issue: [#96](https://github.com/bluetape4k/bluetape4k-graph/issues/96)
 
 ## 1. 문제와 목표


### PR DESCRIPTION
## Summary

- Preserve the issue #96 planning and design documents after the issue was closed as completed.
- Remove trailing Markdown whitespace from the two archived docs.

## Context

Issue #96 (`feat: graph-ktor — Ktor plugin module 추가`) is closed with state reason `COMPLETED`, so this PR keeps the follow-up limited to documentation cleanup.

## Validation

- `gh issue view 96 --json number,title,state,stateReason,closedAt,url`
- `git diff --check -- docs/superpowers/plans/2026-05-12-issue-96-graph-ktor-plan.md docs/superpowers/specs/2026-05-12-issue-96-graph-ktor-design.md`

Gradle tests were not run because the diff is whitespace-only documentation cleanup.