### PR TITLE
Cache graph Testcontainers Docker images

### DIFF
--- a/.github/actions/testcontainers-image-cache/action.yml
+++ b/.github/actions/testcontainers-image-cache/action.yml
@@ -1,0 +1,35 @@
+name: Testcontainers Image Cache
+description: Restore/load or save Docker images used by Testcontainers graph jobs.
+
+inputs:
+  mode:
+    description: Use "restore" before tests and "save" after tests.
+    required: true
+  cache-key:
+    description: Cache key for Docker image archives when mode is "restore".
+    required: false
+  restore-key:
+    description: Restore key prefix for Docker image archives when mode is "restore".
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Docker image archive cache
+      if: ${{ inputs.mode == 'restore' }}
+      uses: actions/cache@v4
+      with:
+        path: /tmp/testcontainers-image-cache
+        key: ${{ inputs.cache-key }}
+        restore-keys: |
+          ${{ inputs.restore-key }}
+
+    - name: Load cached Docker images
+      if: ${{ inputs.mode == 'restore' }}
+      shell: bash
+      run: .github/scripts/docker-image-cache.sh load
+
+    - name: Save Docker images for cache post-step
+      if: ${{ inputs.mode == 'save' }}
+      shell: bash
+      run: .github/scripts/docker-image-cache.sh save

--- a/.github/scripts/docker-image-cache.sh
+++ b/.github/scripts/docker-image-cache.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+cache_dir="${DOCKER_IMAGE_CACHE_DIR:-/tmp/testcontainers-image-cache}"
+images_file="${TESTCONTAINERS_IMAGES_FILE:-.github/testcontainers-images.txt}"
+
+if [[ "$mode" != "load" && "$mode" != "save" ]]; then
+  echo "Usage: $0 <load|save>" >&2
+  exit 2
+fi
+
+mkdir -p "$cache_dir"
+
+archive_name() {
+  local image="$1"
+  printf '%s' "$image" | sed -e 's#[/:@]#_#g'
+}
+
+read_images() {
+  sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "$images_file"
+}
+
+if [[ "$mode" == "load" ]]; then
+  shopt -s nullglob
+  archives=("$cache_dir"/*.tar)
+  if (( ${#archives[@]} == 0 )); then
+    echo "No cached Docker image archives found in $cache_dir"
+    exit 0
+  fi
+
+  for archive in "${archives[@]}"; do
+    echo "Loading cached Docker image archive: $archive"
+    docker load -i "$archive"
+  done
+  exit 0
+fi
+
+while IFS= read -r image; do
+  archive="$cache_dir/$(archive_name "$image").tar"
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    echo "Saving Docker image to cache: $image -> $archive"
+    docker save -o "$archive" "$image"
+  else
+    echo "Image was not pulled by this job, skipping cache save: $image"
+  fi
+done < <(read_images)

--- a/.github/testcontainers-images.txt
+++ b/.github/testcontainers-images.txt
@@ -1,0 +1,6 @@
+# Docker images pulled by graph Testcontainers jobs.
+# Keep this list aligned with bluetape4k-testcontainers graphdb launchers and local graph fixtures.
+neo4j:5.26.24
+memgraph/memgraph:3.9.0
+apache/age:release_PG18_1.7.0
+falkordb/falkordb:v4.18.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
             common:
               - 'buildSrc/**'
               - 'gradle/**'
+              - '.github/actions/testcontainers-image-cache/**'
+              - '.github/scripts/docker-image-cache.sh'
+              - '.github/testcontainers-images.txt'
               - '*.gradle.kts'
               - 'settings.gradle.kts'
               - '.github/workflows/ci.yml'
@@ -301,6 +304,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-ktor and Ktor example
         run: |
           for attempt in 1 2 3; do
@@ -315,6 +325,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -361,6 +377,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3; do
@@ -372,6 +395,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -418,6 +447,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-memgraph
         run: |
           for attempt in 1 2 3; do
@@ -429,6 +465,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -475,6 +517,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-age
         run: |
           for attempt in 1 2 3; do
@@ -486,6 +535,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -532,6 +587,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-falkordb
         run: |
           for attempt in 1 2 3; do
@@ -543,6 +605,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -205,6 +205,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-ktor and Ktor example
         run: |
           for attempt in 1 2 3; do
@@ -219,6 +226,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -262,6 +275,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3; do
@@ -273,6 +293,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -316,6 +342,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-memgraph
         run: |
           for attempt in 1 2 3; do
@@ -327,6 +360,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -370,6 +409,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-age
         run: |
           for attempt in 1 2 3; do
@@ -381,6 +427,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -424,6 +476,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test graph-falkordb
         run: |
           for attempt in 1 2 3; do
@@ -435,6 +494,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Generate Kover XML report
         if: always()
@@ -478,6 +543,13 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
 
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
       - name: Test example modules
         run: |
           for attempt in 1 2 3; do
@@ -492,6 +564,12 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
 
       - name: Upload test results
         if: always()

--- a/docs/lessons/2026-05-13-issue-17-ci-build-cache.md
+++ b/docs/lessons/2026-05-13-issue-17-ci-build-cache.md
@@ -1,0 +1,7 @@
+# Issue #17 CI Build Cache
+
+- Context: Issue #17 already had Gradle caching enabled, but Testcontainers jobs still pulled graph database images without a persistent image archive cache.
+- Decision: Cache Docker image archives for the fixed graph Testcontainers images and load them before container-backed jobs.
+- Outcome: CI and Nightly Testcontainers jobs restore `/tmp/testcontainers-image-cache`, load any saved images, run tests, then save pulled images so the actions/cache post-step can persist them.
+- Verification: `actionlint .github/workflows/ci.yml .github/workflows/nightly.yml` and `bash -n .github/scripts/docker-image-cache.sh`.
+- Future rule: For Testcontainers image-cache work, cache the exact pinned launcher images, not a broad Docker directory, and include the image list in the cache key.


### PR DESCRIPTION
## Summary

- Add a reusable local composite action for restoring/loading and saving Testcontainers Docker image archives.
- Add the pinned graph database image list used by Neo4j, Memgraph, Apache AGE, and FalkorDB tests.
- Wire CI and Nightly container-backed graph jobs to restore images before tests and save pulled images for the cache post-step.

Closes #17

## Review Result

P0/P1 review status: 0 open P0, 0 open P1.

Resolved during review:
- Use job-scoped cache keys to avoid the first completed job saving a partial shared image cache.
- Keep the image list hash in the cache key so launcher tag changes invalidate the cache.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/nightly.yml`
- `bash -n .github/scripts/docker-image-cache.sh`
- `DOCKER_IMAGE_CACHE_DIR=/tmp/empty-testcontainers-image-cache .github/scripts/docker-image-cache.sh load`
- `yq e '.runs.using' .github/actions/testcontainers-image-cache/action.yml`\n- `git diff --cached --check`\n\nNot tested: remote cache hit behavior before the first GitHub Actions run populates caches.