### PR TITLE
docs: 2026-05-13 WIP 큐 갱신

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,63 +1,71 @@
 # WIP - bluetape4k-graph
 
-Snapshot: 2026-05-11 KST
+Snapshot: 2026-05-13 KST
 Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01.
-Open count: 10 issues.
+Open count: 11 issues.
 
 ## Recently Completed
 
-Core graph API foundation work is now merged and should stay in issue/PR history rather than the active queue:
+Core graph API foundation work remains closed and should stay in issue/PR history rather than the active queue:
 
-- `#13` transaction DSL — closed before this refresh.
-- `#32` schema/index manager — closed before this refresh.
-- `#34` merge/upsert — PR #72 merged.
-- `#33` batch insert — PR #78 merged.
-- `#76` graph-okio module rename — PR #77 merged.
-- Governance/doc maintenance merged today: PR #79 Nightly smoke/full lanes, PR #80 lessons guidance, PR #81 Kover policy, PR #82 Dependabot baseline, PR #91 unassigned Dependabot updates.
+- `#13` transaction DSL, `#32` schema/index manager, `#34` merge/upsert, and `#33` batch insert are merged.
+- `#75` graph-core capability docs closed by PR #97.
+- `#40` weighted path suspend tests closed by PR #98.
+- `#96` graph-ktor module closed by PR #100.
+- PR #101 captured merged PR lessons for #97/#98/#100.
+- PR #102 added graph-ktor CI/Nightly verification.
+- PR #105 preserved issue #96 planning/design docs after completion.
+- PR #103 refreshed `WIP.md` on `main`, but the active default branch is `develop`; this refresh realigns `develop`.
 
 ## Current Direction
 
-The foundational operation APIs are now stable enough to move from core API shape into backend expansion, automation hardening, and examples:
+The graph-ktor lane is merged. The immediate focus is pre-release naming cleanup, then CI/backend work in that order.
 
-1. Keep CI/build automation healthy before opening another XL backend lane.
-2. Start Amazon Neptune backend only after confirming the merged transaction/schema/merge/batch contracts cover the required backend semantics.
-3. Let example modules follow the stable API surface instead of driving new API design.
-
-This file is the active backlog source. The former `TODO.md` content was consolidated here and in `CHANGELOG.md`.
+1. Handle `#99` soon because it is pre-release module naming cleanup for `graph-spring-boot4-starter`.
+2. Keep CI/build automation healthy before starting the Amazon Neptune backend.
+3. Let Ktor/example modules follow the merged graph-ktor surface instead of driving new API design.
+4. Defer weighted path benchmark work until the suspend test baseline remains stable.
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
+| P1 | [#99](https://github.com/bluetape4k/bluetape4k-graph/issues/99) graph-spring-boot module naming | M | Pre-release naming cleanup; do before release-facing docs or backend expansion. |
 | P1 | [#17](https://github.com/bluetape4k/bluetape4k-graph/issues/17) build cache optimization | M | Pays back during container-heavy backend work. |
 | P1 | [#18](https://github.com/bluetape4k/bluetape4k-graph/issues/18) CI quality gates | M | Tune carefully now that core API churn has settled. |
-| P1 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Next backend expansion candidate after API foundation merge verification. |
+| P1 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Start after naming cleanup and CI/build health are settled. |
+| P2 | [#19](https://github.com/bluetape4k/bluetape4k-graph/issues/19) Dependabot / Renovate automation | S | Governance baseline exists; verify whether the issue can close. |
 | P2 | [#49](https://github.com/bluetape4k/bluetape4k-graph/issues/49) graph-okio encrypted streaming | L | Separate from graph core; depends on okio/Tink conventions. |
-| P2 | [#10](https://github.com/bluetape4k/bluetape4k-graph/issues/10) extra example modules | L | Can now be planned against stable transaction/schema/merge/batch APIs. |
+| P2 | [#10](https://github.com/bluetape4k/bluetape4k-graph/issues/10) extra example modules | L | Plan against stable transaction/schema/merge/batch APIs and graph-ktor merge result. |
 | P3 | [#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14) backend JMH benchmark | M | Useful after Neptune/backend paths settle. |
 | P3 | [#15](https://github.com/bluetape4k/bluetape4k-graph/issues/15) runtime comparison benchmark | M | After backend baseline APIs are stable. |
-| P3 | [#40](https://github.com/bluetape4k/bluetape4k-graph/issues/40) weighted path suspend tests | S | Narrow quality task. |
-| P3 | [#41](https://github.com/bluetape4k/bluetape4k-graph/issues/41) weighted path benchmark | S | Follows `#40`. |
+| P3 | [#41](https://github.com/bluetape4k/bluetape4k-graph/issues/41) weighted path benchmark | S | Follows merged `#40` suspend test baseline. |
 | P4 | [#16](https://github.com/bluetape4k/bluetape4k-graph/issues/16) public API KDoc examples | M | Defer broad sweep; add KDoc when touching public APIs. |
 
 ## Dependency Map
 
 ```text
-#13 transaction DSL ✅
-#32 schema/index API ✅
-#34 merge/upsert ✅
-#33 batch insert ✅
+#13 transaction DSL (closed)
+#32 schema/index API (closed)
+#34 merge/upsert (closed)
+#33 batch insert (closed)
   -> #30 Neptune backend
   -> #10 extra examples
       -> workshop graph examples
 
-#40 weighted path suspend tests
+#96 graph-ktor (closed by PR #100)
+  -> Ktor examples can now use merged graph-ktor APIs
+
+#99 graph-spring-boot module naming
+  -> release-facing docs and adoption cleanup before backend expansion
+
+#40 weighted path suspend tests (closed by PR #98)
   -> #41 weighted path benchmark
 
 #17/#18 automation
   -> safer large graph changes
 
-#76 graph-okio rename ✅
+#76 graph-okio rename (closed)
   -> #49 graph-okio encrypted streaming
 ```
 
@@ -65,7 +73,8 @@ This file is the active backlog source. The former `TODO.md` content was consoli
 
 | Lane | Limit | Current next |
 |---|---:|---|
+| Naming cleanup | 1 | `#99` before release-facing docs or broad feature work. |
 | CI/automation | 1 | `#17` or `#18` before another large backend PR. |
-| Backend expansion | 1 | `#30` after confirming merged API contracts. |
-| Examples/docs | 1 | `#10` can start only after owning APIs are verified in released docs. |
-| Narrow quality | 1 | `#40`, then `#41`. |
+| Backend expansion | 1 | `#30` after API contracts, naming, and CI health are settled. |
+| Examples/docs | 1 | `#10` only after owning APIs are verified in released docs. |
+| Narrow quality | 1 | `#41` after weighted suspend tests stay green. |


### PR DESCRIPTION
## 요약

- `WIP.md` 스냅샷을 2026-05-13 KST 기준으로 갱신했습니다.
- PR #97/#98/#100 병합으로 #75/#40/#96이 완료된 상태를 반영했습니다.
- PR #101/#102/#105의 lesson, CI/Nightly, archival follow-up을 최근 완료 항목에 추가했습니다.
- #99 graph-spring-boot module naming cleanup을 다음 우선 작업으로 올렸습니다.
- PR #103은 `main` 기준 WIP refresh였고, 이번 PR은 active default branch인 `develop`의 WIP를 정렬합니다.

## 검증

- GitHub connector로 최근 issue/PR 상태를 확인했습니다.
- `develop`의 현재 `WIP.md`를 fetch한 뒤 `WIP.md`만 갱신했습니다.
- 문서 전용 변경이라 Gradle build는 실행하지 않았습니다.

## 참고

Default branch 직접 업데이트는 repository rule을 피하기 위해 PR로 처리했습니다.