### PR TITLE
Document graph public APIs with KDoc examples

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,7 +252,10 @@ subprojects {
             configureEach {
                 dokkaSourceSets {
                     configureEach {
-                        includes.from("README.md")
+                        val dokkaModuleDoc = project.file("dokka.md")
+                        if (dokkaModuleDoc.isFile) {
+                            includes.from(dokkaModuleDoc)
+                        }
                     }
                 }
                 dokkaPublications.html {

--- a/docs/lessons/2026-05-13-issue-16-kdoc-examples.md
+++ b/docs/lessons/2026-05-13-issue-16-kdoc-examples.md
@@ -1,0 +1,29 @@
+# Issue 16 KDoc examples and Dokka validation
+
+## Context
+
+Issue #16 required callable Kotlin examples in public API KDoc and a successful Dokka HTML generation path.
+The largest remaining gaps were GraphML, Jackson NDJSON, and Spring Boot auto-configuration APIs.
+
+## Decision
+
+Add English KDoc examples to the empty public surfaces first, then validate the full Dokka task instead of only
+counting examples. Do not feed normal README files into Dokka as module/package docs; use `dokka.md` when a module
+needs Dokka-specific module documentation.
+
+## Outcome
+
+- `graph-io` example markers increased from 23 to 69.
+- `spring-boot` example markers increased from 0 to 24.
+- Full `dokkaGenerateHtml` now succeeds without unresolved-link warnings from the touched validation path.
+
+## Verification
+
+- `git diff --check`
+- `./gradlew :graph-io-graphml:dokkaGeneratePublicationHtml :graph-io-jackson2:dokkaGeneratePublicationHtml :graph-io-jackson3:dokkaGeneratePublicationHtml :graph-spring-boot:dokkaGeneratePublicationHtml`
+- `./gradlew dokkaGenerateHtml`
+
+## Future Guard
+
+Do not pass arbitrary README files through Dokka `includes`; Dokka module/package docs need the `# Module` or
+`# Package` classifier format and may treat normal Markdown links as unresolved KDoc links.

--- a/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphService.kt
+++ b/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphService.kt
@@ -174,7 +174,7 @@ class LinkedInGraphService(
      *
      * @param fromId 출발 사람 ID.
      * @param toId 도착 사람 ID.
-     * @return 최단 [GraphPath], 경로가 없으면 `null`.
+     * @return 최단 `GraphPath`, 경로가 없으면 `null`.
      */
     fun findConnectionPath(fromId: GraphElementId, toId: GraphElementId) =
         ops.shortestPath(fromId, toId, PathOptions(edgeLabel = "KNOWS", maxDepth = 6))
@@ -188,7 +188,7 @@ class LinkedInGraphService(
      *
      * @param fromId 출발 사람 ID.
      * @param toId 도착 사람 ID.
-     * @return [GraphPath] 목록.
+     * @return `GraphPath` 목록.
      */
     fun findAllConnectionPaths(fromId: GraphElementId, toId: GraphElementId) =
         ops.allPaths(fromId, toId, PathOptions(edgeLabel = "KNOWS", maxDepth = 3))

--- a/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphSuspendService.kt
+++ b/examples/linkedin-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/linkedin/service/LinkedInGraphSuspendService.kt
@@ -163,7 +163,7 @@ class LinkedInGraphSuspendService(
      *
      * @param fromId 출발 사람 ID.
      * @param toId 도착 사람 ID.
-     * @return 최단 [GraphPath], 경로가 없으면 `null`.
+     * @return 최단 `GraphPath`, 경로가 없으면 `null`.
      */
     suspend fun findConnectionPath(fromId: GraphElementId, toId: GraphElementId) =
         ops.shortestPath(fromId, toId, PathOptions(edgeLabel = "KNOWS", maxDepth = 6))

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlAttrType.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlAttrType.kt
@@ -1,6 +1,18 @@
 package io.bluetape4k.graph.io.graphml
 
 /** GraphML `attr.type` 열거형. 파싱 시 값을 적절한 JVM 타입으로 변환한다. */
+/**
+ * GraphML attribute value type.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlAttrType
+ *
+ * val xmlType = GraphMlAttrType.STRING.xmlName
+ * check(xmlType == "string")
+ * ```
+ */
 enum class GraphMlAttrType(val xmlName: String) {
     STRING("string"),
     INT("int"),

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlBulkExporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlBulkExporter.kt
@@ -17,8 +17,29 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 
 /**
- * GraphML 동기 벌크 익스포터.
- * 정점과 간선을 모두 수집한 뒤 StAX 라이터로 단일 XML 파일에 기록한다.
+ * Blocking bulk exporter for GraphML.
+ *
+ * The exporter collects matching vertices and edges, then writes a single XML
+ * document through the StAX writer.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlBulkExporter
+ * import io.bluetape4k.graph.io.graphml.GraphMlExportOptions
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = GraphMlBulkExporter()
+ * val report = exporter.exportGraph(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.graphml")),
+ *     operations = graphOps,
+ *     options = GraphExportOptions(vertexLabels = setOf("Person")),
+ *     graphMlOptions = GraphMlExportOptions(graphId = "social"),
+ * )
+ * check(report.verticesWritten >= 0)
+ * ```
  */
 class GraphMlBulkExporter : GraphBulkExporter<GraphExportSink> {
 

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlBulkImporter.kt
@@ -23,8 +23,29 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 
 /**
- * GraphML 동기 벌크 임포터.
- * StAX 파서로 전체 XML을 읽어 정점을 먼저 생성한 뒤 간선을 연결한다.
+ * Blocking bulk importer for GraphML.
+ *
+ * The importer reads the XML document with StAX, creates all vertices first,
+ * and then connects edges once endpoint ids are known.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlBulkImporter
+ * import io.bluetape4k.graph.io.graphml.GraphMlImportOptions
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = GraphMlBulkImporter()
+ * val report = importer.importGraph(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.graphml")),
+ *     operations = graphOps,
+ *     options = GraphImportOptions(batchSize = 500),
+ *     graphMlOptions = GraphMlImportOptions(defaultVertexLabel = "Entity"),
+ * )
+ * check(report.verticesCreated >= 0)
+ * ```
  */
 class GraphMlBulkImporter : GraphBulkImporter<GraphImportSource> {
 

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlEdgeDefault.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlEdgeDefault.kt
@@ -1,6 +1,18 @@
 package io.bluetape4k.graph.io.graphml
 
 /** GraphML `<graph edgedefault="...">` 값. */
+/**
+ * GraphML edge direction default for a `<graph>` element.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlEdgeDefault
+ * import io.bluetape4k.graph.io.graphml.GraphMlExportOptions
+ *
+ * val options = GraphMlExportOptions(edgeDefault = GraphMlEdgeDefault.DIRECTED)
+ * ```
+ */
 enum class GraphMlEdgeDefault(val xmlName: String) {
     DIRECTED("directed"),
     UNDIRECTED("undirected");

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlExportOptions.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlExportOptions.kt
@@ -3,12 +3,25 @@ package io.bluetape4k.graph.io.graphml
 import java.io.Serializable
 
 /**
- * GraphML 익스포트 옵션.
+ * GraphML export options.
  *
- * @param labelAttrName 정점/간선 라벨을 저장할 `attr.name` 값
- * @param edgeDefault GraphML `<graph edgedefault>` 값
- * @param graphId `<graph id>` 값
- * @param encoding XML 선언의 인코딩
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlEdgeDefault
+ * import io.bluetape4k.graph.io.graphml.GraphMlExportOptions
+ *
+ * val options = GraphMlExportOptions(
+ *     labelAttrName = "kind",
+ *     edgeDefault = GraphMlEdgeDefault.DIRECTED,
+ *     graphId = "catalog",
+ * )
+ * ```
+ *
+ * @param labelAttrName `attr.name` value used to store vertex and edge labels.
+ * @param edgeDefault GraphML `<graph edgedefault>` value.
+ * @param graphId GraphML `<graph id>` value.
+ * @param encoding XML declaration encoding.
  */
 data class GraphMlExportOptions(
     val labelAttrName: String = "label",

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlImportOptions.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlImportOptions.kt
@@ -3,12 +3,26 @@ package io.bluetape4k.graph.io.graphml
 import java.io.Serializable
 
 /**
- * GraphML 임포트 옵션.
+ * GraphML import options.
  *
- * @param labelAttrName 정점/간선의 라벨로 사용할 GraphML `attr.name` 값
- * @param unsupportedElementPolicy 미지원 요소 처리 정책
- * @param defaultVertexLabel 라벨 데이터가 없는 정점에 사용할 기본 라벨
- * @param defaultEdgeLabel 라벨 데이터가 없는 간선에 사용할 기본 라벨
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlImportOptions
+ * import io.bluetape4k.graph.io.graphml.UnsupportedGraphMlElementPolicy
+ *
+ * val options = GraphMlImportOptions(
+ *     labelAttrName = "kind",
+ *     unsupportedElementPolicy = UnsupportedGraphMlElementPolicy.FAIL,
+ *     defaultVertexLabel = "Entity",
+ *     defaultEdgeLabel = "RELATED_TO",
+ * )
+ * ```
+ *
+ * @param labelAttrName GraphML `attr.name` value used as the vertex or edge label.
+ * @param unsupportedElementPolicy Policy for unsupported GraphML elements.
+ * @param defaultVertexLabel Label used when a vertex does not contain label data.
+ * @param defaultEdgeLabel Label used when an edge does not contain label data.
  */
 data class GraphMlImportOptions(
     val labelAttrName: String = "label",

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlVirtualThreadBulkExporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlVirtualThreadBulkExporter.kt
@@ -11,6 +11,26 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /** GraphML Virtual Thread 기반 익스포터. Sync 익스포터를 VT Future로 감싼다. */
+/**
+ * Virtual-thread bulk exporter for GraphML.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlVirtualThreadBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = GraphMlVirtualThreadBulkExporter()
+ * val future = exporter.exportGraphAsync(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.graphml")),
+ *     operations = graphOps,
+ *     options = GraphExportOptions(edgeLabels = setOf("KNOWS")),
+ * )
+ * val report = future.join()
+ * ```
+ */
 class GraphMlVirtualThreadBulkExporter(
     private val sync: GraphMlBulkExporter = GraphMlBulkExporter(),
 ) : GraphVirtualThreadBulkExporter<GraphExportSink> {

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlVirtualThreadBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlVirtualThreadBulkImporter.kt
@@ -11,6 +11,26 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /** GraphML Virtual Thread 기반 임포터. Sync 임포터를 VT Future로 감싼다. */
+/**
+ * Virtual-thread bulk importer for GraphML.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlVirtualThreadBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = GraphMlVirtualThreadBulkImporter()
+ * val future = importer.importGraphAsync(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.graphml")),
+ *     operations = graphOps,
+ *     options = GraphImportOptions(batchSize = 250),
+ * )
+ * val report = future.join()
+ * ```
+ */
 class GraphMlVirtualThreadBulkImporter(
     private val sync: GraphMlBulkImporter = GraphMlBulkImporter(),
 ) : GraphVirtualThreadBulkImporter<GraphImportSource> {

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkExporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkExporter.kt
@@ -23,6 +23,25 @@ import kotlinx.coroutines.withContext
  * GraphML 코루틴(suspend) 벌크 익스포터.
  * Flow로 정점/간선을 수집한 뒤 StAX 라이터로 XML 파일에 기록한다.
  */
+/**
+ * Coroutine bulk exporter for GraphML.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.SuspendGraphMlBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = SuspendGraphMlBulkExporter()
+ * val report = exporter.exportGraphSuspending(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.graphml")),
+ *     operations = suspendGraphOps,
+ *     options = GraphExportOptions(vertexLabels = setOf("Person")),
+ * )
+ * ```
+ */
 class SuspendGraphMlBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
 
     private val writer = StaxGraphMlWriter()

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
@@ -28,6 +28,25 @@ import kotlinx.coroutines.withContext
  * GraphML 코루틴(suspend) 벌크 임포터.
  * StAX 파싱은 IO 디스패처에서 수행하고, 정점/간선 생성은 suspend 함수로 호출한다.
  */
+/**
+ * Coroutine bulk importer for GraphML.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.SuspendGraphMlBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = SuspendGraphMlBulkImporter()
+ * val report = importer.importGraphSuspending(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.graphml")),
+ *     operations = suspendGraphOps,
+ *     options = GraphImportOptions(batchSize = 250),
+ * )
+ * ```
+ */
 class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
 
     private val reader = StaxGraphMlReader()

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/UnsupportedGraphMlElementPolicy.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/UnsupportedGraphMlElementPolicy.kt
@@ -1,4 +1,18 @@
 package io.bluetape4k.graph.io.graphml
 
 /** GraphML 파싱 중 알 수 없는 요소를 만났을 때의 정책. */
+/**
+ * Policy for GraphML elements not supported by the importer.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.graphml.GraphMlImportOptions
+ * import io.bluetape4k.graph.io.graphml.UnsupportedGraphMlElementPolicy
+ *
+ * val strictOptions = GraphMlImportOptions(
+ *     unsupportedElementPolicy = UnsupportedGraphMlElementPolicy.FAIL,
+ * )
+ * ```
+ */
 enum class UnsupportedGraphMlElementPolicy { SKIP, FAIL }

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonBulkExporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonBulkExporter.kt
@@ -17,8 +17,26 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 
 /**
- * Jackson2 기반 NDJSON 동기 벌크 익스포터.
- * 정점을 먼저 쓴 뒤 간선을 쓴다. 각 레코드는 한 줄의 JSON.
+ * Blocking NDJSON bulk exporter backed by Jackson 2.
+ *
+ * Vertices are written before edges, and each graph record occupies one JSON
+ * line.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson2.Jackson2NdJsonBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = Jackson2NdJsonBulkExporter()
+ * val report = exporter.exportGraph(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphExportOptions(vertexLabels = setOf("Person")),
+ * )
+ * ```
  */
 class Jackson2NdJsonBulkExporter : GraphBulkExporter<GraphExportSink> {
 

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonBulkImporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonBulkImporter.kt
@@ -25,8 +25,26 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 
 /**
- * Jackson2 기반 NDJSON 동기 벌크 임포터.
- * 단일 파일에서 vertex/edge 줄을 판별하며, edge는 버퍼에 쌓았다가 모든 vertex 생성 후 flush한다.
+ * Blocking NDJSON bulk importer backed by Jackson 2.
+ *
+ * The importer detects vertex and edge envelopes from a single file, buffers
+ * edges, and writes them after vertices are created.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson2.Jackson2NdJsonBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = Jackson2NdJsonBulkImporter()
+ * val report = importer.importGraph(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphImportOptions(batchSize = 1_000),
+ * )
+ * ```
  */
 class Jackson2NdJsonBulkImporter : GraphBulkImporter<GraphImportSource> {
 

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonVirtualThreadBulkExporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonVirtualThreadBulkExporter.kt
@@ -9,6 +9,26 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Virtual-thread NDJSON bulk exporter backed by Jackson 2.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson2.Jackson2NdJsonVirtualThreadBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = Jackson2NdJsonVirtualThreadBulkExporter()
+ * val future = exporter.exportGraphAsync(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphExportOptions(vertexLabels = setOf("Person")),
+ * )
+ * val report = future.join()
+ * ```
+ */
 class Jackson2NdJsonVirtualThreadBulkExporter : GraphVirtualThreadBulkExporter<GraphExportSink> {
 
     private val sync: Jackson2NdJsonBulkExporter = Jackson2NdJsonBulkExporter()

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonVirtualThreadBulkImporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2NdJsonVirtualThreadBulkImporter.kt
@@ -9,6 +9,26 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Virtual-thread NDJSON bulk importer backed by Jackson 2.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson2.Jackson2NdJsonVirtualThreadBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = Jackson2NdJsonVirtualThreadBulkImporter()
+ * val future = importer.importGraphAsync(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphImportOptions(batchSize = 500),
+ * )
+ * val report = future.join()
+ * ```
+ */
 class Jackson2NdJsonVirtualThreadBulkImporter : GraphVirtualThreadBulkImporter<GraphImportSource> {
 
     private val sync: Jackson2NdJsonBulkImporter = Jackson2NdJsonBulkImporter()

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkExporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkExporter.kt
@@ -19,6 +19,25 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
+/**
+ * Coroutine NDJSON bulk exporter backed by Jackson 2.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson2.SuspendJackson2NdJsonBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = SuspendJackson2NdJsonBulkExporter()
+ * val report = exporter.exportGraphSuspending(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.ndjson")),
+ *     operations = suspendGraphOps,
+ *     options = GraphExportOptions(edgeLabels = setOf("KNOWS")),
+ * )
+ * ```
+ */
 class SuspendJackson2NdJsonBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
 
     private val codec: Jackson2EnvelopeCodec = Jackson2EnvelopeCodec()

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
@@ -26,6 +26,25 @@ import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+/**
+ * Coroutine NDJSON bulk importer backed by Jackson 2.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson2.SuspendJackson2NdJsonBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = SuspendJackson2NdJsonBulkImporter()
+ * val report = importer.importGraphSuspending(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.ndjson")),
+ *     operations = suspendGraphOps,
+ *     options = GraphImportOptions(maxEdgeBufferSize = 50_000),
+ * )
+ * ```
+ */
 class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
 
     private val codec: Jackson2EnvelopeCodec = Jackson2EnvelopeCodec()

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonBulkExporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonBulkExporter.kt
@@ -17,8 +17,26 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 
 /**
- * Jackson3 기반 NDJSON 동기 벌크 익스포터.
- * 정점을 먼저 쓴 뒤 간선을 쓴다. 각 레코드는 한 줄의 JSON.
+ * Blocking NDJSON bulk exporter backed by Jackson 3.
+ *
+ * Vertices are written before edges, and each graph record occupies one JSON
+ * line.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson3.Jackson3NdJsonBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = Jackson3NdJsonBulkExporter()
+ * val report = exporter.exportGraph(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphExportOptions(edgeLabels = setOf("KNOWS")),
+ * )
+ * ```
  */
 class Jackson3NdJsonBulkExporter : GraphBulkExporter<GraphExportSink> {
 

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonBulkImporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonBulkImporter.kt
@@ -25,8 +25,26 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 
 /**
- * Jackson3 기반 NDJSON 동기 벌크 임포터.
- * 단일 파일에서 vertex/edge 줄을 판별하며, edge는 버퍼에 쌓았다가 모든 vertex 생성 후 flush한다.
+ * Blocking NDJSON bulk importer backed by Jackson 3.
+ *
+ * The importer detects vertex and edge envelopes from a single file, buffers
+ * edges, and writes them after vertices are created.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson3.Jackson3NdJsonBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = Jackson3NdJsonBulkImporter()
+ * val report = importer.importGraph(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphImportOptions(defaultVertexLabel = "Entity"),
+ * )
+ * ```
  */
 class Jackson3NdJsonBulkImporter : GraphBulkImporter<GraphImportSource> {
 

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonVirtualThreadBulkExporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonVirtualThreadBulkExporter.kt
@@ -9,6 +9,26 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Virtual-thread NDJSON bulk exporter backed by Jackson 3.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson3.Jackson3NdJsonVirtualThreadBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = Jackson3NdJsonVirtualThreadBulkExporter()
+ * val future = exporter.exportGraphAsync(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphExportOptions(edgeLabels = setOf("KNOWS")),
+ * )
+ * val report = future.join()
+ * ```
+ */
 class Jackson3NdJsonVirtualThreadBulkExporter : GraphVirtualThreadBulkExporter<GraphExportSink> {
 
     private val sync: Jackson3NdJsonBulkExporter = Jackson3NdJsonBulkExporter()

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonVirtualThreadBulkImporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonVirtualThreadBulkImporter.kt
@@ -9,6 +9,26 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Virtual-thread NDJSON bulk importer backed by Jackson 3.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson3.Jackson3NdJsonVirtualThreadBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = Jackson3NdJsonVirtualThreadBulkImporter()
+ * val future = importer.importGraphAsync(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.ndjson")),
+ *     operations = graphOps,
+ *     options = GraphImportOptions(batchSize = 500),
+ * )
+ * val report = future.join()
+ * ```
+ */
 class Jackson3NdJsonVirtualThreadBulkImporter : GraphVirtualThreadBulkImporter<GraphImportSource> {
 
     private val sync: Jackson3NdJsonBulkImporter = Jackson3NdJsonBulkImporter()

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkExporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkExporter.kt
@@ -19,6 +19,25 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
+/**
+ * Coroutine NDJSON bulk exporter backed by Jackson 3.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson3.SuspendJackson3NdJsonBulkExporter
+ * import io.bluetape4k.graph.io.options.GraphExportOptions
+ * import io.bluetape4k.graph.io.source.GraphExportSink
+ * import java.nio.file.Paths
+ *
+ * val exporter = SuspendJackson3NdJsonBulkExporter()
+ * val report = exporter.exportGraphSuspending(
+ *     sink = GraphExportSink.PathSink(Paths.get("graph.ndjson")),
+ *     operations = suspendGraphOps,
+ *     options = GraphExportOptions(vertexLabels = setOf("Person")),
+ * )
+ * ```
+ */
 class SuspendJackson3NdJsonBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
 
     private val codec: Jackson3EnvelopeCodec = Jackson3EnvelopeCodec()

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
@@ -26,6 +26,25 @@ import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+/**
+ * Coroutine NDJSON bulk importer backed by Jackson 3.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.io.jackson3.SuspendJackson3NdJsonBulkImporter
+ * import io.bluetape4k.graph.io.options.GraphImportOptions
+ * import io.bluetape4k.graph.io.source.GraphImportSource
+ * import java.nio.file.Paths
+ *
+ * val importer = SuspendJackson3NdJsonBulkImporter()
+ * val report = importer.importGraphSuspending(
+ *     source = GraphImportSource.PathSource(Paths.get("graph.ndjson")),
+ *     operations = suspendGraphOps,
+ *     options = GraphImportOptions(defaultEdgeLabel = "RELATED_TO"),
+ * )
+ * ```
+ */
 class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
 
     private val codec: Jackson3EnvelopeCodec = Jackson3EnvelopeCodec()

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
@@ -135,7 +135,7 @@ object GraphIoOkioPaths : KLogging() {
     /**
      * GZip 압축 체이닝 편의 함수.
      *
-     * 내부적으로 [Compressors.Streaming.GZip]을 사용한다.
+     * 내부적으로 `Compressors.Streaming.GZip`을 사용한다.
      * 압축 초기화 실패 시 underlying sink를 닫고 예외를 재던진다.
      */
     @Throws(IOException::class)

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendGraphIoOkioBulkAdapter.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendGraphIoOkioBulkAdapter.kt
@@ -107,7 +107,7 @@ class SuspendGraphIoOkioBulkAdapter(
      * OkIO 소스로부터 [format] 포맷으로 그래프를 임포트하고 완료 보고서를 반환한다.
      *
      * blocking I/O를 [runInterruptible] 로 래핑하여 코루틴 취소를 지원한다.
-     * finally 에서 리소스가 반드시 닫히도록 [NonCancellable] 로 보호한다.
+     * finally 에서 리소스가 반드시 닫히도록 `NonCancellable` 로 보호한다.
      *
      * @throws IOException I/O 오류 시
      */

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/GraphMLOkioExtensions.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/extension/GraphMLOkioExtensions.kt
@@ -30,7 +30,7 @@ private val graphmlSuspendAdapter = SuspendGraphIoOkioBulkAdapter()
 /**
  * GraphML 포맷으로 그래프를 OkIO 소스에서 임포트한다.
  *
- * StAX 파서는 [InputStream] 기반이므로 OkIO [okio.BufferedSource]를 InputStream 으로 변환하여 전달한다.
+ * StAX 파서는 `java.io.InputStream` 기반이므로 OkIO [okio.BufferedSource]를 InputStream 으로 변환하여 전달한다.
  * XXE 방지: StAX 팩토리에 `SUPPORT_DTD=false`, `IS_SUPPORTING_EXTERNAL_ENTITIES=false` 적용 (기존 구현 위임).
  *
  * @param source OkIO 기반 임포트 소스

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/sql/AgeTypeParser.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/sql/AgeTypeParser.kt
@@ -27,7 +27,7 @@ object AgeTypeParser : KLogging() {
      * println(vertex.properties["name"])  // "Alice"
      * ```
      *
-     * @param agtypeStr AGE가 반환하는 vertex agtype 문자열. 예: `{"id": 1, "label": "Person", "properties": {"name": "Alice"}}::vertex`
+     * @param agtype AGE가 반환하는 vertex agtype 문자열. 예: `{"id": 1, "label": "Person", "properties": {"name": "Alice"}}::vertex`
      * @return 파싱된 [GraphVertex].
      */
     fun parseVertex(agtype: String): GraphVertex {
@@ -48,7 +48,7 @@ object AgeTypeParser : KLogging() {
      * println(edge.label)  // "KNOWS"
      * ```
      *
-     * @param agtypeStr AGE가 반환하는 edge agtype 문자열.
+     * @param agtype AGE가 반환하는 edge agtype 문자열.
      * @return 파싱된 [GraphEdge].
      */
     fun parseEdge(agtype: String): GraphEdge {
@@ -74,7 +74,7 @@ object AgeTypeParser : KLogging() {
      * println(path.vertices)  // 경로 내 정점 목록
      * ```
      *
-     * @param agtypeStr AGE가 반환하는 path agtype 문자열.
+     * @param agtype AGE가 반환하는 path agtype 문자열.
      * @return 파싱된 [GraphPath].
      */
     fun parsePath(agtype: String): GraphPath {
@@ -124,7 +124,7 @@ object AgeTypeParser : KLogging() {
     }
 
     /**
-     * [agtypeStr]이 AGE vertex 타입 문자열인지 판별한다.
+     * `agtype`이 AGE vertex 타입 문자열인지 판별한다.
      *
      * ```kotlin
      * AgeTypeParser.isVertex("""{"id": 1, "label": "Person", ...}::vertex""")  // true
@@ -134,7 +134,7 @@ object AgeTypeParser : KLogging() {
     fun isVertex(agtype: String): Boolean = agtype.trimEnd().endsWith("::vertex")
 
     /**
-     * [agtypeStr]이 AGE edge 타입 문자열인지 판별한다.
+     * `agtype`이 AGE edge 타입 문자열인지 판별한다.
      *
      * ```kotlin
      * AgeTypeParser.isEdge("""{"id": 99, "label": "KNOWS", ...}::edge""")  // true
@@ -143,7 +143,7 @@ object AgeTypeParser : KLogging() {
     fun isEdge(agtype: String): Boolean = agtype.trimEnd().endsWith("::edge")
 
     /**
-     * [agtypeStr]이 AGE path 타입 문자열인지 판별한다.
+     * `agtype`이 AGE path 타입 문자열인지 판별한다.
      *
      * ```kotlin
      * AgeTypeParser.isPath("""[{...}::vertex, {...}::edge, {...}::vertex]""")  // true
@@ -228,7 +228,7 @@ object AgeTypeParser : KLogging() {
      * // → listOf(1, "str", null, true)
      * ```
      *
-     * @param jsonArrayStr `[1, "str", null, true]` 형태의 JSON 배열 문자열.
+     * @param json `[1, "str", null, true]` 형태의 JSON 배열 문자열.
      * @return 파싱된 불변 [List].
      */
     fun parseJsonArray(json: String): List<Any?> {

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
@@ -40,7 +40,7 @@ import java.util.*
  * path?.let { println("총 비용=${it.totalWeight}, 경로 길이=${it.steps.size}") }
  * ```
  *
- * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수. [Direction]은 호출 전 적용되어야 한다.
+ * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수. `Direction`은 호출 전 적용되어야 한다.
  * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
  */
 class DijkstraRunner(

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
@@ -26,7 +26,7 @@ sealed class GraphTraversalOptions: Serializable {
 }
 
 /**
- * [GraphTraversalRepository.neighbors] 호출 옵션.
+ * `GraphTraversalRepository.neighbors` 호출 옵션.
  *
  * ```kotlin
  * val opts = NeighborOptions(edgeLabel = "KNOWS", direction = Direction.OUTGOING, maxDepth = 2)
@@ -49,7 +49,7 @@ data class NeighborOptions(
 }
 
 /**
- * [GraphTraversalRepository.shortestPath] / [GraphTraversalRepository.allPaths] 호출 옵션.
+ * `GraphTraversalRepository.shortestPath` / `GraphTraversalRepository.allPaths` 호출 옵션.
  *
  * [weightProperty]를 지정하면 Dijkstra/A* 알고리즘으로 가중치 최단 경로를 탐색한다.
  * `null`(기본)이면 백엔드 네이티브 BFS 최단 경로를 사용한다.
@@ -94,7 +94,7 @@ data class PathOptions(
 }
 
 /**
- * [GraphTraversalRepository.bfs] / [GraphTraversalRepository.dfs] 호출 옵션.
+ * `GraphTraversalRepository.bfs` / `GraphTraversalRepository.dfs` 호출 옵션.
  *
  * ### 사용 예제
  * ```kotlin
@@ -119,7 +119,7 @@ data class BfsDfsOptions(
 }
 
 /**
- * [GraphTraversalRepository.detectCycles] 호출 옵션.
+ * `GraphTraversalRepository.detectCycles` 호출 옵션.
  *
  * @param vertexLabel 탐색할 정점 레이블. null이면 모든 레이블 탐색.
  * @param edgeLabel 탐색할 엣지 레이블. null이면 모든 레이블 탐색.

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphMergeOperations.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphMergeOperations.kt
@@ -9,13 +9,13 @@ import io.bluetape4k.support.requireNotBlank
 /**
  * 검증을 통과한 merge/upsert 속성 묶음.
  *
- * [matchProperties]는 요소를 찾는 안정적인 식별자이고, [setProperties]는 생성되었거나
+ * `matchProperties`는 요소를 찾는 안정적인 식별자이고, `setProperties`는 생성되었거나
  * 이미 존재하는 요소에 적용할 갱신 속성이다.
  *
  * ## 동작/계약
- * - [matchProperties]의 값은 `null`일 수 없다. null identity key는 backend별 query 의미가
+ * - `matchProperties`의 값은 `null`일 수 없다. null identity key는 backend별 query 의미가
  *   달라질 수 있기 때문이다.
- * - [setProperties]는 [matchProperties]와 같은 key를 덮어쓸 수 없다.
+ * - `setProperties`는 `matchProperties`와 같은 key를 덮어쓸 수 없다.
  *
  * ```kotlin
  * val props = GraphMergeValidation.validateVertex(
@@ -37,8 +37,8 @@ data class GraphMergeProperties(
  *
  * ## 동작/계약
  * - label과 property key는 backend query에 안전한 identifier여야 한다.
- * - vertex merge는 [validateVertex]에서 non-empty [matchProperties]를 요구한다.
- * - edge merge는 endpoint id와 label이 identity를 이루므로 empty [matchProperties]를 허용한다.
+ * - vertex merge는 [validateVertex]에서 non-empty `matchProperties`를 요구한다.
+ * - edge merge는 endpoint id와 label이 identity를 이루므로 empty `matchProperties`를 허용한다.
  *
  * ```kotlin
  * val validated = GraphMergeValidation.validateEdge(
@@ -56,7 +56,7 @@ object GraphMergeValidation {
      * 정점 merge 입력을 검증한다.
      *
      * 정점은 레이블만으로 merge 하면 여러 기존 정점이 매칭될 수 있으므로
-     * [matchProperties]가 비어 있으면 거부한다.
+     * `matchProperties`가 비어 있으면 거부한다.
      */
     fun validateVertex(
         label: String,
@@ -74,7 +74,7 @@ object GraphMergeValidation {
      * 간선 merge 입력을 검증한다.
      *
      * 간선은 시작 정점 ID, 종료 정점 ID, 레이블이 기본 식별자이므로
-     * [matchProperties]가 비어 있어도 허용한다.
+     * `matchProperties`가 비어 있어도 허용한다.
      */
     fun validateEdge(
         fromId: GraphElementId,
@@ -138,7 +138,7 @@ object GraphMergeValidation {
 interface GraphMergeOperations {
 
     /**
-     * [matchProperties]로 정점을 찾고, 없으면 생성한 뒤 [setProperties]를 적용해 반환한다.
+     * `matchProperties`로 정점을 찾고, 없으면 생성한 뒤 `setProperties`를 적용해 반환한다.
      */
     fun mergeVertex(
         label: String,
@@ -147,8 +147,8 @@ interface GraphMergeOperations {
     ): GraphVertex
 
     /**
-     * 시작/종료 정점, 간선 레이블, [matchProperties]로 간선을 찾고, 없으면 생성한 뒤
-     * [setProperties]를 적용해 반환한다.
+     * 시작/종료 정점, 간선 레이블, `matchProperties`로 간선을 찾고, 없으면 생성한 뒤
+     * `setProperties`를 적용해 반환한다.
      */
     fun mergeEdge(
         fromId: GraphElementId,
@@ -176,14 +176,14 @@ interface GraphMergeOperations {
  */
 interface GraphSuspendMergeOperations {
 
-    /** [matchProperties]로 정점을 찾고, 없으면 생성한 뒤 [setProperties]를 적용해 반환한다. */
+    /** `matchProperties`로 정점을 찾고, 없으면 생성한 뒤 `setProperties`를 적용해 반환한다. */
     suspend fun mergeVertex(
         label: String,
         matchProperties: Map<String, Any?>,
         setProperties: Map<String, Any?> = emptyMap(),
     ): GraphVertex
 
-    /** 시작/종료 정점, 간선 레이블, [matchProperties]로 간선을 찾고, 없으면 생성한 뒤 [setProperties]를 적용한다. */
+    /** 시작/종료 정점, 간선 레이블, `matchProperties`로 간선을 찾고, 없으면 생성한 뒤 `setProperties`를 적용한다. */
     suspend fun mergeEdge(
         fromId: GraphElementId,
         toId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTraversalRepository.kt
@@ -87,7 +87,7 @@ interface GraphSuspendTraversalRepository {
     /**
      * A* 알고리즘으로 가중치 최단 경로를 찾는다 (코루틴 방식).
      *
-     * [options.weightProperty]가 반드시 설정되어야 한다.
+     * `options.weightProperty`가 반드시 설정되어야 한다.
      * [heuristic]은 동기 함수여야 한다 (`suspend` 함수 불가).
      *
      * ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTraversalRepository.kt
@@ -88,7 +88,7 @@ interface GraphTraversalRepository {
     /**
      * A* 알고리즘으로 가중치 최단 경로를 찾는다.
      *
-     * [options.weightProperty]가 반드시 설정되어야 한다.
+     * `options.weightProperty`가 반드시 설정되어야 한다.
      * [heuristic]은 목표 정점까지의 예상 비용을 반환하는 비허용 불가(admissible) 함수여야 한다.
      * 동기 함수만 허용하며 `suspend` 함수는 지원하지 않는다.
      *

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPluginConfig.kt
@@ -10,9 +10,9 @@ import java.util.IdentityHashMap
  * ## 동작/계약
  * - `install(GraphPlugin) { ... }` 블록에서 backend를 반드시 한 번 선택해야 합니다.
  * - [operations]는 이미 생성된 [GraphOperations] / [GraphSuspendOperations]를 Ktor application에 연결합니다.
- * - 기본적으로 caller-owned operations를 닫지 않습니다. [closeOnStop]을 `true`로 지정한 경우에만
+ * - 기본적으로 caller-owned operations를 닫지 않습니다. `closeOnStop`을 `true`로 지정한 경우에만
  *   [io.ktor.server.application.ApplicationStopped] 시점에 전달된 operations를 닫습니다.
- * - 두 operations가 내부 delegate를 공유한다면 caller가 idempotent close를 보장하거나 [closeOnStop]을 꺼야 합니다.
+ * - 두 operations가 내부 delegate를 공유한다면 caller가 idempotent close를 보장하거나 `closeOnStop`을 꺼야 합니다.
  *
  * ```kotlin
  * fun Application.module(syncOps: GraphOperations, suspendOps: GraphSuspendOperations) {
@@ -37,8 +37,8 @@ class GraphPluginConfig {
      *
      * ## 동작/계약
      * - [graphOperations]와 [graphSuspendOperations]는 모두 필수입니다.
-     * - [closeOnStop] 기본값은 `false`입니다. 외부 DI/container가 lifecycle을 소유하는 경우 기본값을 유지합니다.
-     * - [closeOnStop]이 `true`이면 두 객체를 object identity 기준으로 중복 제거한 뒤 한 번씩 닫습니다.
+     * - `closeOnStop` 기본값은 `false`입니다. 외부 DI/container가 lifecycle을 소유하는 경우 기본값을 유지합니다.
+     * - `closeOnStop`이 `true`이면 두 객체를 object identity 기준으로 중복 제거한 뒤 한 번씩 닫습니다.
      *
      * @param graphOperations 동기 graph facade
      * @param graphSuspendOperations 코루틴 graph facade

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
@@ -26,10 +26,28 @@ import org.springframework.context.annotation.DependsOn
 import javax.sql.DataSource
 
 /**
- * Apache AGE 백엔드 AutoConfiguration.
+ * Auto-configuration for the Apache AGE backend.
  *
- * `bluetape4k.graph.backend=age` 일 때 활성화된다.
- * Spring Boot 기본 `DataSource`를 재사용하며, HikariCP가 있으면 AGE extension을 자동 설정한다.
+ * It is active when `bluetape4k.graph.backend=age`. The configuration reuses the
+ * Spring Boot [DataSource] and connects Exposed to it.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.GraphOperations
+ * import org.springframework.boot.autoconfigure.SpringBootApplication
+ * import org.springframework.boot.runApplication
+ *
+ * @SpringBootApplication
+ * class GraphApplication
+ *
+ * val context = runApplication<GraphApplication>(
+ *     "--bluetape4k.graph.backend=age",
+ *     "--bluetape4k.graph.age.graph-name=tenant_graph",
+ *     "--spring.datasource.hikari.connection-init-sql=LOAD 'age'; SET search_path = ag_catalog, public;",
+ * )
+ * val operations = context.getBean(GraphOperations::class.java)
+ * ```
  */
 @AutoConfiguration(after = [DataSourceAutoConfiguration::class])
 @ConditionalOnClass(AgeGraphOperations::class, DataSource::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfiguration.kt
@@ -6,11 +6,27 @@ import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 /**
- * bluetape4k Graph AutoConfiguration 루트.
+ * Root bluetape4k Graph auto-configuration.
  *
- * 백엔드별 AutoConfiguration의 실행 순서를 보장하고 공통 속성(`GraphProperties`)을 노출한다.
- * 이 클래스 자체는 빈을 생성하지 않는다.
- * 백엔드 AutoConfiguration은 `AutoConfiguration.imports`에 개별 등록된다.
+ * This class exposes [GraphProperties] and orders backend-specific
+ * auto-configuration classes. It does not create graph beans by itself; backend
+ * auto-configurations are registered separately in `AutoConfiguration.imports`.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import org.springframework.boot.autoconfigure.SpringBootApplication
+ * import org.springframework.boot.runApplication
+ *
+ * @SpringBootApplication
+ * class GraphApplication
+ *
+ * fun main(args: Array<String>) {
+ *     runApplication<GraphApplication>(*args) {
+ *         setDefaultProperties(mapOf("bluetape4k.graph.backend" to "tinkergraph"))
+ *     }
+ * }
+ * ```
  */
 @AutoConfiguration(
     before = [

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -19,10 +19,28 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
- * FalkorDB 백엔드 AutoConfiguration.
+ * Auto-configuration for the FalkorDB backend.
  *
- * `bluetape4k.graph.backend=falkordb` 일 때 활성화된다.
- * FalkorDB는 Redis 모듈 기반의 그래프 데이터베이스이며, jfalkordb 드라이버([com.falkordb.Driver])를 사용한다.
+ * It is active when `bluetape4k.graph.backend=falkordb`. FalkorDB is a Redis
+ * module based graph database and uses the jfalkordb [com.falkordb.Driver].
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.GraphOperations
+ * import org.springframework.boot.autoconfigure.SpringBootApplication
+ * import org.springframework.boot.runApplication
+ *
+ * @SpringBootApplication
+ * class GraphApplication
+ *
+ * val context = runApplication<GraphApplication>(
+ *     "--bluetape4k.graph.backend=falkordb",
+ *     "--bluetape4k.graph.falkordb.host=localhost",
+ *     "--bluetape4k.graph.falkordb.graph-name=bluetape4k",
+ * )
+ * val operations = context.getBean(GraphOperations::class.java)
+ * ```
  */
 @AutoConfiguration
 @ConditionalOnClass(com.falkordb.Driver::class, FalkorDBGraphOperations::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -23,10 +23,27 @@ import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
 
 /**
- * Memgraph 백엔드 AutoConfiguration.
+ * Auto-configuration for the Memgraph backend.
  *
- * `bluetape4k.graph.backend=memgraph` 일 때 활성화된다.
- * Memgraph는 Neo4j Bolt 프로토콜 호환이므로 Neo4j Driver를 재사용한다.
+ * It is active when `bluetape4k.graph.backend=memgraph`. Memgraph speaks the
+ * Neo4j Bolt protocol, so this configuration uses the Neo4j Java driver.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.GraphOperations
+ * import org.springframework.boot.autoconfigure.SpringBootApplication
+ * import org.springframework.boot.runApplication
+ *
+ * @SpringBootApplication
+ * class GraphApplication
+ *
+ * val context = runApplication<GraphApplication>(
+ *     "--bluetape4k.graph.backend=memgraph",
+ *     "--bluetape4k.graph.memgraph.uri=bolt://localhost:7687",
+ * )
+ * val operations = context.getBean(GraphOperations::class.java)
+ * ```
  */
 @AutoConfiguration
 @ConditionalOnClass(Driver::class, MemgraphGraphOperations::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
@@ -23,10 +23,27 @@ import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
 
 /**
- * Neo4j 백엔드 AutoConfiguration.
+ * Auto-configuration for the Neo4j backend.
  *
- * `bluetape4k.graph.backend=neo4j` 일 때 활성화된다.
- * Spring Boot 기본 Neo4j Driver가 이미 있으면 재사용한다.
+ * It is active when `bluetape4k.graph.backend=neo4j`. If the application
+ * already provides a Neo4j [Driver], that driver is reused.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.GraphOperations
+ * import org.springframework.boot.autoconfigure.SpringBootApplication
+ * import org.springframework.boot.runApplication
+ *
+ * @SpringBootApplication
+ * class GraphApplication
+ *
+ * val context = runApplication<GraphApplication>(
+ *     "--bluetape4k.graph.backend=neo4j",
+ *     "--bluetape4k.graph.neo4j.uri=bolt://localhost:7687",
+ * )
+ * val operations = context.getBean(GraphOperations::class.java)
+ * ```
  */
 @AutoConfiguration
 @ConditionalOnClass(Driver::class, Neo4jGraphOperations::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -18,10 +18,27 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
- * TinkerGraph 인메모리 백엔드 AutoConfiguration.
+ * Auto-configuration for the in-memory TinkerGraph backend.
  *
- * `bluetape4k.graph.backend=tinkergraph` 이거나 속성 미지정 시 활성화된다.
- * 외부 의존성이 없으므로 기본 백엔드로 적합하다.
+ * It is active when `bluetape4k.graph.backend=tinkergraph` or when the backend
+ * property is absent. TinkerGraph has no external service dependency, so it is
+ * the default backend.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.repository.GraphOperations
+ * import org.springframework.boot.autoconfigure.SpringBootApplication
+ * import org.springframework.boot.runApplication
+ *
+ * @SpringBootApplication
+ * class GraphApplication
+ *
+ * val context = runApplication<GraphApplication>(
+ *     "--bluetape4k.graph.backend=tinkergraph",
+ * )
+ * val operations = context.getBean(GraphOperations::class.java)
+ * ```
  */
 @AutoConfiguration
 @ConditionalOnClass(TinkerGraphOperations::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/AgeGraphProperties.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/AgeGraphProperties.kt
@@ -3,7 +3,18 @@ package io.bluetape4k.graph.spring.boot.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Apache AGE 백엔드 속성.
+ * Apache AGE backend properties.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.spring.boot.properties.AgeGraphProperties
+ *
+ * val properties = AgeGraphProperties(
+ *     graphName = "tenant_graph",
+ *     autoCreateGraph = true,
+ * )
+ * ```
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.age")
 data class AgeGraphProperties(

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/FalkorDBGraphProperties.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/FalkorDBGraphProperties.kt
@@ -3,25 +3,38 @@ package io.bluetape4k.graph.spring.boot.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * FalkorDB 백엔드 연결 속성.
+ * FalkorDB backend connection properties.
  *
- * `bluetape4k.graph.backend=falkordb` 일 때 활성화된다.
- * FalkorDB는 Redis 모듈 기반의 그래프 데이터베이스이며, jfalkordb 드라이버를 사용한다.
+ * The backend is active when `bluetape4k.graph.backend=falkordb`. FalkorDB is a
+ * Redis module based graph database and is accessed through the jfalkordb
+ * driver.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.spring.boot.properties.FalkorDBGraphProperties
+ *
+ * val properties = FalkorDBGraphProperties(
+ *     host = "falkordb.example.test",
+ *     port = 6379,
+ *     graphName = "recommendations",
+ * )
+ * ```
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.falkordb")
 data class FalkorDBGraphProperties(
-    /** FalkorDB 호스트 주소 */
+    /** FalkorDB host name or address. */
     val host: String = "localhost",
-    /** FalkorDB Redis 포트 번호 */
+    /** FalkorDB Redis port. */
     val port: Int = 6379,
-    /** 인증 사용자명 (비어있으면 인증 없음) */
+    /** Authentication username. Leave blank for unauthenticated connections. */
     val username: String = "",
-    /** 인증 비밀번호 (비어있으면 인증 없음) */
+    /** Authentication password. Leave blank for unauthenticated connections. */
     val password: String = "",
-    /** 대상 그래프 이름 */
+    /** Target graph name. */
     val graphName: String = "bluetape4k",
-    /** 코루틴 suspend 기반 [io.bluetape4k.graph.repository.GraphSuspendOperations] 빈 등록 여부 */
+    /** Whether to register a coroutine [io.bluetape4k.graph.repository.GraphSuspendOperations] bean. */
     val registerSuspend: Boolean = true,
-    /** Virtual Thread 기반 [io.bluetape4k.graph.repository.GraphVirtualThreadOperations] 빈 등록 여부 */
+    /** Whether to register a virtual-thread [io.bluetape4k.graph.repository.GraphVirtualThreadOperations] bean. */
     val registerVirtualThread: Boolean = true,
 )

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/GraphProperties.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/GraphProperties.kt
@@ -3,14 +3,23 @@ package io.bluetape4k.graph.spring.boot.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * bluetape4k Graph AutoConfiguration 공통 속성.
+ * Common bluetape4k Graph auto-configuration properties.
  *
- * `bluetape4k.graph.backend` 속성으로 활성화할 백엔드를 선택한다.
- * 지원 값: `tinkergraph`, `neo4j`, `memgraph`, `age`.
- * 기본값 없음 — 지정하지 않으면 TinkerGraph가 `matchIfMissing=true`로 활성화된다.
+ * `bluetape4k.graph.backend` selects the active backend. Supported values are
+ * `tinkergraph`, `neo4j`, `memgraph`, `age`, and `falkordb`. When the value is
+ * absent, TinkerGraph is enabled through `matchIfMissing=true`.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.spring.boot.properties.GraphProperties
+ *
+ * val properties = GraphProperties(backend = "neo4j")
+ * check(properties.backend == "neo4j")
+ * ```
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph")
 data class GraphProperties(
-    /** 활성 백엔드: `tinkergraph` | `neo4j` | `memgraph` | `age` */
+    /** Active backend: `tinkergraph`, `neo4j`, `memgraph`, `age`, or `falkordb`. */
     val backend: String? = null,
 )

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/MemgraphGraphProperties.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/MemgraphGraphProperties.kt
@@ -3,7 +3,19 @@ package io.bluetape4k.graph.spring.boot.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Memgraph 백엔드 연결 속성.
+ * Memgraph backend connection properties.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.spring.boot.properties.MemgraphGraphProperties
+ *
+ * val properties = MemgraphGraphProperties(
+ *     uri = "bolt://memgraph.example.test:7687",
+ *     database = "memgraph",
+ *     registerVirtualThread = false,
+ * )
+ * ```
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.memgraph")
 data class MemgraphGraphProperties(

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/Neo4jGraphProperties.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/Neo4jGraphProperties.kt
@@ -3,7 +3,20 @@ package io.bluetape4k.graph.spring.boot.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * Neo4j 백엔드 연결 속성.
+ * Neo4j backend connection properties.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.spring.boot.properties.Neo4jGraphProperties
+ *
+ * val properties = Neo4jGraphProperties(
+ *     uri = "bolt://neo4j.example.test:7687",
+ *     username = "neo4j",
+ *     password = "secret",
+ *     database = "analytics",
+ * )
+ * ```
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.neo4j")
 data class Neo4jGraphProperties(

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/TinkerGraphGraphProperties.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/properties/TinkerGraphGraphProperties.kt
@@ -3,7 +3,18 @@ package io.bluetape4k.graph.spring.boot.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
- * TinkerGraph 인메모리 백엔드 속성.
+ * TinkerGraph in-memory backend properties.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * import io.bluetape4k.graph.spring.boot.properties.TinkerGraphGraphProperties
+ *
+ * val properties = TinkerGraphGraphProperties(
+ *     registerSuspend = true,
+ *     registerVirtualThread = true,
+ * )
+ * ```
  */
 @ConfigurationProperties(prefix = "bluetape4k.graph.tinkergraph")
 data class TinkerGraphGraphProperties(


### PR DESCRIPTION
## Summary

- Add callable English KDoc examples for GraphML and Jackson NDJSON importer/exporter public APIs.
- Add Spring Boot graph properties and auto-configuration examples for public backend setup APIs.
- Fix existing Dokka unresolved-link warnings and use dedicated `dokka.md` files for Dokka module docs instead of arbitrary README files.
- Add a lesson entry for the Dokka validation behavior.

Closes #16.

## Validation

- `git diff --check`
- `./gradlew :graph-io-graphml:dokkaGeneratePublicationHtml :graph-io-jackson2:dokkaGeneratePublicationHtml :graph-io-jackson3:dokkaGeneratePublicationHtml :graph-spring-boot:dokkaGeneratePublicationHtml`
- `./gradlew dokkaGenerateHtml`

## Notes

- Runtime graph import/export behavior was not retested because the implementation changes are limited to KDoc and Dokka configuration.