### PR TITLE
Add domain graph example modules

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -501,7 +501,52 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
-  # ── 10. 커버리지 집계 ─────────────────────────────────────────────────────
+  # ── 10. Domain Examples (Testcontainers) ─────────────────────────────────
+  test-domain-examples:
+    name: Test / Domain Examples (Testcontainers)
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Test domain example modules
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :fraud-detection-examples:test \
+              :recommendation-examples:test \
+              :knowledge-graph-examples:test \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-domain-examples
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
+  # ── 11. 커버리지 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
 
@@ -553,7 +598,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 30
 
-  # ── 11. 결과 집계 ─────────────────────────────────────────────────────────
+  # ── 12. 결과 집계 ─────────────────────────────────────────────────────────
   nightly-status:
     name: Nightly Status
     runs-on: ubuntu-latest
@@ -568,6 +613,7 @@ jobs:
       - test-graph-age
       - test-graph-falkordb
       - test-examples
+      - test-domain-examples
       - coverage-report
     if: always()
     steps:

--- a/docs/lessons/2026-05-13-issue-10-domain-examples.md
+++ b/docs/lessons/2026-05-13-issue-10-domain-examples.md
@@ -1,0 +1,38 @@
+# Issue 10 Domain Examples
+
+## Context
+
+Issue #10 added three graph example modules: fraud detection, recommendation, and knowledge graph. Each module needed
+blocking and suspend services, backend-independent tests, README locale pairs, and Nightly coverage.
+
+## Decision
+
+Use the existing abstract-test pattern from `code-graph-examples` and `linkedin-graph-examples`. Keep each module's
+domain service thin over `GraphOperations` / `GraphSuspendOperations`, and place container-heavy domain example tests in a
+separate Full Nightly job instead of PR test jobs.
+
+## Outcome
+
+The new modules cover TinkerGraph, Neo4j, Memgraph, Apache AGE, and FalkorDB for both blocking and suspend APIs. The
+recommendation example uses paired one-hop traversals rather than mixed `maxDepth = 2` results so backend behavior stays
+predictable.
+
+## Verification
+
+- `./gradlew projects --no-daemon`
+- `./gradlew :fraud-detection-examples:compileKotlin :fraud-detection-examples:compileTestKotlin :recommendation-examples:compileKotlin :recommendation-examples:compileTestKotlin :knowledge-graph-examples:compileKotlin :knowledge-graph-examples:compileTestKotlin --no-daemon`
+- `./gradlew :fraud-detection-examples:test --tests '*TinkerGraph*' :recommendation-examples:test --tests '*TinkerGraph*' :knowledge-graph-examples:test --tests '*TinkerGraph*' --no-daemon`
+- `./gradlew :fraud-detection-examples:test :recommendation-examples:test :knowledge-graph-examples:test --no-daemon --continue`
+- `actionlint .github/workflows/nightly.yml`
+- `actionlint .github/workflows/ci.yml`
+- `./gradlew build -x test --parallel --no-daemon`
+- `rg -n -P "[가-힣]" examples/fraud-detection-examples/src/main examples/recommendation-examples/src/main examples/knowledge-graph-examples/src/main`
+- `git diff --check`
+
+IDE diagnostics were not available in the Codex tool surface for this session, so Gradle compile/test gates were used as
+fallback evidence.
+
+## Future Guidance
+
+When adding graph example modules, add a separate Full Nightly job for container-heavy domain examples and keep PR CI on
+compile/build unless the module has a fast in-memory test scope that should run on every PR.

--- a/docs/lessons/2026-05-13-issue-10-domain-examples.md
+++ b/docs/lessons/2026-05-13-issue-10-domain-examples.md
@@ -17,6 +17,10 @@ The new modules cover TinkerGraph, Neo4j, Memgraph, Apache AGE, and FalkorDB for
 recommendation example uses paired one-hop traversals rather than mixed `maxDepth = 2` results so backend behavior stays
 predictable.
 
+The README locale pairs were later expanded into learner-oriented tutorials. Each README now starts from learning goals,
+explains why a graph database fits the domain, and includes both a UML class diagram and a sequence/flow diagram before
+the API snippet.
+
 ## Verification
 
 - `./gradlew projects --no-daemon`
@@ -28,6 +32,7 @@ predictable.
 - `./gradlew build -x test --parallel --no-daemon`
 - `rg -n -P "[가-힣]" examples/fraud-detection-examples/src/main examples/recommendation-examples/src/main examples/knowledge-graph-examples/src/main`
 - `git diff --check`
+- README-only learning-doc update: `git diff --check`
 
 IDE diagnostics were not available in the Codex tool surface for this session, so Gradle compile/test gates were used as
 fallback evidence.
@@ -36,3 +41,6 @@ fallback evidence.
 
 When adding graph example modules, add a separate Full Nightly job for container-heavy domain examples and keep PR CI on
 compile/build unless the module has a fast in-memory test scope that should run on every PR.
+
+For example READMEs, prefer a tutorial structure: learning goals, graph database rationale, architecture diagram, UML
+domain diagram, execution flow, API snippet, and test-reading guidance.

--- a/docs/superpowers/plans/2026-05-13-issue-10-domain-examples-plan.md
+++ b/docs/superpowers/plans/2026-05-13-issue-10-domain-examples-plan.md
@@ -1,0 +1,329 @@
+# Issue 10 Domain Examples Implementation Plan
+
+## Inputs
+
+- Spec: `docs/superpowers/specs/2026-05-13-issue-10-domain-examples-design.md`
+- Issue: #10 `[Epic] 추가 예시 모듈 — fraud-detection / recommendation / knowledge-graph`
+- Worktree: `.worktrees/feat-issue-10-domain-examples`
+- Branch: `feat/issue-10-domain-examples`
+
+## Scope
+
+Implement three new example modules:
+
+- `examples/fraud-detection-examples`
+- `examples/recommendation-examples`
+- `examples/knowledge-graph-examples`
+
+Each module includes:
+
+- `build.gradle.kts`
+- `README.md`
+- `README.ko.md`
+- schema DSL file
+- blocking service
+- suspend service
+- abstract blocking test
+- abstract suspend test
+- five blocking backend concrete tests
+- five suspend backend concrete tests
+
+## Implementation Tasks
+
+### 1. Scaffold modules (S)
+
+Create:
+
+```text
+examples/fraud-detection-examples/
+examples/recommendation-examples/
+examples/knowledge-graph-examples/
+```
+
+For each module:
+
+- Copy the dependency shape from `examples/code-graph-examples/build.gradle.kts`.
+- Add `src/main/kotlin/io/bluetape4k/graph/examples/<domain>/schema`.
+- Add `src/main/kotlin/io/bluetape4k/graph/examples/<domain>/service`.
+- Add `src/test/kotlin/io/bluetape4k/graph/examples/<domain>`.
+
+Expected Gradle project names through existing `settings.gradle.kts`:
+
+- `:fraud-detection-examples`
+- `:recommendation-examples`
+- `:knowledge-graph-examples`
+
+Rollback checkpoint:
+
+- Run `./gradlew projects` and verify all three module names are present.
+
+### 2. Implement fraud detection example (M)
+
+Files:
+
+- `FraudDetectionSchema.kt`
+- `FraudDetectionService.kt`
+- `FraudDetectionSuspendService.kt`
+
+Domain operations:
+
+- create accounts
+- create transfer edges
+- detect circular transfers with `CycleOptions(edgeLabel = "TRANSFERRED_TO")`
+- detect suspicious clusters with `ComponentOptions(vertexLabel = "Account", edgeLabel = "TRANSFERRED_TO", minSize = minSize)`
+- rank high-risk accounts with `PageRankOptions(vertexLabel = "Account", edgeLabel = "TRANSFERRED_TO", topK = limit)`
+
+Tests:
+
+- account and transfer creation
+- circular transfer detection returns at least one cycle
+- suspicious cluster detection returns a component with expected size
+- PageRank topK membership includes the expected sink account by stable vertex property/id; do not assert exact rank
+  position or score value.
+- suspend tests mirror blocking tests with `Flow.toList()`
+
+Diagnostics and compile gate:
+
+- Run IDE diagnostics for touched Kotlin files when available.
+- If IDE diagnostics are unavailable in the active Codex environment, record the gap and use Gradle compile/test as
+  fallback evidence.
+- Fix import errors and unresolved `@Deprecated` warnings before compile/test.
+- Run `./gradlew :fraud-detection-examples:compileKotlin :fraud-detection-examples:compileTestKotlin --no-daemon`.
+- Run TinkerGraph fraud tests before adding container backend fanout.
+
+### 3. Implement recommendation example (M)
+
+Files:
+
+- `RecommendationSchema.kt`
+- `RecommendationService.kt`
+- `RecommendationSuspendService.kt`
+
+Domain operations:
+
+- create users and products
+- record `PURCHASED` edges from users to products
+- create social `FOLLOWS` edges between users
+- recommend products with paired neighbor calls, not a mixed `maxDepth = 2` result:
+  - source purchased products: `user --PURCHASED--> product`
+  - similar users: `product <--PURCHASED-- user`
+  - candidate products: `similar user --PURCHASED--> product`
+  - exclude products already purchased by the source user and distinct by product id
+- recommend follows with paired neighbor calls over `FOLLOWS`:
+  - direct follows: `source --FOLLOWS--> user`
+  - second-hop follows: `direct --FOLLOWS--> user`
+  - exclude the source user and all direct follows, then distinct by user id
+- rank popular products with `PageRankOptions(vertexLabel = "Product", edgeLabel = "PURCHASED", topK = limit)`
+
+Tests:
+
+- product recommendation suggests a product bought by a similar user
+- follow recommendation suggests a two-hop follow target
+- PageRank topK membership includes the expected product by stable vertex property/id; do not assert exact rank position
+  or score value.
+- suspend tests mirror blocking tests with `Flow.toList()`
+
+Suspend Flow semantics:
+
+- For repository APIs that already return `Flow<T>`, return the mapped/filtered Flow directly.
+- For multi-step recommendations that need intermediate collection, use `flow { ... emit(...) }` or collected lists followed
+  by `.asFlow()`; do not catch broad exceptions. If catch blocks become necessary, rethrow `CancellationException`.
+
+Diagnostics and compile gate:
+
+- Run IDE diagnostics for touched Kotlin files when available; otherwise record the gap and rely on Gradle compile/test.
+- Fix import errors and unresolved `@Deprecated` warnings before compile/test.
+- Run `./gradlew :recommendation-examples:compileKotlin :recommendation-examples:compileTestKotlin --no-daemon`.
+- Run TinkerGraph recommendation tests before adding container backend fanout.
+
+### 4. Implement knowledge graph example (M)
+
+Files:
+
+- `KnowledgeGraphSchema.kt`
+- `KnowledgeGraphService.kt`
+- `KnowledgeGraphSuspendService.kt`
+
+Domain operations:
+
+- create entities, concepts, and documents
+- link documents to entities with `MENTIONS`
+- relate entities and concepts with typed `RELATED_TO` or `IS_A` edges
+- find related entities through `neighbors`
+- infer relationship paths through `allPaths`, bounded by `maxDepth` and a service-side `maxPaths` limit so all backends
+  expose the same maximum result count
+
+Tests:
+
+- entity/document linking returns mentioned entities
+- related entity traversal returns expected entity
+- relationship path inference returns a bounded non-empty path set containing the expected labels/ids; do not assert exact
+  traversal order beyond source/target and maximum count.
+- suspend tests mirror blocking tests with `Flow.toList()`
+
+Diagnostics and compile gate:
+
+- Run IDE diagnostics for touched Kotlin files when available; otherwise record the gap and rely on Gradle compile/test.
+- Fix import errors and unresolved `@Deprecated` warnings before compile/test.
+- Run `./gradlew :knowledge-graph-examples:compileKotlin :knowledge-graph-examples:compileTestKotlin --no-daemon`.
+- Run TinkerGraph knowledge graph tests before adding container backend fanout.
+
+### 5. Add backend concrete tests for each module (L)
+
+For each module and service mode, add:
+
+- `TinkerGraph<Domain>Test`
+- `Neo4j<Domain>Test`
+- `Memgraph<Domain>Test`
+- `Age<Domain>Test`
+- `FalkorDB<Domain>Test`
+
+Reuse setup from existing examples:
+
+- TinkerGraph: in-memory operations
+- Neo4j: `Neo4jServer.Launcher.neo4j`
+- Memgraph: `MemgraphServer.Launcher.memgraph`
+- AGE: `PostgreSQLAgeServer.Launcher.postgresqlAge`, HikariCP, Exposed `Database.connect`
+- FalkorDB: `FalkorDBServer.Launcher.falkordb`, UUID-suffixed graph name per concrete class, best-effort drop in
+  `@AfterAll` with logging
+
+Isolation rules:
+
+- Keep each concrete class aligned with existing example patterns and inherit `Abstract*Test` / `Abstract*SuspendTest`
+  behavior.
+- Verify AGE tests do not depend on leaked Exposed default database state; copy the existing AGE fixture pattern
+  verbatim and keep graph names/domain data isolated.
+- Preserve `testMutex`-compatible execution assumptions already used by container-backed tests.
+
+Per-module backend rollout:
+
+- First add TinkerGraph blocking and suspend tests.
+- Then add Neo4j and Memgraph.
+- Then add AGE.
+- Then add FalkorDB with UUID graph names and cleanup.
+
+### 6. Add README locale sets (M)
+
+For each module:
+
+- `README.md` in English
+- `README.ko.md` in Korean
+
+Each README includes:
+
+- language switch below title
+- architecture section with Mermaid diagram
+- core features
+- usage examples
+- configuration/testing notes
+- dependency snippet
+
+Rollback checkpoint:
+
+- Verify every module has both `README.md` and `README.ko.md`.
+- Verify the language switch appears directly below each title.
+
+### 7. Update workflows (M)
+
+7a. Edit `.github/workflows/nightly.yml`:
+
+- Add a new job `test-domain-examples`.
+- Run:
+  - `:fraud-detection-examples:test`
+  - `:recommendation-examples:test`
+  - `:knowledge-graph-examples:test`
+- Use Docker/Testcontainers env matching the existing `test-examples` job, including inherited `JAVA_VERSION: ${{ env.JAVA_VERSION }}`.
+- Add `test-domain-examples` to `nightly-status.needs`.
+
+7b. Audit `.github/workflows/ci.yml`:
+
+- If CI enumerates example modules explicitly, update it for the new modules.
+- If CI only runs repository-wide compile/build tasks that auto-include modules through `settings.gradle.kts`, document that
+  no `ci.yml` edit is needed.
+- Do not add these container-heavy module tests to PR CI test jobs unless existing CI policy requires it.
+
+7c. Validate workflow syntax:
+
+- Run `actionlint .github/workflows/nightly.yml`.
+- Run `actionlint .github/workflows/ci.yml` if `ci.yml` is edited; otherwise record the no-edit audit result.
+
+7d. Remote Nightly verification:
+
+- After pushing the branch or opening the PR, run `gh workflow run nightly.yml --ref <branch> -f scope=full`.
+- Record the Nightly run URL and result before declaring DoD.
+
+### 8. Verification
+
+Run in order:
+
+1. `git status --porcelain`
+2. `./gradlew projects`
+3. IDE diagnostics for touched Kotlin files when available; otherwise record the fallback.
+4. `actionlint .github/workflows/nightly.yml`
+5. `actionlint .github/workflows/ci.yml` if edited.
+6. `./gradlew :fraud-detection-examples:test --no-daemon`
+7. `./gradlew :recommendation-examples:test --no-daemon`
+8. `./gradlew :knowledge-graph-examples:test --no-daemon`
+9. `./gradlew build -x test --parallel`
+10. `rg -P "[가-힣]" examples/fraud-detection-examples/src/main examples/recommendation-examples/src/main examples/knowledge-graph-examples/src/main`
+    should return no public source KDoc/text matches.
+11. `git diff --check`
+12. `gh workflow run nightly.yml --ref feat/issue-10-domain-examples -f scope=full`, then capture the run URL and result.
+
+If container-backed local tests fail due local Docker availability, rerun the TinkerGraph subset if possible and record
+the Docker gap. Do not claim full completion without either local full tests or CI/Nightly evidence.
+
+### 9. Review and cleanup
+
+- Verify public KDoc is English in new public classes.
+- Verify README locale pairs are both present.
+- Check module names through `./gradlew projects`.
+- Ensure no generated build or docs output is staged.
+- Add a concise lesson under `docs/lessons/`.
+
+Lesson template:
+
+```markdown
+# Issue 10 Domain Examples
+
+## Context
+
+## Decision
+
+## Outcome
+
+## Verification
+
+## Future Guidance
+```
+
+## Commit Protocol
+
+- Commit spec and plan before implementation.
+- Use English Conventional Commit subjects with Lore trailers.
+- Prefer one commit for design artifacts, one or more commits for implementation, and one commit for workflow/docs cleanup
+  only if that split improves reviewability.
+- Do not use `--no-verify`.
+- Do not force-push unless explicitly instructed.
+
+## Rollback Points
+
+- After module scaffolding: `./gradlew projects`
+- After each module blocking service: TinkerGraph blocking test
+- After each module suspend service: TinkerGraph suspend test
+- After each README locale pair: file presence and language switch check
+- After each backend group: targeted backend test class subset
+- After Nightly edit: `actionlint`
+- Before PR: full targeted module tests, build, KDoc language grep, diff check
+- After PR: full Nightly `workflow_dispatch scope=full` run URL/result
+
+## Step 3-R Review Notes
+
+- Review artifact: `.omx/artifacts/claude-issue-10-plan-review-20260513081601.md`
+- Blocking findings addressed:
+  - `ci.yml` audit/update task added.
+  - Full Nightly `workflow_dispatch scope=full` verification added as required DoD evidence.
+  - Recommendation traversal algorithm now specifies paired neighbor calls and exclusion sets.
+  - Kotlin IDE diagnostics/fallback gates added before compile/test.
+  - Cross-backend assertion shapes now avoid exact PageRank scores/order and exact traversal ordering.
+- P0/P1 after edits: 0 known.

--- a/docs/superpowers/specs/2026-05-13-issue-10-domain-examples-design.md
+++ b/docs/superpowers/specs/2026-05-13-issue-10-domain-examples-design.md
@@ -1,0 +1,411 @@
+# Issue 10 Domain Examples Design
+
+## Context
+
+Issue #10 adds three domain example modules to demonstrate graph algorithm usage:
+
+- `fraud-detection-examples`
+- `recommendation-examples`
+- `knowledge-graph-examples`
+
+Existing examples already establish the implementation shape:
+
+- `examples/code-graph-examples`
+- `examples/linkedin-graph-examples`
+
+The new modules should reuse the same module layout, backend matrix, service/test split, and Testcontainers singleton
+patterns rather than introducing a new example framework.
+
+## Goals
+
+- Add three example modules under `examples/`.
+- Demonstrate algorithm-oriented graph APIs through practical domain services.
+- Cover blocking and coroutine service variants.
+- Cover backend smoke tests for Neo4j, Memgraph, Apache AGE, FalkorDB, and TinkerGraph.
+- Keep examples excluded from Maven Central publishing by following existing `examples/` conventions.
+- Add the new modules to full Nightly example verification.
+
+## Non-Goals
+
+- No new graph-core API.
+- No new graph backend behavior.
+- No new production dependencies outside example modules.
+- No broad CI expansion for every pull request; container-heavy example tests stay in full Nightly.
+
+## Existing Pattern Evidence
+
+### Module Inclusion
+
+`settings.gradle.kts` includes every `examples/*/build.gradle.kts` directory through:
+
+```kotlin
+includeModules("examples", false, false)
+```
+
+Therefore each new example needs only its own `build.gradle.kts`.
+
+### Dependencies
+
+`code-graph-examples` and `linkedin-graph-examples` depend on:
+
+- `:graph-core`
+- all five backend modules
+- `bluetape4k.coroutines`
+- `kotlinx-coroutines-core`
+- test-only Testcontainers, Neo4j driver, PostgreSQL driver, HikariCP, and coroutine test support
+- `:graph-falkordb` test fixtures for FalkorDB server support
+
+The three new modules should copy this dependency shape.
+
+Each new module should use this dependency block shape:
+
+```kotlin
+dependencies {
+    implementation(project(":graph-core"))
+    implementation(project(":graph-age"))
+    implementation(project(":graph-neo4j"))
+    implementation(project(":graph-memgraph"))
+    implementation(project(":graph-tinkerpop"))
+    implementation(project(":graph-falkordb"))
+
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.neo4j)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.neo4j.java.driver)
+    testRuntimeOnly(libs.postgresql.driver)
+    testImplementation(libs.hikaricp)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(project(":graph-falkordb"))
+    testImplementation(testFixtures(project(":graph-falkordb")))
+}
+```
+
+Root `build.gradle.kts` already serializes all `test` tasks through `testMutex`, so the new module tests inherit the
+same Testcontainers conflict protection as existing examples.
+
+### Schema DSL
+
+Each module should define schema labels under `src/main/kotlin/.../schema`, following `CodeGraphSchema.kt` and
+`LinkedInSchema.kt`.
+
+Example shape:
+
+```kotlin
+object AccountLabel : VertexLabel("Account") {
+    val accountNumber = string("accountNumber")
+}
+
+object TransferredToLabel : EdgeLabel("TRANSFERRED_TO", AccountLabel, AccountLabel) {
+    val amount = long("amount")
+}
+```
+
+### Backend Tests
+
+Existing examples use:
+
+- abstract blocking test class with shared scenario tests
+- abstract suspend test class with the same scenario coverage
+- backend-specific concrete classes that only provide `ops`
+- AGE setup with `PostgreSQLAgeServer.Launcher.postgresqlAge`, HikariCP, and Exposed `Database.connect`
+- FalkorDB setup with random graph names and cleanup in `@AfterAll`
+- Neo4j/Memgraph setup through `Neo4jServer.Launcher` / `MemgraphServer.Launcher`
+- TinkerGraph setup with in-memory operations
+
+## Proposed Module Designs
+
+### fraud-detection-examples
+
+Package root:
+
+```text
+io.bluetape4k.graph.examples.fraud
+```
+
+Public service classes:
+
+- `FraudDetectionService`
+- `FraudDetectionSuspendService`
+
+Schema labels:
+
+- vertices: `Account`, `Transaction`
+- edges: `TRANSFERRED_TO`, `OWNS`
+
+Main scenarios:
+
+- Circular transfer detection: find account-to-account transfer cycles.
+- Suspicious cluster detection: find weakly connected account components above a minimum size.
+- High-risk account lookup: rank accounts by PageRank over transfer edges.
+
+Blocking service API:
+
+```kotlin
+class FraudDetectionService(
+    private val ops: GraphOperations,
+    private val graphName: String = "fraud_detection",
+) {
+    fun initialize()
+    fun addAccount(accountNumber: String, ownerName: String = "", riskLevel: String = "normal"): GraphVertex
+    fun addTransfer(fromAccountId: GraphElementId, toAccountId: GraphElementId, amount: Long, traceId: String = "")
+    fun detectCircularTransfers(maxDepth: Int = 5): List<GraphCycle>
+    fun findSuspiciousClusters(minSize: Int = 2): List<GraphComponent>
+    fun rankHighRiskAccounts(limit: Int = 10): List<PageRankScore>
+}
+```
+
+Suspend service API:
+
+```kotlin
+class FraudDetectionSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "fraud_detection",
+) {
+    suspend fun initialize()
+    suspend fun addAccount(accountNumber: String, ownerName: String = "", riskLevel: String = "normal"): GraphVertex
+    suspend fun addTransfer(fromAccountId: GraphElementId, toAccountId: GraphElementId, amount: Long, traceId: String = "")
+    fun detectCircularTransfers(maxDepth: Int = 5): Flow<GraphCycle>
+    fun findSuspiciousClusters(minSize: Int = 2): Flow<GraphComponent>
+    fun rankHighRiskAccounts(limit: Int = 10): Flow<PageRankScore>
+}
+```
+
+### recommendation-examples
+
+Package root:
+
+```text
+io.bluetape4k.graph.examples.recommendation
+```
+
+Public service classes:
+
+- `RecommendationService`
+- `RecommendationSuspendService`
+
+Schema labels:
+
+- vertices: `User`, `Product`, `Category`
+- edges: `PURCHASED`, `VIEWED`, `FOLLOWS`, `IN_CATEGORY`
+
+Main scenarios:
+
+- Product recommendation from neighbor traversal over user-product relations.
+- Social follow recommendation from 2-hop `FOLLOWS` traversal.
+- Popular product ranking through PageRank over interaction edges.
+
+Blocking service API:
+
+```kotlin
+class RecommendationService(
+    private val ops: GraphOperations,
+    private val graphName: String = "recommendation",
+) {
+    fun initialize()
+    fun addUser(userId: String, name: String = ""): GraphVertex
+    fun addProduct(sku: String, name: String, category: String = ""): GraphVertex
+    fun purchase(userId: GraphElementId, productId: GraphElementId, quantity: Int = 1)
+    fun follow(followerId: GraphElementId, targetId: GraphElementId)
+    fun recommendProducts(userId: GraphElementId, maxDepth: Int = 2): List<GraphVertex>
+    fun recommendFollows(userId: GraphElementId): List<GraphVertex>
+    fun rankPopularProducts(limit: Int = 10): List<PageRankScore>
+}
+```
+
+Implementation constraints:
+
+- `rankPopularProducts` must use `PageRankOptions(vertexLabel = "Product", edgeLabel = "PURCHASED", topK = limit)`.
+- `recommendProducts` should use a stable two-step traversal: purchased products -> users who purchased them -> their
+  purchased products, then remove products already purchased by the source user.
+- `recommendFollows` should use `FOLLOWS` two-hop traversal and remove direct follows plus the source user.
+
+Suspend service API:
+
+```kotlin
+class RecommendationSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "recommendation",
+) {
+    suspend fun initialize()
+    suspend fun addUser(userId: String, name: String = ""): GraphVertex
+    suspend fun addProduct(sku: String, name: String, category: String = ""): GraphVertex
+    suspend fun purchase(userId: GraphElementId, productId: GraphElementId, quantity: Int = 1)
+    suspend fun follow(followerId: GraphElementId, targetId: GraphElementId)
+    fun recommendProducts(userId: GraphElementId, maxDepth: Int = 2): Flow<GraphVertex>
+    fun recommendFollows(userId: GraphElementId): Flow<GraphVertex>
+    fun rankPopularProducts(limit: Int = 10): Flow<PageRankScore>
+}
+```
+
+### knowledge-graph-examples
+
+Package root:
+
+```text
+io.bluetape4k.graph.examples.knowledge
+```
+
+Public service classes:
+
+- `KnowledgeGraphService`
+- `KnowledgeGraphSuspendService`
+
+Schema labels:
+
+- vertices: `Entity`, `Concept`, `Document`
+- edges: `MENTIONS`, `RELATED_TO`, `IS_A`, `DERIVED_FROM`
+
+Main scenarios:
+
+- Entity linking from documents to entities.
+- Concept hierarchy traversal.
+- Relationship path inference through `allPaths`.
+
+Blocking service API:
+
+```kotlin
+class KnowledgeGraphService(
+    private val ops: GraphOperations,
+    private val graphName: String = "knowledge_graph",
+) {
+    fun initialize()
+    fun addEntity(name: String, entityType: String = "generic"): GraphVertex
+    fun addConcept(name: String, domain: String = ""): GraphVertex
+    fun addDocument(documentId: String, title: String): GraphVertex
+    fun mention(documentId: GraphElementId, entityId: GraphElementId)
+    fun relate(fromId: GraphElementId, toId: GraphElementId, relation: String = "RELATED_TO")
+    fun findRelatedEntities(entityId: GraphElementId, maxDepth: Int = 2): List<GraphVertex>
+    fun inferRelationshipPaths(fromId: GraphElementId, toId: GraphElementId, maxDepth: Int = 4, maxPaths: Int = 50): List<GraphPath>
+}
+```
+
+Suspend service API:
+
+```kotlin
+class KnowledgeGraphSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "knowledge_graph",
+) {
+    suspend fun initialize()
+    suspend fun addEntity(name: String, entityType: String = "generic"): GraphVertex
+    suspend fun addConcept(name: String, domain: String = ""): GraphVertex
+    suspend fun addDocument(documentId: String, title: String): GraphVertex
+    suspend fun mention(documentId: GraphElementId, entityId: GraphElementId)
+    suspend fun relate(fromId: GraphElementId, toId: GraphElementId, relation: String = "RELATED_TO")
+    fun findRelatedEntities(entityId: GraphElementId, maxDepth: Int = 2): Flow<GraphVertex>
+    fun inferRelationshipPaths(fromId: GraphElementId, toId: GraphElementId, maxDepth: Int = 4, maxPaths: Int = 50): Flow<GraphPath>
+}
+```
+
+## Architecture Decisions
+
+### One module per domain
+
+Each domain gets a separate Gradle module, matching issue #10 and making examples easy to run independently.
+
+Rejected alternative: one `domain-graph-examples` module with three packages.
+
+Reason: one module would reduce Gradle files but weaken discoverability and make Nightly failures less attributable.
+
+### Duplicate small backend fixtures per module
+
+Backend concrete test classes will mirror existing examples instead of introducing shared test-fixture modules.
+
+Rejected alternative: extract a shared `examples-test-support` module.
+
+Reason: the existing examples intentionally keep test setup local. A shared fixture would be a larger architecture change
+than issue #10 requires and could create cross-example coupling.
+
+### Algorithm APIs stay service-facing
+
+Services expose domain methods, not raw `GraphOperations` wrappers. Tests verify outcomes through domain terms.
+
+Reason: the examples should teach users how to translate a business scenario into graph operations.
+
+### Full Nightly owns backend matrix verification
+
+The PR build will compile all modules through `./gradlew build -x test --parallel`, but container-heavy example tests
+will be added to a new full Nightly domain example job instead of the existing `test-examples` job.
+
+Reason: existing example backend matrices already run in full Nightly only, and adding five-backend example suites to PR
+CI would increase pull request cost substantially. A separate Nightly job improves failure attribution and avoids pushing
+the existing `test-examples` job past its 30-minute timeout.
+
+## Backend Capability Matrix
+
+| Scenario | TinkerGraph | Neo4j | Memgraph | Apache AGE | FalkorDB |
+|---|---|---|---|---|---|
+| Fraud circular transfer detection | run, assert non-empty cycle | run, assert non-empty cycle | run, assert non-empty cycle | run, assert non-empty cycle | run, assert non-empty cycle |
+| Fraud suspicious clusters | run, assert min component size | run, assert min component size | run, assert min component size | run, assert min component size | run, assert min component size |
+| Fraud PageRank | run, assert expected account in topK | run, assert expected account in topK | run, assert expected account in topK | run, assert expected account in topK | run via JVM fallback, assert expected account in topK |
+| Recommendation product traversal | run, assert recommended product label | run, assert recommended product label | run, assert recommended product label | run, assert recommended product label | run, assert recommended product label |
+| Recommendation PageRank | run, `PURCHASED` edge filter | run, `PURCHASED` edge filter | run, `PURCHASED` edge filter | run, `PURCHASED` edge filter | run via JVM fallback, `PURCHASED` edge filter |
+| Knowledge related entities | run, assert related entity label | run, assert related entity label | run, assert related entity label | run, assert related entity label | run, assert related entity label |
+| Knowledge relationship paths | run, assert bounded paths | run, assert bounded paths | run, assert bounded paths | run, assert bounded paths | run, assert bounded paths |
+
+## Verification Strategy
+
+Local verification:
+
+- `./gradlew projects`
+- `./gradlew :fraud-detection-examples:test --no-daemon`
+- `./gradlew :recommendation-examples:test --no-daemon`
+- `./gradlew :knowledge-graph-examples:test --no-daemon`
+- `./gradlew build -x test --parallel`
+- `actionlint .github/workflows/nightly.yml` if Nightly workflow is edited
+
+Remote verification:
+
+- PR CI compile-only build should include the new modules through `settings.gradle.kts`.
+- Full Nightly should run all new example tests in a new `test-domain-examples` job.
+- The Nightly status aggregation should include `test-domain-examples`.
+- If practical after merge, run `workflow_dispatch` with `scope=full` and record the run URL.
+
+## Risks
+
+- Backend algorithm parity may differ. Tests should assert stable, cross-backend properties such as non-empty results,
+  expected labels, and path/component existence, not backend-specific ordering.
+- AGE uses a global Exposed `Database.connect` side effect. Keep AGE tests consistent with existing examples.
+- FalkorDB graph cleanup must use unique graph names and best-effort drop in `@AfterAll`.
+- PageRank ranking can vary by score tie. Tests should check that expected vertices appear in the top result set rather
+  than asserting exact score values.
+- `allPaths` can grow quickly on dense knowledge graphs. `inferRelationshipPaths` must expose `maxPaths` and tests should
+  use small fixtures.
+
+## Acceptance Criteria
+
+- Three new example modules exist and are auto-included by Gradle.
+- Each module has blocking and suspend service classes.
+- Each module has abstract blocking/suspend tests plus five backend concrete test classes for each mode.
+- README.md and README.ko.md exist for every new module.
+- New public KDoc is English.
+- README files include the language switch, architecture/features/usage/config/dependencies sections, and a Mermaid
+  architecture diagram.
+- Nightly full workflow includes a separate `test-domain-examples` job for the three new modules.
+- New module test tasks inherit the root `testMutex` serialization.
+- Local targeted tests pass for all three modules.
+- `./gradlew build -x test --parallel` passes.
+
+## Step 2-R Review Notes
+
+### Claude Code Opus Advisor
+
+Artifact: `.omx/artifacts/claude-issue-10-spec-review-20260513081123.md`
+Model: `${CLAUDE_ADVISOR_MODEL:-claude-opus-4-7}`
+
+| Priority | Finding | Decision | Follow-up |
+|---|---|---|---|
+| P0 | Service APIs lacked `graphName`. | Accepted | Added `graphName` to all service API sketches. |
+| P0 | Suspend service API was not specified. | Accepted | Added Flow-based suspend API sketches. |
+| P0 | Backend capability/skip policy was missing. | Accepted | Added backend capability matrix. |
+| P0 | New public KDoc language was not specified. | Accepted | Added English KDoc acceptance criterion. |
+| P0 | Recommendation PageRank edge scope was ambiguous. | Accepted | Fixed to `PageRankOptions(edgeLabel = "PURCHASED")`. |
+| P1 | Schema DSL, dependency block, testMutex, and Nightly edit location were under-specified. | Accepted | Added concrete sections and Nightly job decision. |
+| P2 | Knowledge `allPaths` can explode. | Accepted | Added `maxPaths` to service API. |
+
+Latest integrated finding status: P0 = 0, P1 = 0.

--- a/examples/fraud-detection-examples/README.ko.md
+++ b/examples/fraud-detection-examples/README.ko.md
@@ -2,17 +2,91 @@
 
 > 🇺🇸 [English](README.md)
 
-계좌 이체를 그래프로 모델링하고, bluetape4k-graph의 백엔드 독립 API로 이상 거래 분석을 수행하는 예제입니다.
+계좌 이체를 그래프로 모델링하고, bluetape4k-graph의 백엔드 독립 API로 이상 거래 분석을 수행하는 방법을 배우는 예제입니다.
+
+## 무엇을 배우나?
+
+| 주제 | 의미 |
+|---|---|
+| 이체 그래프 모델링 | 돈의 이동은 계좌 사이의 방향성 있는 관계로 표현하기 좋습니다. |
+| 순환 탐지 | `A -> B -> C -> A` 같은 이체 고리는 layering 또는 wash activity 신호가 될 수 있습니다. |
+| 연결 컴포넌트 | 서로 강하게 연결된 계좌 묶음을 의심 클러스터로 볼 수 있습니다. |
+| PageRank | 중요한 자금 흐름을 많이 받는 계좌를 검토 우선순위로 올릴 수 있습니다. |
+| 백엔드 이식성 | 같은 서비스가 TinkerGraph, Neo4j, Memgraph, Apache AGE, FalkorDB에서 동작합니다. |
+
+## 왜 Graph DB가 좋은가?
+
+이상 거래 신호는 단일 row보다 관계에서 나오는 경우가 많습니다. 이체 테이블만으로도 데이터를 저장할 수는 있지만,
+"어떤 계좌가 고리를 이루는가?", "어떤 계좌들이 같은 의심 클러스터에 속하는가?", "네트워크 중심에 있는 수신 계좌는
+무엇인가?" 같은 질문은 반복 self-join과 별도 traversal 로직이 필요합니다.
+
+Graph DB를 사용하면 도메인 언어가 그대로 모델이 됩니다.
+
+- 계좌는 vertex,
+- 이체는 방향성 edge,
+- 의심 행위는 path, cycle, component, centrality로 표현됩니다.
+
+그래서 분석 규칙을 도메인 모델 가까이에 둘 수 있고, 여러 Graph DB 백엔드에서도 같은 계약으로 실행할 수 있습니다.
 
 ## 아키텍처
 
 ```mermaid
 flowchart LR
-    AccountA[Account] -->|TRANSFERRED_TO| AccountB[Account]
-    AccountB -->|TRANSFERRED_TO| AccountC[Account]
-    AccountC -->|TRANSFERRED_TO| AccountA
-    Service[FraudDetectionService] --> Ops[GraphOperations]
-    Service --> Analytics[Cycles / Components / PageRank]
+    Test[Example test] --> Service[FraudDetectionService]
+    Service --> Ops[GraphOperations]
+    Ops --> Backend[(Graph backend)]
+    Backend --> Analytics[Cycles / Components / PageRank]
+    Analytics --> Findings[Review candidates]
+```
+
+## 도메인 UML
+
+```mermaid
+classDiagram
+    class Account {
+        +String accountId
+        +String ownerName
+        +String riskTier
+    }
+
+    class Transfer {
+        +Long amount
+        +String occurredAt
+    }
+
+    class FraudDetectionService {
+        +addAccount(accountId, ownerName, riskTier)
+        +recordTransfer(fromAccountId, toAccountId, amount)
+        +detectCircularTransfers(maxDepth, maxCycles)
+        +detectSuspiciousClusters(minSize)
+        +rankHighRiskAccounts(limit)
+    }
+
+    Account "1" --> "*" Transfer : outgoing
+    Transfer "*" --> "1" Account : incoming
+    FraudDetectionService ..> Account
+    FraudDetectionService ..> Transfer
+```
+
+## 분석 흐름
+
+```mermaid
+sequenceDiagram
+    participant Learner
+    participant Service as FraudDetectionService
+    participant Ops as GraphOperations
+    participant DB as Graph DB
+
+    Learner->>Service: addAccount(...)
+    Service->>Ops: createVertex("Account", ...)
+    Ops->>DB: persist account
+    Learner->>Service: recordTransfer(...)
+    Service->>Ops: createEdge(..., "TRANSFERRED_TO", ...)
+    Ops->>DB: persist transfer
+    Learner->>Service: detectCircularTransfers()
+    Service->>Ops: detectCycles(CycleOptions)
+    Ops->>DB: traverse transfer graph
+    DB-->>Learner: suspicious cycles
 ```
 
 ## 주요 기능
@@ -42,6 +116,17 @@ val cycles = service.detectCircularTransfers()
 val clusters = service.detectSuspiciousClusters(minSize = 3)
 val ranked = service.rankHighRiskAccounts(limit = 10)
 ```
+
+## 테스트 읽는 법
+
+`AbstractFraudDetectionTest`와 `AbstractFraudDetectionSuspendTest`가 학습 시나리오입니다. 구체 backend test class는
+backend별 `GraphOperations` 구현만 제공합니다.
+
+| 테스트 종류 | 목적 |
+|---|---|
+| Abstract tests | 이상 거래 분석 동작을 한 번만 설명합니다. |
+| TinkerGraph tests | 빠른 메모리 기반 smoke test입니다. |
+| Neo4j/Memgraph/AGE/FalkorDB tests | 실제 backend에서도 같은 도메인 동작이 유지되는지 검증합니다. |
 
 ## 테스트 실행
 

--- a/examples/fraud-detection-examples/README.ko.md
+++ b/examples/fraud-detection-examples/README.ko.md
@@ -1,0 +1,64 @@
+# fraud-detection-examples
+
+> 🇺🇸 [English](README.md)
+
+계좌 이체를 그래프로 모델링하고, bluetape4k-graph의 백엔드 독립 API로 이상 거래 분석을 수행하는 예제입니다.
+
+## 아키텍처
+
+```mermaid
+flowchart LR
+    AccountA[Account] -->|TRANSFERRED_TO| AccountB[Account]
+    AccountB -->|TRANSFERRED_TO| AccountC[Account]
+    AccountC -->|TRANSFERRED_TO| AccountA
+    Service[FraudDetectionService] --> Ops[GraphOperations]
+    Service --> Analytics[Cycles / Components / PageRank]
+```
+
+## 주요 기능
+
+| 기능 | Graph API |
+|---|---|
+| 순환 이체 탐지 | `detectCycles(CycleOptions)` |
+| 의심 클러스터 탐지 | `connectedComponents(ComponentOptions)` |
+| 고위험 계좌 랭킹 | `pageRank(PageRankOptions)` |
+| 코루틴 지원 | `FraudDetectionSuspendService`와 `Flow` 결과 |
+
+## 사용 예
+
+```kotlin
+val service = FraudDetectionService(ops)
+service.initialize()
+
+val alice = service.addAccount("acct-alice", "Alice")
+val bob = service.addAccount("acct-bob", "Bob")
+val carol = service.addAccount("acct-carol", "Carol")
+
+service.recordTransfer(alice.id, bob.id, amount = 100)
+service.recordTransfer(bob.id, carol.id, amount = 75)
+service.recordTransfer(carol.id, alice.id, amount = 50)
+
+val cycles = service.detectCircularTransfers()
+val clusters = service.detectSuspiciousClusters(minSize = 3)
+val ranked = service.rankHighRiskAccounts(limit = 10)
+```
+
+## 테스트 실행
+
+```bash
+./gradlew :fraud-detection-examples:test
+./gradlew :fraud-detection-examples:test --tests "*TinkerGraph*"
+```
+
+TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apache AGE, FalkorDB 테스트는 Docker/Testcontainers가 필요합니다.
+
+## 의존성
+
+```kotlin
+implementation(project(":graph-core"))
+implementation(project(":graph-neo4j"))
+implementation(project(":graph-memgraph"))
+implementation(project(":graph-age"))
+implementation(project(":graph-falkordb"))
+implementation(project(":graph-tinkerpop"))
+```

--- a/examples/fraud-detection-examples/README.md
+++ b/examples/fraud-detection-examples/README.md
@@ -1,0 +1,64 @@
+# fraud-detection-examples
+
+> 🇰🇷 [한국어 문서](README.ko.md)
+
+Fraud detection example showing how to model account transfers as a graph and run backend-independent analytics with bluetape4k-graph.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    AccountA[Account] -->|TRANSFERRED_TO| AccountB[Account]
+    AccountB -->|TRANSFERRED_TO| AccountC[Account]
+    AccountC -->|TRANSFERRED_TO| AccountA
+    Service[FraudDetectionService] --> Ops[GraphOperations]
+    Service --> Analytics[Cycles / Components / PageRank]
+```
+
+## Core Features
+
+| Feature | Graph API |
+|---|---|
+| Circular transfer detection | `detectCycles(CycleOptions)` |
+| Suspicious cluster detection | `connectedComponents(ComponentOptions)` |
+| High-risk account ranking | `pageRank(PageRankOptions)` |
+| Coroutine support | `FraudDetectionSuspendService` with `Flow` results |
+
+## Usage
+
+```kotlin
+val service = FraudDetectionService(ops)
+service.initialize()
+
+val alice = service.addAccount("acct-alice", "Alice")
+val bob = service.addAccount("acct-bob", "Bob")
+val carol = service.addAccount("acct-carol", "Carol")
+
+service.recordTransfer(alice.id, bob.id, amount = 100)
+service.recordTransfer(bob.id, carol.id, amount = 75)
+service.recordTransfer(carol.id, alice.id, amount = 50)
+
+val cycles = service.detectCircularTransfers()
+val clusters = service.detectSuspiciousClusters(minSize = 3)
+val ranked = service.rankHighRiskAccounts(limit = 10)
+```
+
+## Running Tests
+
+```bash
+./gradlew :fraud-detection-examples:test
+./gradlew :fraud-detection-examples:test --tests "*TinkerGraph*"
+```
+
+TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests require Docker/Testcontainers.
+
+## Dependencies
+
+```kotlin
+implementation(project(":graph-core"))
+implementation(project(":graph-neo4j"))
+implementation(project(":graph-memgraph"))
+implementation(project(":graph-age"))
+implementation(project(":graph-falkordb"))
+implementation(project(":graph-tinkerpop"))
+```

--- a/examples/fraud-detection-examples/README.md
+++ b/examples/fraud-detection-examples/README.md
@@ -2,17 +2,93 @@
 
 > 🇰🇷 [한국어 문서](README.ko.md)
 
-Fraud detection example showing how to model account transfers as a graph and run backend-independent analytics with bluetape4k-graph.
+This example teaches how to model money transfers as a graph and run fraud-oriented analytics through the
+backend-independent bluetape4k-graph API.
+
+## What You Learn
+
+| Topic | Why it matters |
+|---|---|
+| Transfer graph modeling | Money movement is naturally a directed relationship between accounts. |
+| Cycle detection | Circular transfer chains can indicate layering or wash activity. |
+| Connected components | Dense account groups can reveal suspicious clusters. |
+| PageRank | Accounts receiving many important flows can be ranked for review. |
+| Backend portability | The same service runs on TinkerGraph, Neo4j, Memgraph, Apache AGE, and FalkorDB. |
+
+## Why Use a Graph Database?
+
+Fraud signals are often relationship signals, not single-row signals. A relational table can store transfers, but
+questions such as "which accounts form a loop?", "which accounts belong to the same suspicious cluster?", or "which
+receiver is central in this transfer network?" require repeated self-joins and custom traversal logic.
+
+A graph database makes these questions explicit:
+
+- accounts are vertices,
+- transfers are directed edges,
+- suspicious behavior is expressed as paths, cycles, components, and centrality.
+
+That keeps the domain language close to the query language and lets the same analytics contract run across multiple
+graph backends.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    AccountA[Account] -->|TRANSFERRED_TO| AccountB[Account]
-    AccountB -->|TRANSFERRED_TO| AccountC[Account]
-    AccountC -->|TRANSFERRED_TO| AccountA
-    Service[FraudDetectionService] --> Ops[GraphOperations]
-    Service --> Analytics[Cycles / Components / PageRank]
+    Test[Example test] --> Service[FraudDetectionService]
+    Service --> Ops[GraphOperations]
+    Ops --> Backend[(Graph backend)]
+    Backend --> Analytics[Cycles / Components / PageRank]
+    Analytics --> Findings[Review candidates]
+```
+
+## Domain UML
+
+```mermaid
+classDiagram
+    class Account {
+        +String accountId
+        +String ownerName
+        +String riskTier
+    }
+
+    class Transfer {
+        +Long amount
+        +String occurredAt
+    }
+
+    class FraudDetectionService {
+        +addAccount(accountId, ownerName, riskTier)
+        +recordTransfer(fromAccountId, toAccountId, amount)
+        +detectCircularTransfers(maxDepth, maxCycles)
+        +detectSuspiciousClusters(minSize)
+        +rankHighRiskAccounts(limit)
+    }
+
+    Account "1" --> "*" Transfer : outgoing
+    Transfer "*" --> "1" Account : incoming
+    FraudDetectionService ..> Account
+    FraudDetectionService ..> Transfer
+```
+
+## Analysis Flow
+
+```mermaid
+sequenceDiagram
+    participant Learner
+    participant Service as FraudDetectionService
+    participant Ops as GraphOperations
+    participant DB as Graph DB
+
+    Learner->>Service: addAccount(...)
+    Service->>Ops: createVertex("Account", ...)
+    Ops->>DB: persist account
+    Learner->>Service: recordTransfer(...)
+    Service->>Ops: createEdge(..., "TRANSFERRED_TO", ...)
+    Ops->>DB: persist transfer
+    Learner->>Service: detectCircularTransfers()
+    Service->>Ops: detectCycles(CycleOptions)
+    Ops->>DB: traverse transfer graph
+    DB-->>Learner: suspicious cycles
 ```
 
 ## Core Features
@@ -42,6 +118,17 @@ val cycles = service.detectCircularTransfers()
 val clusters = service.detectSuspiciousClusters(minSize = 3)
 val ranked = service.rankHighRiskAccounts(limit = 10)
 ```
+
+## How to Read the Tests
+
+Start with `AbstractFraudDetectionTest` and `AbstractFraudDetectionSuspendTest`. They contain the learning scenarios.
+Concrete backend classes only provide the backend-specific `GraphOperations` implementation.
+
+| Test class type | Purpose |
+|---|---|
+| Abstract tests | Explain the fraud detection behavior once. |
+| TinkerGraph tests | Fast in-memory smoke path. |
+| Neo4j/Memgraph/AGE/FalkorDB tests | Prove the same domain behavior works against real backends. |
 
 ## Running Tests
 

--- a/examples/fraud-detection-examples/build.gradle.kts
+++ b/examples/fraud-detection-examples/build.gradle.kts
@@ -1,0 +1,23 @@
+dependencies {
+    implementation(project(":graph-core"))
+    implementation(project(":graph-age"))
+    implementation(project(":graph-neo4j"))
+    implementation(project(":graph-memgraph"))
+    implementation(project(":graph-tinkerpop"))
+    implementation(project(":graph-falkordb"))
+
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.neo4j)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.neo4j.java.driver)       // bluetape4k-testcontainers는 compileOnly로 선언
+    testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
+    testImplementation(libs.hikaricp)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(project(":graph-falkordb"))
+    testImplementation(testFixtures(project(":graph-falkordb")))
+}

--- a/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/schema/FraudDetectionSchema.kt
+++ b/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/schema/FraudDetectionSchema.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.graph.examples.fraud.schema
+
+import io.bluetape4k.graph.schema.EdgeLabel
+import io.bluetape4k.graph.schema.VertexLabel
+
+/**
+ * Account vertices used by the fraud detection example.
+ *
+ * ```kotlin
+ * val account = ops.createVertex(AccountLabel.label, mapOf(AccountLabel.accountId.name to "acct-1"))
+ * ```
+ */
+object AccountLabel : VertexLabel("Account") {
+    val accountId = string("accountId")
+    val ownerName = string("ownerName")
+    val riskTier = string("riskTier")
+}
+
+/**
+ * Money transfer edges between accounts.
+ *
+ * ```kotlin
+ * ops.createEdge(source.id, target.id, TransferredToLabel.label, mapOf(TransferredToLabel.amount.name to 100))
+ * ```
+ */
+object TransferredToLabel : EdgeLabel("TRANSFERRED_TO", AccountLabel, AccountLabel) {
+    val amount = long("amount")
+    val occurredAt = string("occurredAt")
+}

--- a/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/service/FraudDetectionService.kt
+++ b/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/service/FraudDetectionService.kt
@@ -1,0 +1,126 @@
+package io.bluetape4k.graph.examples.fraud.service
+
+import io.bluetape4k.graph.examples.fraud.schema.AccountLabel
+import io.bluetape4k.graph.examples.fraud.schema.TransferredToLabel
+import io.bluetape4k.graph.model.ComponentOptions
+import io.bluetape4k.graph.model.CycleOptions
+import io.bluetape4k.graph.model.GraphComponent
+import io.bluetape4k.graph.model.GraphCycle
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.PageRankOptions
+import io.bluetape4k.graph.model.PageRankScore
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+
+/**
+ * Fraud detection graph service built on top of [GraphOperations].
+ *
+ * The service models accounts as vertices and money transfers as directed edges. It demonstrates cycle
+ * detection for circular transfers, connected components for suspicious clusters, and PageRank for accounts
+ * that receive central transfer flow.
+ *
+ * ```kotlin
+ * val service = FraudDetectionService(ops)
+ * service.initialize()
+ * val alice = service.addAccount("acct-alice", "Alice")
+ * val bob = service.addAccount("acct-bob", "Bob")
+ * service.recordTransfer(alice.id, bob.id, amount = 100)
+ * val cycles = service.detectCircularTransfers()
+ * ```
+ */
+class FraudDetectionService(
+    private val ops: GraphOperations,
+    private val graphName: String = "fraud_detection",
+) {
+    companion object : KLogging()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Fraud detection graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds an account vertex.
+     */
+    fun addAccount(
+        accountId: String,
+        ownerName: String,
+        riskTier: String = "standard",
+    ): GraphVertex {
+        accountId.requireNotBlank("accountId")
+        ownerName.requireNotBlank("ownerName")
+        return ops.createVertex(
+            AccountLabel.label,
+            mapOf(
+                AccountLabel.accountId.name to accountId,
+                AccountLabel.ownerName.name to ownerName,
+                AccountLabel.riskTier.name to riskTier,
+            )
+        )
+    }
+
+    /**
+     * Records a directed transfer between two accounts.
+     */
+    fun recordTransfer(
+        fromAccountId: GraphElementId,
+        toAccountId: GraphElementId,
+        amount: Long,
+        occurredAt: String = "",
+    ) {
+        require(amount > 0) { "amount must be > 0, was $amount" }
+        ops.createEdge(
+            fromAccountId,
+            toAccountId,
+            TransferredToLabel.label,
+            mapOf(TransferredToLabel.amount.name to amount, TransferredToLabel.occurredAt.name to occurredAt)
+        )
+    }
+
+    /**
+     * Detects circular transfer chains such as `A -> B -> C -> A`.
+     */
+    fun detectCircularTransfers(maxDepth: Int = 5, maxCycles: Int = 20): List<GraphCycle> =
+        ops.detectCycles(
+            CycleOptions(
+                vertexLabel = AccountLabel.label,
+                edgeLabel = TransferredToLabel.label,
+                maxDepth = maxDepth,
+                maxCycles = maxCycles,
+            )
+        )
+
+    /**
+     * Finds suspicious account clusters connected by transfer activity.
+     */
+    fun detectSuspiciousClusters(minSize: Int = 2): List<GraphComponent> =
+        ops.connectedComponents(
+            ComponentOptions(
+                vertexLabel = AccountLabel.label,
+                edgeLabel = TransferredToLabel.label,
+                minSize = minSize,
+            )
+        )
+
+    /**
+     * Ranks accounts by centrality in the transfer graph.
+     */
+    fun rankHighRiskAccounts(limit: Int = 10): List<PageRankScore> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+        return ops.pageRank(
+            PageRankOptions(
+                vertexLabel = AccountLabel.label,
+                edgeLabel = TransferredToLabel.label,
+                topK = limit,
+            )
+        )
+    }
+}

--- a/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/service/FraudDetectionSuspendService.kt
+++ b/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/service/FraudDetectionSuspendService.kt
@@ -1,0 +1,122 @@
+package io.bluetape4k.graph.examples.fraud.service
+
+import io.bluetape4k.graph.examples.fraud.schema.AccountLabel
+import io.bluetape4k.graph.examples.fraud.schema.TransferredToLabel
+import io.bluetape4k.graph.model.ComponentOptions
+import io.bluetape4k.graph.model.CycleOptions
+import io.bluetape4k.graph.model.GraphComponent
+import io.bluetape4k.graph.model.GraphCycle
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.PageRankOptions
+import io.bluetape4k.graph.model.PageRankScore
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Coroutine and Flow version of [FraudDetectionService].
+ *
+ * Read operations return [Flow] when the underlying graph API streams results.
+ *
+ * ```kotlin
+ * val service = FraudDetectionSuspendService(ops)
+ * service.initialize()
+ * val cycles = service.detectCircularTransfers().toList()
+ * ```
+ */
+class FraudDetectionSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "fraud_detection",
+) {
+    companion object : KLoggingChannel()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    suspend fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Fraud detection graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds an account vertex.
+     */
+    suspend fun addAccount(
+        accountId: String,
+        ownerName: String,
+        riskTier: String = "standard",
+    ): GraphVertex {
+        accountId.requireNotBlank("accountId")
+        ownerName.requireNotBlank("ownerName")
+        return ops.createVertex(
+            AccountLabel.label,
+            mapOf(
+                AccountLabel.accountId.name to accountId,
+                AccountLabel.ownerName.name to ownerName,
+                AccountLabel.riskTier.name to riskTier,
+            )
+        )
+    }
+
+    /**
+     * Records a directed transfer between two accounts.
+     */
+    suspend fun recordTransfer(
+        fromAccountId: GraphElementId,
+        toAccountId: GraphElementId,
+        amount: Long,
+        occurredAt: String = "",
+    ) {
+        require(amount > 0) { "amount must be > 0, was $amount" }
+        ops.createEdge(
+            fromAccountId,
+            toAccountId,
+            TransferredToLabel.label,
+            mapOf(TransferredToLabel.amount.name to amount, TransferredToLabel.occurredAt.name to occurredAt)
+        )
+    }
+
+    /**
+     * Detects circular transfer chains such as `A -> B -> C -> A`.
+     */
+    fun detectCircularTransfers(maxDepth: Int = 5, maxCycles: Int = 20): Flow<GraphCycle> =
+        ops.detectCycles(
+            CycleOptions(
+                vertexLabel = AccountLabel.label,
+                edgeLabel = TransferredToLabel.label,
+                maxDepth = maxDepth,
+                maxCycles = maxCycles,
+            )
+        )
+
+    /**
+     * Finds suspicious account clusters connected by transfer activity.
+     */
+    fun detectSuspiciousClusters(minSize: Int = 2): Flow<GraphComponent> =
+        ops.connectedComponents(
+            ComponentOptions(
+                vertexLabel = AccountLabel.label,
+                edgeLabel = TransferredToLabel.label,
+                minSize = minSize,
+            )
+        )
+
+    /**
+     * Ranks accounts by centrality in the transfer graph.
+     */
+    fun rankHighRiskAccounts(limit: Int = 10): Flow<PageRankScore> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+        return ops.pageRank(
+            PageRankOptions(
+                vertexLabel = AccountLabel.label,
+                edgeLabel = TransferredToLabel.label,
+                topK = limit,
+            )
+        )
+    }
+}

--- a/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/AbstractFraudDetectionSuspendTest.kt
+++ b/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/AbstractFraudDetectionSuspendTest.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.graph.examples.fraud
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.fraud.service.FraudDetectionSuspendService
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractFraudDetectionSuspendTest {
+
+    companion object : KLogging()
+
+    protected abstract val ops: GraphSuspendOperations
+    protected open val graphName: String = "fraud_detection_suspend_test"
+    protected val service: FraudDetectionSuspendService by lazy { FraudDetectionSuspendService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() = runTest {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+    }
+
+    @Test
+    fun `creates accounts and transfer edges`() = runTest {
+        val alice = service.addAccount("acct-alice", "Alice", "standard")
+        val bob = service.addAccount("acct-bob", "Bob", "watch")
+
+        service.recordTransfer(alice.id, bob.id, amount = 100)
+
+        val scores = service.rankHighRiskAccounts(limit = 10).toList()
+        scores.shouldNotBeEmpty()
+        scores.map { it.vertex.properties["accountId"] } shouldContain "acct-bob"
+    }
+
+    @Test
+    fun `detects circular transfers`() = runTest {
+        val a = service.addAccount("acct-a", "A")
+        val b = service.addAccount("acct-b", "B")
+        val c = service.addAccount("acct-c", "C")
+
+        service.recordTransfer(a.id, b.id, amount = 100)
+        service.recordTransfer(b.id, c.id, amount = 75)
+        service.recordTransfer(c.id, a.id, amount = 50)
+
+        val cycles = service.detectCircularTransfers(maxDepth = 5).toList()
+        cycles.shouldNotBeEmpty()
+        cycles.first().path.vertices.first().id shouldBeEqualTo cycles.first().path.vertices.last().id
+    }
+
+    @Test
+    fun `detects suspicious transfer clusters`() = runTest {
+        val a = service.addAccount("acct-a", "A")
+        val b = service.addAccount("acct-b", "B")
+        val c = service.addAccount("acct-c", "C")
+
+        service.recordTransfer(a.id, b.id, amount = 100)
+        service.recordTransfer(b.id, c.id, amount = 100)
+
+        val clusters = service.detectSuspiciousClusters(minSize = 3).toList()
+        clusters.shouldNotBeEmpty()
+        clusters.any { component ->
+            component.size >= 3 && component.vertices.map { it.properties["accountId"] }.containsAll(listOf("acct-a", "acct-b", "acct-c"))
+        }.shouldBeTrue()
+    }
+
+    @Test
+    fun `ranks high risk receiver inside top results`() = runTest {
+        val sink = service.addAccount("acct-sink", "Sink")
+        repeat(4) { index ->
+            val source = service.addAccount("acct-source-$index", "Source $index")
+            service.recordTransfer(source.id, sink.id, amount = 100L + index)
+        }
+
+        val accountIds = service.rankHighRiskAccounts(limit = 10).toList().map { it.vertex.properties["accountId"] }
+        accountIds.size shouldBeGreaterOrEqualTo 1
+        accountIds shouldContain "acct-sink"
+    }
+}

--- a/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/AbstractFraudDetectionTest.kt
+++ b/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/AbstractFraudDetectionTest.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.graph.examples.fraud
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.fraud.service.FraudDetectionService
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractFraudDetectionTest {
+
+    companion object : KLogging()
+
+    protected abstract val ops: GraphOperations
+    protected open val graphName: String = "fraud_detection_test"
+    protected val service: FraudDetectionService by lazy { FraudDetectionService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+    }
+
+    @Test
+    fun `creates accounts and transfer edges`() {
+        val alice = service.addAccount("acct-alice", "Alice", "standard")
+        val bob = service.addAccount("acct-bob", "Bob", "watch")
+
+        service.recordTransfer(alice.id, bob.id, amount = 100)
+
+        val scores = service.rankHighRiskAccounts(limit = 10)
+        scores.shouldNotBeEmpty()
+        scores.map { it.vertex.properties["accountId"] } shouldContain "acct-bob"
+    }
+
+    @Test
+    fun `detects circular transfers`() {
+        val a = service.addAccount("acct-a", "A")
+        val b = service.addAccount("acct-b", "B")
+        val c = service.addAccount("acct-c", "C")
+
+        service.recordTransfer(a.id, b.id, amount = 100)
+        service.recordTransfer(b.id, c.id, amount = 75)
+        service.recordTransfer(c.id, a.id, amount = 50)
+
+        val cycles = service.detectCircularTransfers(maxDepth = 5)
+        cycles.shouldNotBeEmpty()
+        cycles.first().path.vertices.first().id shouldBeEqualTo cycles.first().path.vertices.last().id
+    }
+
+    @Test
+    fun `detects suspicious transfer clusters`() {
+        val a = service.addAccount("acct-a", "A")
+        val b = service.addAccount("acct-b", "B")
+        val c = service.addAccount("acct-c", "C")
+
+        service.recordTransfer(a.id, b.id, amount = 100)
+        service.recordTransfer(b.id, c.id, amount = 100)
+
+        val clusters = service.detectSuspiciousClusters(minSize = 3)
+        clusters.shouldNotBeEmpty()
+        clusters.any { component ->
+            component.size >= 3 && component.vertices.map { it.properties["accountId"] }.containsAll(listOf("acct-a", "acct-b", "acct-c"))
+        }.shouldBeTrue()
+    }
+
+    @Test
+    fun `ranks high risk receiver inside top results`() {
+        val sink = service.addAccount("acct-sink", "Sink")
+        repeat(4) { index ->
+            val source = service.addAccount("acct-source-$index", "Source $index")
+            service.recordTransfer(source.id, sink.id, amount = 100L + index)
+        }
+
+        val accountIds = service.rankHighRiskAccounts(limit = 10).map { it.vertex.properties["accountId"] }
+        accountIds.size shouldBeGreaterOrEqualTo 1
+        accountIds shouldContain "acct-sink"
+    }
+}

--- a/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionBackendTests.kt
+++ b/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionBackendTests.kt
@@ -1,0 +1,180 @@
+package io.bluetape4k.graph.examples.fraud
+
+import com.falkordb.FalkorDB
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.graph.age.AgeGraphOperations
+import io.bluetape4k.graph.age.AgeGraphSuspendOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
+import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+import java.util.UUID
+
+class TinkerGraphFraudDetectionTest : AbstractFraudDetectionTest() {
+    override val ops = TinkerGraphOperations()
+    override val graphName = "default"
+}
+
+class TinkerGraphFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
+    override val ops = TinkerGraphSuspendOperations()
+    override val graphName = "default"
+}
+
+class Neo4jFraudDetectionTest : AbstractFraudDetectionTest() {
+    private val driver: Driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    override val ops = Neo4jGraphOperations(driver)
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+}
+
+class Neo4jFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
+    private val driver: Driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    override val ops = Neo4jGraphSuspendOperations(driver)
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+}
+
+class MemgraphFraudDetectionTest : AbstractFraudDetectionTest() {
+    private lateinit var driver: Driver
+    override lateinit var ops: MemgraphGraphOperations
+
+    @BeforeAll
+    fun startServer() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        driver.close()
+    }
+}
+
+class MemgraphFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
+    private lateinit var driver: Driver
+    override lateinit var ops: MemgraphGraphSuspendOperations
+
+    @BeforeAll
+    fun startServer() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        driver.close()
+    }
+}
+
+class AgeFraudDetectionTest : AbstractFraudDetectionTest() {
+    override val graphName = "fraud_detection_test"
+    private lateinit var dataSource: HikariDataSource
+    override lateinit var ops: AgeGraphOperations
+
+    @BeforeAll
+    fun startServer() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        Database.connect(dataSource)
+        ops = AgeGraphOperations(graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        dataSource.close()
+    }
+}
+
+class AgeFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
+    override val graphName = "fraud_detection_suspend_test"
+    private lateinit var dataSource: HikariDataSource
+    override lateinit var ops: AgeGraphSuspendOperations
+
+    @BeforeAll
+    fun startServer() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        Database.connect(dataSource)
+        ops = AgeGraphSuspendOperations(graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        dataSource.close()
+    }
+}
+
+class FalkorDBFraudDetectionTest : AbstractFraudDetectionTest() {
+    private lateinit var driver: com.falkordb.Driver
+    override lateinit var ops: FalkorDBGraphOperations
+    override val graphName: String = "fraud_${UUID.randomUUID().toString().replace("-", "").take(8)}"
+
+    @BeforeAll
+    fun startServer() {
+        driver = FalkorDB.driver(FalkorDBServer.Launcher.falkordb.host, FalkorDBServer.Launcher.falkordb.port)
+        ops = FalkorDBGraphOperations(driver, graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        runCatching { ops.dropGraph(graphName) }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
+        driver.close()
+    }
+}
+
+class FalkorDBFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
+    private lateinit var driver: com.falkordb.Driver
+    override lateinit var ops: FalkorDBGraphSuspendOperations
+    override val graphName: String = "fraud_${UUID.randomUUID().toString().replace("-", "").take(8)}"
+
+    @BeforeAll
+    fun startServer() {
+        driver = FalkorDB.driver(FalkorDBServer.Launcher.falkordb.host, FalkorDBServer.Launcher.falkordb.port)
+        ops = FalkorDBGraphSuspendOperations(driver, graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        runCatching { runBlocking { ops.dropGraph(graphName) } }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
+        driver.close()
+    }
+}

--- a/examples/fraud-detection-examples/src/test/resources/junit-platform.properties
+++ b/examples/fraud-detection-examples/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/fraud-detection-examples/src/test/resources/logback-test.xml
+++ b/examples/fraud-detection-examples/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- @formatter:off -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5p) %magenta(${PID:- }) --- [%25.25t] %cyan(%-40.40logger{39}) : %m%n"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.graph" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/examples/knowledge-graph-examples/README.ko.md
+++ b/examples/knowledge-graph-examples/README.ko.md
@@ -1,0 +1,61 @@
+# knowledge-graph-examples
+
+> 🇺🇸 [English](README.md)
+
+문서 mention, 엔티티 관계, 개념 분류, 제한된 관계 경로 추론을 보여주는 지식 그래프 예제입니다.
+
+## 아키텍처
+
+```mermaid
+flowchart LR
+    Document[Document] -->|MENTIONS| EntityA[Entity]
+    EntityA -->|RELATED_TO| EntityB[Entity]
+    EntityB -->|IS_A| Concept[Concept]
+    Service[KnowledgeGraphService] --> Ops[GraphOperations]
+```
+
+## 주요 기능
+
+| 기능 | Graph API |
+|---|---|
+| mention 조회 | `MENTIONS` 간선의 `neighbors` 탐색 |
+| 관련 엔티티 탐색 | `RELATED_TO` 간선의 `neighbors` 탐색 |
+| 관계 경로 추론 | service-side `maxPaths`가 적용된 `allPaths(PathOptions)` |
+| 코루틴 지원 | `KnowledgeGraphSuspendService`와 `Flow` 결과 |
+
+## 사용 예
+
+```kotlin
+val service = KnowledgeGraphService(ops)
+service.initialize()
+
+val doc = service.addDocument("doc-1", "Graph API Guide", "docs")
+val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+val coroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+
+service.mention(doc.id, kotlin.id, confidence = 95)
+service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
+
+val mentioned = service.findMentionedEntities(doc.id)
+val paths = service.inferRelationshipPaths(kotlin.id, coroutines.id)
+```
+
+## 테스트 실행
+
+```bash
+./gradlew :knowledge-graph-examples:test
+./gradlew :knowledge-graph-examples:test --tests "*TinkerGraph*"
+```
+
+TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apache AGE, FalkorDB 테스트는 Docker/Testcontainers가 필요합니다.
+
+## 의존성
+
+```kotlin
+implementation(project(":graph-core"))
+implementation(project(":graph-neo4j"))
+implementation(project(":graph-memgraph"))
+implementation(project(":graph-age"))
+implementation(project(":graph-falkordb"))
+implementation(project(":graph-tinkerpop"))
+```

--- a/examples/knowledge-graph-examples/README.ko.md
+++ b/examples/knowledge-graph-examples/README.ko.md
@@ -2,16 +2,104 @@
 
 > 🇺🇸 [English](README.md)
 
-문서 mention, 엔티티 관계, 개념 분류, 제한된 관계 경로 추론을 보여주는 지식 그래프 예제입니다.
+문서, 엔티티, 개념을 지식 그래프로 모델링하고 엔티티 사이의 제한된 관계 경로를 추론하는 방법을 배우는 예제입니다.
+
+## 무엇을 배우나?
+
+| 주제 | 의미 |
+|---|---|
+| 지식 그래프 모델링 | 문서, 엔티티, 개념을 연결된 사실로 표현합니다. |
+| mention 조회 | 문서가 언급하는 엔티티를 `MENTIONS` edge로 찾습니다. |
+| 관련 엔티티 탐색 | 도메인 관계를 중첩 레코드가 아니라 path로 표현합니다. |
+| 개념 분류 | `IS_A` 링크로 구체 엔티티를 정규화된 개념에 연결합니다. |
+| 제한된 경로 추론 | `allPaths`로 안전한 깊이와 결과 수 안에서 관계 설명을 얻습니다. |
+
+## 왜 Graph DB가 좋은가?
+
+지식 그래프의 가치는 사실 사이의 연결에 있습니다. 문서 저장소는 문서 본문을 저장할 수 있고, 관계형 DB는 엔티티 테이블을
+저장할 수 있습니다. 하지만 "Kotlin이 어떤 중간 개념을 통해 Spring과 연결되는가?"는 자연스럽게 path 질문입니다.
+
+Graph DB를 사용하면 다음을 직접 표현할 수 있습니다.
+
+- 문서, 엔티티, 개념은 vertex,
+- mention, 분류, 관계는 typed edge,
+- 발견 과정은 traversal과 path inference,
+- 같은 모델을 검색 보강, 설명, 추천에 재사용할 수 있습니다.
+
+이 예제는 작은 그래프를 사용해 관계 경로가 왜 생기는지 학습자가 직접 확인할 수 있게 구성되어 있습니다.
 
 ## 아키텍처
 
 ```mermaid
 flowchart LR
-    Document[Document] -->|MENTIONS| EntityA[Entity]
-    EntityA -->|RELATED_TO| EntityB[Entity]
-    EntityB -->|IS_A| Concept[Concept]
-    Service[KnowledgeGraphService] --> Ops[GraphOperations]
+    Test[Example test] --> Service[KnowledgeGraphService]
+    Service --> Ops[GraphOperations]
+    Ops --> Backend[(Graph backend)]
+    Backend --> Lookup[Mention lookup]
+    Backend --> Paths[Relationship paths]
+    Lookup --> Insights[Knowledge insights]
+    Paths --> Insights
+```
+
+## 도메인 UML
+
+```mermaid
+classDiagram
+    class Document {
+        +String documentId
+        +String title
+        +String source
+    }
+
+    class Entity {
+        +String entityId
+        +String name
+        +String entityType
+    }
+
+    class Concept {
+        +String conceptId
+        +String name
+        +String domain
+    }
+
+    class KnowledgeGraphService {
+        +addDocument(documentId, title, source)
+        +addEntity(entityId, name, entityType)
+        +addConcept(conceptId, name, domain)
+        +mention(documentId, entityId, confidence)
+        +relateEntities(fromEntityId, toEntityId, relationType)
+        +classify(entityId, conceptId)
+        +findMentionedEntities(documentId)
+        +findRelatedEntities(entityId, depth)
+        +inferRelationshipPaths(fromEntityId, toEntityId, maxDepth, maxPaths)
+    }
+
+    Document "*" --> "*" Entity : MENTIONS
+    Entity "*" --> "*" Entity : RELATED_TO
+    Entity "*" --> "*" Concept : IS_A
+    KnowledgeGraphService ..> Document
+    KnowledgeGraphService ..> Entity
+    KnowledgeGraphService ..> Concept
+```
+
+## 경로 추론 흐름
+
+```mermaid
+sequenceDiagram
+    participant Learner
+    participant Service as KnowledgeGraphService
+    participant Ops as GraphOperations
+    participant DB as Graph DB
+
+    Learner->>Service: mention(document, entity)
+    Service->>Ops: createEdge(document, entity, "MENTIONS")
+    Learner->>Service: relateEntities(kotlin, coroutines)
+    Service->>Ops: createEdge(kotlin, coroutines, "RELATED_TO")
+    Learner->>Service: inferRelationshipPaths(kotlin, spring)
+    Service->>Ops: allPaths(PathOptions(edgeLabel = "RELATED_TO"))
+    Ops->>DB: bounded path traversal
+    DB-->>Learner: explainable relationship paths
 ```
 
 ## 주요 기능
@@ -39,6 +127,17 @@ service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
 val mentioned = service.findMentionedEntities(doc.id)
 val paths = service.inferRelationshipPaths(kotlin.id, coroutines.id)
 ```
+
+## 테스트 읽는 법
+
+Abstract test는 작은 지식 그래프를 만들고, mention 조회, 관련 엔티티 탐색, 개념 분류, 제한된 관계 경로 추론을 한 흐름으로
+보여줍니다.
+
+| 테스트 종류 | 목적 |
+|---|---|
+| Abstract tests | 지식 그래프 동작을 한 번만 설명합니다. |
+| TinkerGraph tests | 빠른 메모리 기반 smoke test입니다. |
+| Neo4j/Memgraph/AGE/FalkorDB tests | 실제 backend에서도 같은 path/lookup 동작이 유지되는지 검증합니다. |
 
 ## 테스트 실행
 

--- a/examples/knowledge-graph-examples/README.md
+++ b/examples/knowledge-graph-examples/README.md
@@ -2,16 +2,106 @@
 
 > 🇰🇷 [한국어 문서](README.ko.md)
 
-Knowledge graph example showing document mentions, entity relationships, concept classification, and bounded relationship path inference.
+This example teaches how to model documents, entities, and concepts as a knowledge graph and infer bounded relationship
+paths between entities.
+
+## What You Learn
+
+| Topic | Why it matters |
+|---|---|
+| Knowledge graph modeling | Documents, entities, and concepts become connected facts. |
+| Mention lookup | A document can reveal the entities it discusses through `MENTIONS` edges. |
+| Related entity traversal | Domain relationships are represented as paths, not nested records. |
+| Concept classification | `IS_A` links connect concrete entities to normalized concepts. |
+| Bounded path inference | `allPaths` explains how two entities are connected within a safe depth and result limit. |
+
+## Why Use a Graph Database?
+
+Knowledge graphs are useful when the value is in the connection between facts. A document store can keep document text,
+and a relational database can store entity tables, but "how is Kotlin connected to Spring through intermediate concepts?"
+is naturally a path question.
+
+With a graph database:
+
+- documents, entities, and concepts are first-class vertices,
+- mentions, classifications, and relationships are typed edges,
+- discovery is expressed through traversal and path inference,
+- the same model supports search enrichment, explanation, and recommendation.
+
+This example focuses on small, explainable graphs so learners can see why the path exists.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    Document[Document] -->|MENTIONS| EntityA[Entity]
-    EntityA -->|RELATED_TO| EntityB[Entity]
-    EntityB -->|IS_A| Concept[Concept]
-    Service[KnowledgeGraphService] --> Ops[GraphOperations]
+    Test[Example test] --> Service[KnowledgeGraphService]
+    Service --> Ops[GraphOperations]
+    Ops --> Backend[(Graph backend)]
+    Backend --> Lookup[Mention lookup]
+    Backend --> Paths[Relationship paths]
+    Lookup --> Insights[Knowledge insights]
+    Paths --> Insights
+```
+
+## Domain UML
+
+```mermaid
+classDiagram
+    class Document {
+        +String documentId
+        +String title
+        +String source
+    }
+
+    class Entity {
+        +String entityId
+        +String name
+        +String entityType
+    }
+
+    class Concept {
+        +String conceptId
+        +String name
+        +String domain
+    }
+
+    class KnowledgeGraphService {
+        +addDocument(documentId, title, source)
+        +addEntity(entityId, name, entityType)
+        +addConcept(conceptId, name, domain)
+        +mention(documentId, entityId, confidence)
+        +relateEntities(fromEntityId, toEntityId, relationType)
+        +classify(entityId, conceptId)
+        +findMentionedEntities(documentId)
+        +findRelatedEntities(entityId, depth)
+        +inferRelationshipPaths(fromEntityId, toEntityId, maxDepth, maxPaths)
+    }
+
+    Document "*" --> "*" Entity : MENTIONS
+    Entity "*" --> "*" Entity : RELATED_TO
+    Entity "*" --> "*" Concept : IS_A
+    KnowledgeGraphService ..> Document
+    KnowledgeGraphService ..> Entity
+    KnowledgeGraphService ..> Concept
+```
+
+## Path Inference Flow
+
+```mermaid
+sequenceDiagram
+    participant Learner
+    participant Service as KnowledgeGraphService
+    participant Ops as GraphOperations
+    participant DB as Graph DB
+
+    Learner->>Service: mention(document, entity)
+    Service->>Ops: createEdge(document, entity, "MENTIONS")
+    Learner->>Service: relateEntities(kotlin, coroutines)
+    Service->>Ops: createEdge(kotlin, coroutines, "RELATED_TO")
+    Learner->>Service: inferRelationshipPaths(kotlin, spring)
+    Service->>Ops: allPaths(PathOptions(edgeLabel = "RELATED_TO"))
+    Ops->>DB: bounded path traversal
+    DB-->>Learner: explainable relationship paths
 ```
 
 ## Core Features
@@ -39,6 +129,17 @@ service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
 val mentioned = service.findMentionedEntities(doc.id)
 val paths = service.inferRelationshipPaths(kotlin.id, coroutines.id)
 ```
+
+## How to Read the Tests
+
+The abstract tests show the complete story: load a small knowledge graph, query mentioned entities, traverse related
+entities, classify an entity under a concept, and infer relationship paths with a fixed bound.
+
+| Test class type | Purpose |
+|---|---|
+| Abstract tests | Explain knowledge graph behavior once. |
+| TinkerGraph tests | Fast in-memory smoke path. |
+| Neo4j/Memgraph/AGE/FalkorDB tests | Prove the same path and lookup behavior on real backends. |
 
 ## Running Tests
 

--- a/examples/knowledge-graph-examples/README.md
+++ b/examples/knowledge-graph-examples/README.md
@@ -1,0 +1,61 @@
+# knowledge-graph-examples
+
+> 🇰🇷 [한국어 문서](README.ko.md)
+
+Knowledge graph example showing document mentions, entity relationships, concept classification, and bounded relationship path inference.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Document[Document] -->|MENTIONS| EntityA[Entity]
+    EntityA -->|RELATED_TO| EntityB[Entity]
+    EntityB -->|IS_A| Concept[Concept]
+    Service[KnowledgeGraphService] --> Ops[GraphOperations]
+```
+
+## Core Features
+
+| Feature | Graph API |
+|---|---|
+| Mention lookup | `neighbors` over `MENTIONS` |
+| Related entity traversal | `neighbors` over `RELATED_TO` |
+| Relationship path inference | `allPaths(PathOptions)` with service-side `maxPaths` |
+| Coroutine support | `KnowledgeGraphSuspendService` with `Flow` results |
+
+## Usage
+
+```kotlin
+val service = KnowledgeGraphService(ops)
+service.initialize()
+
+val doc = service.addDocument("doc-1", "Graph API Guide", "docs")
+val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+val coroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+
+service.mention(doc.id, kotlin.id, confidence = 95)
+service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
+
+val mentioned = service.findMentionedEntities(doc.id)
+val paths = service.inferRelationshipPaths(kotlin.id, coroutines.id)
+```
+
+## Running Tests
+
+```bash
+./gradlew :knowledge-graph-examples:test
+./gradlew :knowledge-graph-examples:test --tests "*TinkerGraph*"
+```
+
+TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests require Docker/Testcontainers.
+
+## Dependencies
+
+```kotlin
+implementation(project(":graph-core"))
+implementation(project(":graph-neo4j"))
+implementation(project(":graph-memgraph"))
+implementation(project(":graph-age"))
+implementation(project(":graph-falkordb"))
+implementation(project(":graph-tinkerpop"))
+```

--- a/examples/knowledge-graph-examples/build.gradle.kts
+++ b/examples/knowledge-graph-examples/build.gradle.kts
@@ -1,0 +1,23 @@
+dependencies {
+    implementation(project(":graph-core"))
+    implementation(project(":graph-age"))
+    implementation(project(":graph-neo4j"))
+    implementation(project(":graph-memgraph"))
+    implementation(project(":graph-tinkerpop"))
+    implementation(project(":graph-falkordb"))
+
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.neo4j)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.neo4j.java.driver)       // bluetape4k-testcontainers는 compileOnly로 선언
+    testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
+    testImplementation(libs.hikaricp)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(project(":graph-falkordb"))
+    testImplementation(testFixtures(project(":graph-falkordb")))
+}

--- a/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/schema/KnowledgeGraphSchema.kt
+++ b/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/schema/KnowledgeGraphSchema.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.graph.examples.knowledge.schema
+
+import io.bluetape4k.graph.schema.EdgeLabel
+import io.bluetape4k.graph.schema.VertexLabel
+
+/**
+ * Entity vertices such as people, organizations, places, or products.
+ */
+object EntityLabel : VertexLabel("Entity") {
+    val entityId = string("entityId")
+    val name = string("name")
+    val entityType = string("entityType")
+}
+
+/**
+ * Concept vertices used to normalize domain vocabulary.
+ */
+object ConceptLabel : VertexLabel("Concept") {
+    val conceptId = string("conceptId")
+    val name = string("name")
+    val domain = string("domain")
+}
+
+/**
+ * Document vertices that mention entities.
+ */
+object DocumentLabel : VertexLabel("Document") {
+    val documentId = string("documentId")
+    val title = string("title")
+    val source = string("source")
+}
+
+/**
+ * Document-to-entity mention edges.
+ */
+object MentionsLabel : EdgeLabel("MENTIONS", DocumentLabel, EntityLabel) {
+    val confidence = integer("confidence")
+}
+
+/**
+ * Entity-to-entity related edges.
+ */
+object RelatedToLabel : EdgeLabel("RELATED_TO", EntityLabel, EntityLabel) {
+    val relationType = string("relationType")
+}
+
+/**
+ * Entity-to-concept classification edges.
+ */
+object IsALabel : EdgeLabel("IS_A", EntityLabel, ConceptLabel)

--- a/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/service/KnowledgeGraphService.kt
+++ b/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/service/KnowledgeGraphService.kt
@@ -1,0 +1,143 @@
+package io.bluetape4k.graph.examples.knowledge.service
+
+import io.bluetape4k.graph.examples.knowledge.schema.ConceptLabel
+import io.bluetape4k.graph.examples.knowledge.schema.DocumentLabel
+import io.bluetape4k.graph.examples.knowledge.schema.EntityLabel
+import io.bluetape4k.graph.examples.knowledge.schema.IsALabel
+import io.bluetape4k.graph.examples.knowledge.schema.MentionsLabel
+import io.bluetape4k.graph.examples.knowledge.schema.RelatedToLabel
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+
+/**
+ * Knowledge graph service built on top of [GraphOperations].
+ *
+ * The service models entities, concepts, and documents, then demonstrates entity lookup through document mentions,
+ * related-entity traversal, and bounded relationship path inference.
+ *
+ * ```kotlin
+ * val service = KnowledgeGraphService(ops)
+ * service.initialize()
+ * val paper = service.addDocument("doc-1", "Graph APIs")
+ * val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+ * service.mention(paper.id, kotlin.id, confidence = 95)
+ * ```
+ */
+class KnowledgeGraphService(
+    private val ops: GraphOperations,
+    private val graphName: String = "knowledge_graph",
+) {
+    companion object : KLogging()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Knowledge graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds an entity vertex.
+     */
+    fun addEntity(entityId: String, name: String, entityType: String): GraphVertex {
+        entityId.requireNotBlank("entityId")
+        name.requireNotBlank("name")
+        entityType.requireNotBlank("entityType")
+        return ops.createVertex(
+            EntityLabel.label,
+            mapOf(EntityLabel.entityId.name to entityId, EntityLabel.name.name to name, EntityLabel.entityType.name to entityType)
+        )
+    }
+
+    /**
+     * Adds a concept vertex.
+     */
+    fun addConcept(conceptId: String, name: String, domain: String = ""): GraphVertex {
+        conceptId.requireNotBlank("conceptId")
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            ConceptLabel.label,
+            mapOf(ConceptLabel.conceptId.name to conceptId, ConceptLabel.name.name to name, ConceptLabel.domain.name to domain)
+        )
+    }
+
+    /**
+     * Adds a document vertex.
+     */
+    fun addDocument(documentId: String, title: String, source: String = ""): GraphVertex {
+        documentId.requireNotBlank("documentId")
+        title.requireNotBlank("title")
+        return ops.createVertex(
+            DocumentLabel.label,
+            mapOf(DocumentLabel.documentId.name to documentId, DocumentLabel.title.name to title, DocumentLabel.source.name to source)
+        )
+    }
+
+    /**
+     * Connects a document to an entity that it mentions.
+     */
+    fun mention(documentId: GraphElementId, entityId: GraphElementId, confidence: Int = 100) {
+        require(confidence in 0..100) { "confidence must be in 0..100, was $confidence" }
+        ops.createEdge(documentId, entityId, MentionsLabel.label, mapOf(MentionsLabel.confidence.name to confidence))
+    }
+
+    /**
+     * Connects two entities with a typed relationship.
+     */
+    fun relateEntities(fromEntityId: GraphElementId, toEntityId: GraphElementId, relationType: String = "related") {
+        relationType.requireNotBlank("relationType")
+        ops.createEdge(
+            fromEntityId,
+            toEntityId,
+            RelatedToLabel.label,
+            mapOf(RelatedToLabel.relationType.name to relationType)
+        )
+    }
+
+    /**
+     * Classifies an entity under a concept.
+     */
+    fun classify(entityId: GraphElementId, conceptId: GraphElementId) {
+        ops.createEdge(entityId, conceptId, IsALabel.label, emptyMap())
+    }
+
+    /**
+     * Finds entities mentioned by a document.
+     */
+    fun findMentionedEntities(documentId: GraphElementId): List<GraphVertex> =
+        ops.neighbors(documentId, NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1))
+
+    /**
+     * Finds entities related to the source entity.
+     */
+    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): List<GraphVertex> =
+        ops.neighbors(entityId, NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth))
+
+    /**
+     * Finds relationship paths between two entities and applies a service-side result bound.
+     */
+    fun inferRelationshipPaths(
+        fromEntityId: GraphElementId,
+        toEntityId: GraphElementId,
+        maxDepth: Int = 3,
+        maxPaths: Int = 10,
+    ): List<GraphPath> {
+        require(maxPaths > 0) { "maxPaths must be > 0, was $maxPaths" }
+        return ops.allPaths(
+            fromEntityId,
+            toEntityId,
+            PathOptions(edgeLabel = RelatedToLabel.label, maxDepth = maxDepth)
+        ).take(maxPaths)
+    }
+}

--- a/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/service/KnowledgeGraphSuspendService.kt
+++ b/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/service/KnowledgeGraphSuspendService.kt
@@ -1,0 +1,134 @@
+package io.bluetape4k.graph.examples.knowledge.service
+
+import io.bluetape4k.graph.examples.knowledge.schema.ConceptLabel
+import io.bluetape4k.graph.examples.knowledge.schema.DocumentLabel
+import io.bluetape4k.graph.examples.knowledge.schema.EntityLabel
+import io.bluetape4k.graph.examples.knowledge.schema.IsALabel
+import io.bluetape4k.graph.examples.knowledge.schema.MentionsLabel
+import io.bluetape4k.graph.examples.knowledge.schema.RelatedToLabel
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphPath
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PathOptions
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.take
+
+/**
+ * Coroutine and Flow version of [KnowledgeGraphService].
+ */
+class KnowledgeGraphSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "knowledge_graph",
+) {
+    companion object : KLoggingChannel()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    suspend fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Knowledge graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds an entity vertex.
+     */
+    suspend fun addEntity(entityId: String, name: String, entityType: String): GraphVertex {
+        entityId.requireNotBlank("entityId")
+        name.requireNotBlank("name")
+        entityType.requireNotBlank("entityType")
+        return ops.createVertex(
+            EntityLabel.label,
+            mapOf(EntityLabel.entityId.name to entityId, EntityLabel.name.name to name, EntityLabel.entityType.name to entityType)
+        )
+    }
+
+    /**
+     * Adds a concept vertex.
+     */
+    suspend fun addConcept(conceptId: String, name: String, domain: String = ""): GraphVertex {
+        conceptId.requireNotBlank("conceptId")
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            ConceptLabel.label,
+            mapOf(ConceptLabel.conceptId.name to conceptId, ConceptLabel.name.name to name, ConceptLabel.domain.name to domain)
+        )
+    }
+
+    /**
+     * Adds a document vertex.
+     */
+    suspend fun addDocument(documentId: String, title: String, source: String = ""): GraphVertex {
+        documentId.requireNotBlank("documentId")
+        title.requireNotBlank("title")
+        return ops.createVertex(
+            DocumentLabel.label,
+            mapOf(DocumentLabel.documentId.name to documentId, DocumentLabel.title.name to title, DocumentLabel.source.name to source)
+        )
+    }
+
+    /**
+     * Connects a document to an entity that it mentions.
+     */
+    suspend fun mention(documentId: GraphElementId, entityId: GraphElementId, confidence: Int = 100) {
+        require(confidence in 0..100) { "confidence must be in 0..100, was $confidence" }
+        ops.createEdge(documentId, entityId, MentionsLabel.label, mapOf(MentionsLabel.confidence.name to confidence))
+    }
+
+    /**
+     * Connects two entities with a typed relationship.
+     */
+    suspend fun relateEntities(fromEntityId: GraphElementId, toEntityId: GraphElementId, relationType: String = "related") {
+        relationType.requireNotBlank("relationType")
+        ops.createEdge(
+            fromEntityId,
+            toEntityId,
+            RelatedToLabel.label,
+            mapOf(RelatedToLabel.relationType.name to relationType)
+        )
+    }
+
+    /**
+     * Classifies an entity under a concept.
+     */
+    suspend fun classify(entityId: GraphElementId, conceptId: GraphElementId) {
+        ops.createEdge(entityId, conceptId, IsALabel.label, emptyMap())
+    }
+
+    /**
+     * Finds entities mentioned by a document.
+     */
+    fun findMentionedEntities(documentId: GraphElementId): Flow<GraphVertex> =
+        ops.neighbors(documentId, NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1))
+
+    /**
+     * Finds entities related to the source entity.
+     */
+    fun findRelatedEntities(entityId: GraphElementId, depth: Int = 1): Flow<GraphVertex> =
+        ops.neighbors(entityId, NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth))
+
+    /**
+     * Finds relationship paths between two entities and applies a service-side result bound.
+     */
+    fun inferRelationshipPaths(
+        fromEntityId: GraphElementId,
+        toEntityId: GraphElementId,
+        maxDepth: Int = 3,
+        maxPaths: Int = 10,
+    ): Flow<GraphPath> {
+        require(maxPaths > 0) { "maxPaths must be > 0, was $maxPaths" }
+        return ops.allPaths(
+            fromEntityId,
+            toEntityId,
+            PathOptions(edgeLabel = RelatedToLabel.label, maxDepth = maxDepth)
+        ).take(maxPaths)
+    }
+}

--- a/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/AbstractKnowledgeGraphSuspendTest.kt
+++ b/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/AbstractKnowledgeGraphSuspendTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.graph.examples.knowledge
+
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.knowledge.service.KnowledgeGraphSuspendService
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractKnowledgeGraphSuspendTest {
+
+    companion object : KLogging()
+
+    protected abstract val ops: GraphSuspendOperations
+    protected open val graphName: String = "knowledge_graph_suspend_test"
+    protected val service: KnowledgeGraphSuspendService by lazy { KnowledgeGraphSuspendService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() = runTest {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+    }
+
+    @Test
+    fun `finds entities mentioned by a document`() = runTest {
+        val document = service.addDocument("doc-1", "Graph API Guide", "docs")
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val neo4j = service.addEntity("entity-neo4j", "Neo4j", "Database")
+
+        service.mention(document.id, kotlin.id, confidence = 95)
+        service.mention(document.id, neo4j.id, confidence = 90)
+
+        val entityIds = service.findMentionedEntities(document.id).toList().map { it.properties["entityId"] }
+        entityIds shouldContain "entity-kotlin"
+        entityIds shouldContain "entity-neo4j"
+    }
+
+    @Test
+    fun `finds related entities`() = runTest {
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val coroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+
+        service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
+
+        val related = service.findRelatedEntities(kotlin.id).toList()
+        related.shouldNotBeEmpty()
+        related.map { it.properties["entityId"] } shouldContain "entity-coroutines"
+    }
+
+    @Test
+    fun `infers bounded relationship paths`() = runTest {
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val coroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+        val spring = service.addEntity("entity-spring", "Spring", "Framework")
+
+        service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
+        service.relateEntities(coroutines.id, spring.id, relationType = "integrates-with")
+
+        val paths = service.inferRelationshipPaths(kotlin.id, spring.id, maxDepth = 3, maxPaths = 2).toList()
+        paths.shouldNotBeEmpty()
+        paths.size shouldBeGreaterOrEqualTo 1
+        paths.first().vertices.map { it.properties["entityId"] } shouldContain "entity-kotlin"
+        paths.first().vertices.map { it.properties["entityId"] } shouldContain "entity-spring"
+    }
+
+    @Test
+    fun `classifies entities under concepts`() = runTest {
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val language = service.addConcept("concept-language", "Programming Language", "software")
+
+        service.classify(kotlin.id, language.id)
+
+        val concepts = ops.neighbors(
+            kotlin.id,
+            NeighborOptions(edgeLabel = "IS_A", direction = Direction.OUTGOING, maxDepth = 1)
+        ).toList()
+        concepts.shouldNotBeEmpty()
+        concepts.map { it.properties["conceptId"] } shouldContain "concept-language"
+    }
+}

--- a/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/AbstractKnowledgeGraphTest.kt
+++ b/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/AbstractKnowledgeGraphTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.graph.examples.knowledge
+
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.knowledge.service.KnowledgeGraphService
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractKnowledgeGraphTest {
+
+    companion object : KLogging()
+
+    protected abstract val ops: GraphOperations
+    protected open val graphName: String = "knowledge_graph_test"
+    protected val service: KnowledgeGraphService by lazy { KnowledgeGraphService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+    }
+
+    @Test
+    fun `finds entities mentioned by a document`() {
+        val document = service.addDocument("doc-1", "Graph API Guide", "docs")
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val neo4j = service.addEntity("entity-neo4j", "Neo4j", "Database")
+
+        service.mention(document.id, kotlin.id, confidence = 95)
+        service.mention(document.id, neo4j.id, confidence = 90)
+
+        val entityIds = service.findMentionedEntities(document.id).map { it.properties["entityId"] }
+        entityIds shouldContain "entity-kotlin"
+        entityIds shouldContain "entity-neo4j"
+    }
+
+    @Test
+    fun `finds related entities`() {
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val coroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+
+        service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
+
+        val related = service.findRelatedEntities(kotlin.id)
+        related.shouldNotBeEmpty()
+        related.map { it.properties["entityId"] } shouldContain "entity-coroutines"
+    }
+
+    @Test
+    fun `infers bounded relationship paths`() {
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val coroutines = service.addEntity("entity-coroutines", "Coroutines", "Library")
+        val spring = service.addEntity("entity-spring", "Spring", "Framework")
+
+        service.relateEntities(kotlin.id, coroutines.id, relationType = "has-feature")
+        service.relateEntities(coroutines.id, spring.id, relationType = "integrates-with")
+
+        val paths = service.inferRelationshipPaths(kotlin.id, spring.id, maxDepth = 3, maxPaths = 2)
+        paths.shouldNotBeEmpty()
+        paths.size shouldBeGreaterOrEqualTo 1
+        paths.first().vertices.map { it.properties["entityId"] } shouldContain "entity-kotlin"
+        paths.first().vertices.map { it.properties["entityId"] } shouldContain "entity-spring"
+    }
+
+    @Test
+    fun `classifies entities under concepts`() {
+        val kotlin = service.addEntity("entity-kotlin", "Kotlin", "Language")
+        val language = service.addConcept("concept-language", "Programming Language", "software")
+
+        service.classify(kotlin.id, language.id)
+
+        val concepts = ops.neighbors(
+            kotlin.id,
+            io.bluetape4k.graph.model.NeighborOptions(
+                edgeLabel = "IS_A",
+                direction = io.bluetape4k.graph.model.Direction.OUTGOING,
+                maxDepth = 1,
+            )
+        )
+        concepts.shouldNotBeEmpty()
+        concepts.map { it.properties["conceptId"] } shouldContain "concept-language"
+    }
+}

--- a/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphBackendTests.kt
+++ b/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphBackendTests.kt
@@ -1,0 +1,180 @@
+package io.bluetape4k.graph.examples.knowledge
+
+import com.falkordb.FalkorDB
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.graph.age.AgeGraphOperations
+import io.bluetape4k.graph.age.AgeGraphSuspendOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
+import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+import java.util.UUID
+
+class TinkerGraphKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    override val ops = TinkerGraphOperations()
+    override val graphName = "default"
+}
+
+class TinkerGraphKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    override val ops = TinkerGraphSuspendOperations()
+    override val graphName = "default"
+}
+
+class Neo4jKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    private val driver: Driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    override val ops = Neo4jGraphOperations(driver)
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+}
+
+class Neo4jKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    private val driver: Driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    override val ops = Neo4jGraphSuspendOperations(driver)
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+}
+
+class MemgraphKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    private lateinit var driver: Driver
+    override lateinit var ops: MemgraphGraphOperations
+
+    @BeforeAll
+    fun startServer() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        driver.close()
+    }
+}
+
+class MemgraphKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    private lateinit var driver: Driver
+    override lateinit var ops: MemgraphGraphSuspendOperations
+
+    @BeforeAll
+    fun startServer() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        driver.close()
+    }
+}
+
+class AgeKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    override val graphName = "knowledge_graph_test"
+    private lateinit var dataSource: HikariDataSource
+    override lateinit var ops: AgeGraphOperations
+
+    @BeforeAll
+    fun startServer() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        Database.connect(dataSource)
+        ops = AgeGraphOperations(graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        dataSource.close()
+    }
+}
+
+class AgeKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    override val graphName = "knowledge_graph_suspend_test"
+    private lateinit var dataSource: HikariDataSource
+    override lateinit var ops: AgeGraphSuspendOperations
+
+    @BeforeAll
+    fun startServer() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        Database.connect(dataSource)
+        ops = AgeGraphSuspendOperations(graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        dataSource.close()
+    }
+}
+
+class FalkorDBKnowledgeGraphTest : AbstractKnowledgeGraphTest() {
+    private lateinit var driver: com.falkordb.Driver
+    override lateinit var ops: FalkorDBGraphOperations
+    override val graphName: String = "knowledge_${UUID.randomUUID().toString().replace("-", "").take(8)}"
+
+    @BeforeAll
+    fun startServer() {
+        driver = FalkorDB.driver(FalkorDBServer.Launcher.falkordb.host, FalkorDBServer.Launcher.falkordb.port)
+        ops = FalkorDBGraphOperations(driver, graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        runCatching { ops.dropGraph(graphName) }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
+        driver.close()
+    }
+}
+
+class FalkorDBKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
+    private lateinit var driver: com.falkordb.Driver
+    override lateinit var ops: FalkorDBGraphSuspendOperations
+    override val graphName: String = "knowledge_${UUID.randomUUID().toString().replace("-", "").take(8)}"
+
+    @BeforeAll
+    fun startServer() {
+        driver = FalkorDB.driver(FalkorDBServer.Launcher.falkordb.host, FalkorDBServer.Launcher.falkordb.port)
+        ops = FalkorDBGraphSuspendOperations(driver, graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        runCatching { runBlocking { ops.dropGraph(graphName) } }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
+        driver.close()
+    }
+}

--- a/examples/knowledge-graph-examples/src/test/resources/junit-platform.properties
+++ b/examples/knowledge-graph-examples/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/knowledge-graph-examples/src/test/resources/logback-test.xml
+++ b/examples/knowledge-graph-examples/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- @formatter:off -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5p) %magenta(${PID:- }) --- [%25.25t] %cyan(%-40.40logger{39}) : %m%n"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.graph" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/examples/recommendation-examples/README.ko.md
+++ b/examples/recommendation-examples/README.ko.md
@@ -1,0 +1,65 @@
+# recommendation-examples
+
+> 🇺🇸 [English](README.md)
+
+상품 추천과 소셜 팔로우 추천을 그래프 탐색 및 PageRank로 구현하는 예제입니다.
+
+## 아키텍처
+
+```mermaid
+flowchart LR
+    UserA[User] -->|PURCHASED| ProductA[Product]
+    UserB[User] -->|PURCHASED| ProductA
+    UserB -->|PURCHASED| ProductB[Product]
+    UserA -->|FOLLOWS| UserB
+    UserB -->|FOLLOWS| UserC[User]
+    Service[RecommendationService] --> Ops[GraphOperations]
+```
+
+## 주요 기능
+
+| 기능 | Graph API |
+|---|---|
+| 상품 추천 | `PURCHASED` 간선의 paired `neighbors` 탐색 |
+| 팔로우 추천 | `FOLLOWS` 간선의 2-hop `neighbors` 탐색 |
+| 인기 상품 랭킹 | `pageRank(PageRankOptions)` |
+| 코루틴 지원 | `RecommendationSuspendService`와 `Flow` 결과 |
+
+## 사용 예
+
+```kotlin
+val service = RecommendationService(ops)
+service.initialize()
+
+val alice = service.addUser("u-alice", "Alice")
+val bob = service.addUser("u-bob", "Bob")
+val camera = service.addProduct("p-camera", "Camera")
+val tripod = service.addProduct("p-tripod", "Tripod")
+
+service.recordPurchase(alice.id, camera.id)
+service.recordPurchase(bob.id, camera.id)
+service.recordPurchase(bob.id, tripod.id)
+
+val products = service.recommendProducts(alice.id)
+val popular = service.rankPopularProducts(limit = 10)
+```
+
+## 테스트 실행
+
+```bash
+./gradlew :recommendation-examples:test
+./gradlew :recommendation-examples:test --tests "*TinkerGraph*"
+```
+
+TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apache AGE, FalkorDB 테스트는 Docker/Testcontainers가 필요합니다.
+
+## 의존성
+
+```kotlin
+implementation(project(":graph-core"))
+implementation(project(":graph-neo4j"))
+implementation(project(":graph-memgraph"))
+implementation(project(":graph-age"))
+implementation(project(":graph-falkordb"))
+implementation(project(":graph-tinkerpop"))
+```

--- a/examples/recommendation-examples/README.ko.md
+++ b/examples/recommendation-examples/README.ko.md
@@ -2,18 +2,102 @@
 
 > 🇺🇸 [English](README.md)
 
-상품 추천과 소셜 팔로우 추천을 그래프 탐색 및 PageRank로 구현하는 예제입니다.
+상품 추천과 소셜 팔로우 추천을 그래프 탐색 및 PageRank로 구현하는 방법을 배우는 예제입니다.
+
+## 무엇을 배우나?
+
+| 주제 | 의미 |
+|---|---|
+| 구매 그래프 모델링 | 구매는 사용자에서 상품으로 향하는 관계입니다. |
+| traversal 기반 협업 필터링 | 같은 상품을 구매한 사용자를 통해 유사 사용자를 찾을 수 있습니다. |
+| 팔로우 추천 | 2-hop 소셜 경로는 새 팔로우 후보를 제안하는 데 유용합니다. |
+| 인기 상품 랭킹 | PageRank로 구매 그래프 안에서 중요한 상품을 찾습니다. |
+| 백엔드 이식성 | 같은 추천 서비스가 지원되는 모든 Graph DB backend에서 동작합니다. |
+
+## 왜 Graph DB가 좋은가?
+
+추천은 관계 문제입니다. 중요한 질문은 "Alice가 무엇을 샀는가?"에서 끝나지 않습니다. "Alice와 같은 상품을 산 사람은
+누구이고, 그 사람은 또 무엇을 샀는가?", "Alice가 팔로우하는 사람이 팔로우하는 사람은 누구인가?"처럼 multi-hop
+traversal이 필요합니다.
+
+Graph DB를 사용하면 다음처럼 표현할 수 있습니다.
+
+- 사용자와 상품은 vertex,
+- 구매와 팔로우는 edge,
+- 추천 후보는 짧은 path와 제외 규칙,
+- 상품 랭킹은 graph algorithm입니다.
+
+그래서 실제 추천 시스템의 핵심 아이디어를 작은 코드로 학습할 수 있습니다.
 
 ## 아키텍처
 
 ```mermaid
 flowchart LR
-    UserA[User] -->|PURCHASED| ProductA[Product]
-    UserB[User] -->|PURCHASED| ProductA
-    UserB -->|PURCHASED| ProductB[Product]
-    UserA -->|FOLLOWS| UserB
-    UserB -->|FOLLOWS| UserC[User]
-    Service[RecommendationService] --> Ops[GraphOperations]
+    Test[Example test] --> Service[RecommendationService]
+    Service --> Ops[GraphOperations]
+    Ops --> Backend[(Graph backend)]
+    Backend --> Traversal[Product / follow traversal]
+    Backend --> Ranking[PageRank]
+    Traversal --> Results[Recommendations]
+    Ranking --> Results
+```
+
+## 도메인 UML
+
+```mermaid
+classDiagram
+    class User {
+        +String userId
+        +String displayName
+        +String segment
+    }
+
+    class Product {
+        +String productId
+        +String name
+        +String category
+    }
+
+    class Purchase {
+        +Int quantity
+        +String purchasedAt
+    }
+
+    class RecommendationService {
+        +addUser(userId, displayName, segment)
+        +addProduct(productId, name, category)
+        +recordPurchase(userId, productId, quantity)
+        +follow(followerId, targetId)
+        +recommendProducts(userId, limit)
+        +recommendFollows(userId, limit)
+        +rankPopularProducts(limit)
+    }
+
+    User "1" --> "*" Purchase : makes
+    Purchase "*" --> "1" Product : targets
+    User "*" --> "*" User : FOLLOWS
+    RecommendationService ..> User
+    RecommendationService ..> Product
+```
+
+## 추천 흐름
+
+```mermaid
+sequenceDiagram
+    participant Learner
+    participant Service as RecommendationService
+    participant Ops as GraphOperations
+    participant DB as Graph DB
+
+    Learner->>Service: recordPurchase(alice, camera)
+    Service->>Ops: createEdge(alice, camera, "PURCHASED")
+    Ops->>DB: persist purchase
+    Learner->>Service: recommendProducts(alice)
+    Service->>Ops: neighbors(alice, PURCHASED OUTGOING)
+    Service->>Ops: neighbors(camera, PURCHASED INCOMING)
+    Service->>Ops: neighbors(similarUser, PURCHASED OUTGOING)
+    Ops->>DB: traverse purchase graph
+    DB-->>Learner: candidate products excluding Alice's existing products
 ```
 
 ## 주요 기능
@@ -43,6 +127,17 @@ service.recordPurchase(bob.id, tripod.id)
 val products = service.recommendProducts(alice.id)
 val popular = service.rankPopularProducts(limit = 10)
 ```
+
+## 테스트 읽는 법
+
+Abstract test가 튜토리얼입니다. 작은 그래프를 만들고 추천을 실행한 뒤, backend별 점수나 정렬에 의존하지 않고 안정적인
+후보 포함 여부를 검증합니다.
+
+| 테스트 종류 | 목적 |
+|---|---|
+| Abstract tests | 상품 추천, 팔로우 추천, 랭킹 동작을 한 번만 설명합니다. |
+| TinkerGraph tests | 빠른 메모리 기반 smoke test입니다. |
+| Neo4j/Memgraph/AGE/FalkorDB tests | backend 독립 추천 동작을 검증합니다. |
 
 ## 테스트 실행
 

--- a/examples/recommendation-examples/README.md
+++ b/examples/recommendation-examples/README.md
@@ -2,18 +2,102 @@
 
 > 🇰🇷 [한국어 문서](README.ko.md)
 
-Recommendation example showing product and social recommendations with graph traversal and PageRank.
+This example teaches how to build product and social recommendations with graph traversal and PageRank.
+
+## What You Learn
+
+| Topic | Why it matters |
+|---|---|
+| Purchase graph modeling | A purchase is a relationship from a user to a product. |
+| Collaborative filtering by traversal | Similar users can be found through shared purchased products. |
+| Follow recommendations | Two-hop social paths suggest people a user may want to follow. |
+| Product popularity ranking | PageRank ranks products by their position in the purchase graph. |
+| Backend portability | The same recommendation service runs across all supported graph backends. |
+
+## Why Use a Graph Database?
+
+Recommendations are relationship problems. The interesting question is not only "what did Alice buy?", but "who bought
+the same thing as Alice, and what else did they buy?" or "who is followed by people Alice already follows?" These are
+multi-hop traversals.
+
+With a graph database:
+
+- users and products are vertices,
+- purchases and follows are edges,
+- recommendations are short paths with clear exclusion rules,
+- graph algorithms can rank candidate products without rewriting the domain model.
+
+This makes the example close to real recommendation systems while keeping the implementation small enough to study.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    UserA[User] -->|PURCHASED| ProductA[Product]
-    UserB[User] -->|PURCHASED| ProductA
-    UserB -->|PURCHASED| ProductB[Product]
-    UserA -->|FOLLOWS| UserB
-    UserB -->|FOLLOWS| UserC[User]
-    Service[RecommendationService] --> Ops[GraphOperations]
+    Test[Example test] --> Service[RecommendationService]
+    Service --> Ops[GraphOperations]
+    Ops --> Backend[(Graph backend)]
+    Backend --> Traversal[Product / follow traversal]
+    Backend --> Ranking[PageRank]
+    Traversal --> Results[Recommendations]
+    Ranking --> Results
+```
+
+## Domain UML
+
+```mermaid
+classDiagram
+    class User {
+        +String userId
+        +String displayName
+        +String segment
+    }
+
+    class Product {
+        +String productId
+        +String name
+        +String category
+    }
+
+    class Purchase {
+        +Int quantity
+        +String purchasedAt
+    }
+
+    class RecommendationService {
+        +addUser(userId, displayName, segment)
+        +addProduct(productId, name, category)
+        +recordPurchase(userId, productId, quantity)
+        +follow(followerId, targetId)
+        +recommendProducts(userId, limit)
+        +recommendFollows(userId, limit)
+        +rankPopularProducts(limit)
+    }
+
+    User "1" --> "*" Purchase : makes
+    Purchase "*" --> "1" Product : targets
+    User "*" --> "*" User : FOLLOWS
+    RecommendationService ..> User
+    RecommendationService ..> Product
+```
+
+## Recommendation Flow
+
+```mermaid
+sequenceDiagram
+    participant Learner
+    participant Service as RecommendationService
+    participant Ops as GraphOperations
+    participant DB as Graph DB
+
+    Learner->>Service: recordPurchase(alice, camera)
+    Service->>Ops: createEdge(alice, camera, "PURCHASED")
+    Ops->>DB: persist purchase
+    Learner->>Service: recommendProducts(alice)
+    Service->>Ops: neighbors(alice, PURCHASED OUTGOING)
+    Service->>Ops: neighbors(camera, PURCHASED INCOMING)
+    Service->>Ops: neighbors(similarUser, PURCHASED OUTGOING)
+    Ops->>DB: traverse purchase graph
+    DB-->>Learner: candidate products excluding Alice's existing products
 ```
 
 ## Core Features
@@ -43,6 +127,17 @@ service.recordPurchase(bob.id, tripod.id)
 val products = service.recommendProducts(alice.id)
 val popular = service.rankPopularProducts(limit = 10)
 ```
+
+## How to Read the Tests
+
+The abstract tests are the tutorial. They build a tiny graph, run a recommendation, and assert stable membership rather
+than exact score values or backend-specific ordering.
+
+| Test class type | Purpose |
+|---|---|
+| Abstract tests | Explain product, follow, and ranking behavior once. |
+| TinkerGraph tests | Fast in-memory smoke path. |
+| Neo4j/Memgraph/AGE/FalkorDB tests | Prove backend-independent recommendation behavior. |
 
 ## Running Tests
 

--- a/examples/recommendation-examples/README.md
+++ b/examples/recommendation-examples/README.md
@@ -1,0 +1,65 @@
+# recommendation-examples
+
+> 🇰🇷 [한국어 문서](README.ko.md)
+
+Recommendation example showing product and social recommendations with graph traversal and PageRank.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    UserA[User] -->|PURCHASED| ProductA[Product]
+    UserB[User] -->|PURCHASED| ProductA
+    UserB -->|PURCHASED| ProductB[Product]
+    UserA -->|FOLLOWS| UserB
+    UserB -->|FOLLOWS| UserC[User]
+    Service[RecommendationService] --> Ops[GraphOperations]
+```
+
+## Core Features
+
+| Feature | Graph API |
+|---|---|
+| Product recommendations | paired `neighbors` traversal over `PURCHASED` |
+| Follow recommendations | two-hop `neighbors` traversal over `FOLLOWS` |
+| Popular product ranking | `pageRank(PageRankOptions)` |
+| Coroutine support | `RecommendationSuspendService` with `Flow` results |
+
+## Usage
+
+```kotlin
+val service = RecommendationService(ops)
+service.initialize()
+
+val alice = service.addUser("u-alice", "Alice")
+val bob = service.addUser("u-bob", "Bob")
+val camera = service.addProduct("p-camera", "Camera")
+val tripod = service.addProduct("p-tripod", "Tripod")
+
+service.recordPurchase(alice.id, camera.id)
+service.recordPurchase(bob.id, camera.id)
+service.recordPurchase(bob.id, tripod.id)
+
+val products = service.recommendProducts(alice.id)
+val popular = service.rankPopularProducts(limit = 10)
+```
+
+## Running Tests
+
+```bash
+./gradlew :recommendation-examples:test
+./gradlew :recommendation-examples:test --tests "*TinkerGraph*"
+```
+
+TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests require Docker/Testcontainers.
+
+## Dependencies
+
+```kotlin
+implementation(project(":graph-core"))
+implementation(project(":graph-neo4j"))
+implementation(project(":graph-memgraph"))
+implementation(project(":graph-age"))
+implementation(project(":graph-falkordb"))
+implementation(project(":graph-tinkerpop"))
+```

--- a/examples/recommendation-examples/build.gradle.kts
+++ b/examples/recommendation-examples/build.gradle.kts
@@ -1,0 +1,23 @@
+dependencies {
+    implementation(project(":graph-core"))
+    implementation(project(":graph-age"))
+    implementation(project(":graph-neo4j"))
+    implementation(project(":graph-memgraph"))
+    implementation(project(":graph-tinkerpop"))
+    implementation(project(":graph-falkordb"))
+
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.neo4j)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.neo4j.java.driver)       // bluetape4k-testcontainers는 compileOnly로 선언
+    testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
+    testImplementation(libs.hikaricp)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(project(":graph-falkordb"))
+    testImplementation(testFixtures(project(":graph-falkordb")))
+}

--- a/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/schema/RecommendationSchema.kt
+++ b/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/schema/RecommendationSchema.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.graph.examples.recommendation.schema
+
+import io.bluetape4k.graph.schema.EdgeLabel
+import io.bluetape4k.graph.schema.VertexLabel
+
+/**
+ * User vertices in the recommendation example.
+ */
+object UserLabel : VertexLabel("User") {
+    val userId = string("userId")
+    val displayName = string("displayName")
+    val segment = string("segment")
+}
+
+/**
+ * Product vertices in the recommendation example.
+ */
+object ProductLabel : VertexLabel("Product") {
+    val productId = string("productId")
+    val name = string("name")
+    val category = string("category")
+}
+
+/**
+ * Purchase edges from users to products.
+ */
+object PurchasedLabel : EdgeLabel("PURCHASED", UserLabel, ProductLabel) {
+    val quantity = integer("quantity")
+    val purchasedAt = string("purchasedAt")
+}
+
+/**
+ * Social follow edges between users.
+ */
+object FollowsLabel : EdgeLabel("FOLLOWS", UserLabel, UserLabel)

--- a/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/service/RecommendationService.kt
+++ b/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/service/RecommendationService.kt
@@ -1,0 +1,157 @@
+package io.bluetape4k.graph.examples.recommendation.service
+
+import io.bluetape4k.graph.examples.recommendation.schema.FollowsLabel
+import io.bluetape4k.graph.examples.recommendation.schema.ProductLabel
+import io.bluetape4k.graph.examples.recommendation.schema.PurchasedLabel
+import io.bluetape4k.graph.examples.recommendation.schema.UserLabel
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PageRankOptions
+import io.bluetape4k.graph.model.PageRankScore
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+
+/**
+ * Recommendation graph service built on top of [GraphOperations].
+ *
+ * The service demonstrates product recommendations through purchase co-occurrence, follow recommendations through
+ * two-hop social traversal, and product popularity ranking through PageRank.
+ *
+ * ```kotlin
+ * val service = RecommendationService(ops)
+ * service.initialize()
+ * val alice = service.addUser("u-alice", "Alice")
+ * val camera = service.addProduct("p-camera", "Camera")
+ * service.recordPurchase(alice.id, camera.id)
+ * ```
+ */
+class RecommendationService(
+    private val ops: GraphOperations,
+    private val graphName: String = "recommendation",
+) {
+    companion object : KLogging()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Recommendation graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds a user vertex.
+     */
+    fun addUser(userId: String, displayName: String, segment: String = ""): GraphVertex {
+        userId.requireNotBlank("userId")
+        displayName.requireNotBlank("displayName")
+        return ops.createVertex(
+            UserLabel.label,
+            mapOf(UserLabel.userId.name to userId, UserLabel.displayName.name to displayName, UserLabel.segment.name to segment)
+        )
+    }
+
+    /**
+     * Adds a product vertex.
+     */
+    fun addProduct(productId: String, name: String, category: String = ""): GraphVertex {
+        productId.requireNotBlank("productId")
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            ProductLabel.label,
+            mapOf(ProductLabel.productId.name to productId, ProductLabel.name.name to name, ProductLabel.category.name to category)
+        )
+    }
+
+    /**
+     * Records a purchase edge from a user to a product.
+     */
+    fun recordPurchase(userId: GraphElementId, productId: GraphElementId, quantity: Int = 1, purchasedAt: String = "") {
+        require(quantity > 0) { "quantity must be > 0, was $quantity" }
+        ops.createEdge(
+            userId,
+            productId,
+            PurchasedLabel.label,
+            mapOf(PurchasedLabel.quantity.name to quantity, PurchasedLabel.purchasedAt.name to purchasedAt)
+        )
+    }
+
+    /**
+     * Creates a directed follow edge between users.
+     */
+    fun follow(followerId: GraphElementId, targetId: GraphElementId) {
+        ops.createEdge(followerId, targetId, FollowsLabel.label, emptyMap())
+    }
+
+    /**
+     * Recommends products bought by users who purchased the same products as the source user.
+     */
+    fun recommendProducts(userId: GraphElementId, limit: Int = 10): List<GraphVertex> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+
+        val ownedProducts = ops.neighbors(
+            userId,
+            NeighborOptions(edgeLabel = PurchasedLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+        )
+        val ownedProductIds = ownedProducts.mapTo(mutableSetOf()) { it.id }
+
+        return ownedProducts
+            .flatMap { product ->
+                ops.neighbors(
+                    product.id,
+                    NeighborOptions(edgeLabel = PurchasedLabel.label, direction = Direction.INCOMING, maxDepth = 1)
+                )
+            }
+            .filterNot { it.id == userId }
+            .distinctBy { it.id }
+            .flatMap { similarUser ->
+                ops.neighbors(
+                    similarUser.id,
+                    NeighborOptions(edgeLabel = PurchasedLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+                )
+            }
+            .filterNot { it.id in ownedProductIds }
+            .distinctBy { it.id }
+            .take(limit)
+    }
+
+    /**
+     * Recommends follow targets from second-hop follow relationships.
+     */
+    fun recommendFollows(userId: GraphElementId, limit: Int = 10): List<GraphVertex> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+
+        val directFollows = ops.neighbors(
+            userId,
+            NeighborOptions(edgeLabel = FollowsLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+        )
+        val excludedIds = directFollows.mapTo(mutableSetOf(userId)) { it.id }
+
+        return directFollows
+            .flatMap { direct ->
+                ops.neighbors(
+                    direct.id,
+                    NeighborOptions(edgeLabel = FollowsLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+                )
+            }
+            .filterNot { it.id in excludedIds }
+            .distinctBy { it.id }
+            .take(limit)
+    }
+
+    /**
+     * Ranks products by purchase graph PageRank.
+     */
+    fun rankPopularProducts(limit: Int = 10): List<PageRankScore> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+        return ops.pageRank(
+            PageRankOptions(vertexLabel = ProductLabel.label, edgeLabel = PurchasedLabel.label, topK = limit)
+        )
+    }
+}

--- a/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/service/RecommendationSuspendService.kt
+++ b/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/service/RecommendationSuspendService.kt
@@ -1,0 +1,151 @@
+package io.bluetape4k.graph.examples.recommendation.service
+
+import io.bluetape4k.graph.examples.recommendation.schema.FollowsLabel
+import io.bluetape4k.graph.examples.recommendation.schema.ProductLabel
+import io.bluetape4k.graph.examples.recommendation.schema.PurchasedLabel
+import io.bluetape4k.graph.examples.recommendation.schema.UserLabel
+import io.bluetape4k.graph.model.Direction
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PageRankOptions
+import io.bluetape4k.graph.model.PageRankScore
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+
+/**
+ * Coroutine and Flow version of [RecommendationService].
+ */
+class RecommendationSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "recommendation",
+) {
+    companion object : KLoggingChannel()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    suspend fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Recommendation graph '$graphName' created" }
+        }
+    }
+
+    /**
+     * Adds a user vertex.
+     */
+    suspend fun addUser(userId: String, displayName: String, segment: String = ""): GraphVertex {
+        userId.requireNotBlank("userId")
+        displayName.requireNotBlank("displayName")
+        return ops.createVertex(
+            UserLabel.label,
+            mapOf(UserLabel.userId.name to userId, UserLabel.displayName.name to displayName, UserLabel.segment.name to segment)
+        )
+    }
+
+    /**
+     * Adds a product vertex.
+     */
+    suspend fun addProduct(productId: String, name: String, category: String = ""): GraphVertex {
+        productId.requireNotBlank("productId")
+        name.requireNotBlank("name")
+        return ops.createVertex(
+            ProductLabel.label,
+            mapOf(ProductLabel.productId.name to productId, ProductLabel.name.name to name, ProductLabel.category.name to category)
+        )
+    }
+
+    /**
+     * Records a purchase edge from a user to a product.
+     */
+    suspend fun recordPurchase(userId: GraphElementId, productId: GraphElementId, quantity: Int = 1, purchasedAt: String = "") {
+        require(quantity > 0) { "quantity must be > 0, was $quantity" }
+        ops.createEdge(
+            userId,
+            productId,
+            PurchasedLabel.label,
+            mapOf(PurchasedLabel.quantity.name to quantity, PurchasedLabel.purchasedAt.name to purchasedAt)
+        )
+    }
+
+    /**
+     * Creates a directed follow edge between users.
+     */
+    suspend fun follow(followerId: GraphElementId, targetId: GraphElementId) {
+        ops.createEdge(followerId, targetId, FollowsLabel.label, emptyMap())
+    }
+
+    /**
+     * Recommends products bought by users who purchased the same products as the source user.
+     */
+    suspend fun recommendProducts(userId: GraphElementId, limit: Int = 10): Flow<GraphVertex> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+
+        val ownedProducts = ops.neighbors(
+            userId,
+            NeighborOptions(edgeLabel = PurchasedLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+        ).toList()
+        val ownedProductIds = ownedProducts.mapTo(mutableSetOf()) { it.id }
+
+        return ownedProducts
+            .flatMap { product ->
+                ops.neighbors(
+                    product.id,
+                    NeighborOptions(edgeLabel = PurchasedLabel.label, direction = Direction.INCOMING, maxDepth = 1)
+                ).toList()
+            }
+            .filterNot { it.id == userId }
+            .distinctBy { it.id }
+            .flatMap { similarUser ->
+                ops.neighbors(
+                    similarUser.id,
+                    NeighborOptions(edgeLabel = PurchasedLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+                ).toList()
+            }
+            .filterNot { it.id in ownedProductIds }
+            .distinctBy { it.id }
+            .take(limit)
+            .asFlow()
+    }
+
+    /**
+     * Recommends follow targets from second-hop follow relationships.
+     */
+    suspend fun recommendFollows(userId: GraphElementId, limit: Int = 10): Flow<GraphVertex> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+
+        val directFollows = ops.neighbors(
+            userId,
+            NeighborOptions(edgeLabel = FollowsLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+        ).toList()
+        val excludedIds = directFollows.mapTo(mutableSetOf(userId)) { it.id }
+
+        return directFollows
+            .flatMap { direct ->
+                ops.neighbors(
+                    direct.id,
+                    NeighborOptions(edgeLabel = FollowsLabel.label, direction = Direction.OUTGOING, maxDepth = 1)
+                ).toList()
+            }
+            .filterNot { it.id in excludedIds }
+            .distinctBy { it.id }
+            .take(limit)
+            .asFlow()
+    }
+
+    /**
+     * Ranks products by purchase graph PageRank.
+     */
+    fun rankPopularProducts(limit: Int = 10): Flow<PageRankScore> {
+        require(limit > 0) { "limit must be > 0, was $limit" }
+        return ops.pageRank(
+            PageRankOptions(vertexLabel = ProductLabel.label, edgeLabel = PurchasedLabel.label, topK = limit)
+        )
+    }
+}

--- a/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/AbstractRecommendationSuspendTest.kt
+++ b/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/AbstractRecommendationSuspendTest.kt
@@ -1,0 +1,76 @@
+package io.bluetape4k.graph.examples.recommendation
+
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.recommendation.service.RecommendationSuspendService
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractRecommendationSuspendTest {
+
+    companion object : KLogging()
+
+    protected abstract val ops: GraphSuspendOperations
+    protected open val graphName: String = "recommendation_suspend_test"
+    protected val service: RecommendationSuspendService by lazy { RecommendationSuspendService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() = runTest {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+    }
+
+    @Test
+    fun `recommends products from similar buyers`() = runTest {
+        val alice = service.addUser("u-alice", "Alice")
+        val bob = service.addUser("u-bob", "Bob")
+        val camera = service.addProduct("p-camera", "Camera", "electronics")
+        val tripod = service.addProduct("p-tripod", "Tripod", "electronics")
+
+        service.recordPurchase(alice.id, camera.id)
+        service.recordPurchase(bob.id, camera.id)
+        service.recordPurchase(bob.id, tripod.id)
+
+        val recommendations = service.recommendProducts(alice.id).toList()
+        recommendations.shouldNotBeEmpty()
+        recommendations.map { it.properties["productId"] } shouldContain "p-tripod"
+    }
+
+    @Test
+    fun `recommends second hop follow targets`() = runTest {
+        val alice = service.addUser("u-alice", "Alice")
+        val bob = service.addUser("u-bob", "Bob")
+        val carol = service.addUser("u-carol", "Carol")
+
+        service.follow(alice.id, bob.id)
+        service.follow(bob.id, carol.id)
+
+        val followTargets = service.recommendFollows(alice.id).toList()
+        followTargets.shouldNotBeEmpty()
+        followTargets.map { it.properties["userId"] } shouldContain "u-carol"
+    }
+
+    @Test
+    fun `ranks popular products inside top results`() = runTest {
+        val camera = service.addProduct("p-camera", "Camera")
+        repeat(3) { index ->
+            val user = service.addUser("u-$index", "User $index")
+            service.recordPurchase(user.id, camera.id)
+        }
+        val tripod = service.addProduct("p-tripod", "Tripod")
+        service.recordPurchase(service.addUser("u-extra", "Extra").id, tripod.id)
+
+        val productIds = service.rankPopularProducts(limit = 10).toList().map { it.vertex.properties["productId"] }
+        productIds.size shouldBeGreaterOrEqualTo 1
+        productIds shouldContain "p-camera"
+    }
+}

--- a/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/AbstractRecommendationTest.kt
+++ b/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/AbstractRecommendationTest.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.graph.examples.recommendation
+
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.recommendation.service.RecommendationService
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractRecommendationTest {
+
+    companion object : KLogging()
+
+    protected abstract val ops: GraphOperations
+    protected open val graphName: String = "recommendation_test"
+    protected val service: RecommendationService by lazy { RecommendationService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+    }
+
+    @Test
+    fun `recommends products from similar buyers`() {
+        val alice = service.addUser("u-alice", "Alice")
+        val bob = service.addUser("u-bob", "Bob")
+        val camera = service.addProduct("p-camera", "Camera", "electronics")
+        val tripod = service.addProduct("p-tripod", "Tripod", "electronics")
+
+        service.recordPurchase(alice.id, camera.id)
+        service.recordPurchase(bob.id, camera.id)
+        service.recordPurchase(bob.id, tripod.id)
+
+        val recommendations = service.recommendProducts(alice.id)
+        recommendations.shouldNotBeEmpty()
+        recommendations.map { it.properties["productId"] } shouldContain "p-tripod"
+    }
+
+    @Test
+    fun `recommends second hop follow targets`() {
+        val alice = service.addUser("u-alice", "Alice")
+        val bob = service.addUser("u-bob", "Bob")
+        val carol = service.addUser("u-carol", "Carol")
+
+        service.follow(alice.id, bob.id)
+        service.follow(bob.id, carol.id)
+
+        val followTargets = service.recommendFollows(alice.id)
+        followTargets.shouldNotBeEmpty()
+        followTargets.map { it.properties["userId"] } shouldContain "u-carol"
+    }
+
+    @Test
+    fun `ranks popular products inside top results`() {
+        val camera = service.addProduct("p-camera", "Camera")
+        repeat(3) { index ->
+            val user = service.addUser("u-$index", "User $index")
+            service.recordPurchase(user.id, camera.id)
+        }
+        val tripod = service.addProduct("p-tripod", "Tripod")
+        service.recordPurchase(service.addUser("u-extra", "Extra").id, tripod.id)
+
+        val productIds = service.rankPopularProducts(limit = 10).map { it.vertex.properties["productId"] }
+        productIds.size shouldBeGreaterOrEqualTo 1
+        productIds shouldContain "p-camera"
+    }
+}

--- a/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationBackendTests.kt
+++ b/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationBackendTests.kt
@@ -1,0 +1,180 @@
+package io.bluetape4k.graph.examples.recommendation
+
+import com.falkordb.FalkorDB
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.graph.age.AgeGraphOperations
+import io.bluetape4k.graph.age.AgeGraphSuspendOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
+import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.logging.warn
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.Driver
+import org.neo4j.driver.GraphDatabase
+import java.util.UUID
+
+class TinkerGraphRecommendationTest : AbstractRecommendationTest() {
+    override val ops = TinkerGraphOperations()
+    override val graphName = "default"
+}
+
+class TinkerGraphRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
+    override val ops = TinkerGraphSuspendOperations()
+    override val graphName = "default"
+}
+
+class Neo4jRecommendationTest : AbstractRecommendationTest() {
+    private val driver: Driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    override val ops = Neo4jGraphOperations(driver)
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+}
+
+class Neo4jRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
+    private val driver: Driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    override val ops = Neo4jGraphSuspendOperations(driver)
+
+    @AfterAll
+    fun teardown() {
+        driver.close()
+    }
+}
+
+class MemgraphRecommendationTest : AbstractRecommendationTest() {
+    private lateinit var driver: Driver
+    override lateinit var ops: MemgraphGraphOperations
+
+    @BeforeAll
+    fun startServer() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphOperations(driver)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        driver.close()
+    }
+}
+
+class MemgraphRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
+    private lateinit var driver: Driver
+    override lateinit var ops: MemgraphGraphSuspendOperations
+
+    @BeforeAll
+    fun startServer() {
+        driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
+        ops = MemgraphGraphSuspendOperations(driver)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        driver.close()
+    }
+}
+
+class AgeRecommendationTest : AbstractRecommendationTest() {
+    override val graphName = "recommendation_test"
+    private lateinit var dataSource: HikariDataSource
+    override lateinit var ops: AgeGraphOperations
+
+    @BeforeAll
+    fun startServer() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        Database.connect(dataSource)
+        ops = AgeGraphOperations(graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        dataSource.close()
+    }
+}
+
+class AgeRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
+    override val graphName = "recommendation_suspend_test"
+    private lateinit var dataSource: HikariDataSource
+    override lateinit var ops: AgeGraphSuspendOperations
+
+    @BeforeAll
+    fun startServer() {
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        dataSource = HikariDataSource(HikariConfig().apply {
+            jdbcUrl = server.jdbcUrl
+            username = server.username
+            password = server.password
+            driverClassName = "org.postgresql.Driver"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+            maximumPoolSize = 5
+        })
+        Database.connect(dataSource)
+        ops = AgeGraphSuspendOperations(graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        dataSource.close()
+    }
+}
+
+class FalkorDBRecommendationTest : AbstractRecommendationTest() {
+    private lateinit var driver: com.falkordb.Driver
+    override lateinit var ops: FalkorDBGraphOperations
+    override val graphName: String = "recommendation_${UUID.randomUUID().toString().replace("-", "").take(8)}"
+
+    @BeforeAll
+    fun startServer() {
+        driver = FalkorDB.driver(FalkorDBServer.Launcher.falkordb.host, FalkorDBServer.Launcher.falkordb.port)
+        ops = FalkorDBGraphOperations(driver, graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        runCatching { ops.dropGraph(graphName) }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
+        driver.close()
+    }
+}
+
+class FalkorDBRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
+    private lateinit var driver: com.falkordb.Driver
+    override lateinit var ops: FalkorDBGraphSuspendOperations
+    override val graphName: String = "recommendation_${UUID.randomUUID().toString().replace("-", "").take(8)}"
+
+    @BeforeAll
+    fun startServer() {
+        driver = FalkorDB.driver(FalkorDBServer.Launcher.falkordb.host, FalkorDBServer.Launcher.falkordb.port)
+        ops = FalkorDBGraphSuspendOperations(driver, graphName)
+    }
+
+    @AfterAll
+    fun stopServer() {
+        runCatching { runBlocking { ops.dropGraph(graphName) } }
+            .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
+        driver.close()
+    }
+}

--- a/examples/recommendation-examples/src/test/resources/junit-platform.properties
+++ b/examples/recommendation-examples/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/recommendation-examples/src/test/resources/logback-test.xml
+++ b/examples/recommendation-examples/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- @formatter:off -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5p) %magenta(${PID:- }) --- [%25.25t] %cyan(%-40.40logger{39}) : %m%n"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+    <!-- formatter:on -->
+
+    <logger name="io.bluetape4k.graph" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

- Add fraud detection, recommendation, and knowledge graph example modules.
- Provide blocking and suspend services with backend-independent tests for TinkerGraph, Neo4j, Memgraph, Apache AGE, and FalkorDB.
- Add English/Korean README locale pairs and a Full Nightly `test-domain-examples` job.

Closes #10

## Verification

- `./gradlew projects --no-daemon`
- `./gradlew :fraud-detection-examples:compileKotlin :fraud-detection-examples:compileTestKotlin :recommendation-examples:compileKotlin :recommendation-examples:compileTestKotlin :knowledge-graph-examples:compileKotlin :knowledge-graph-examples:compileTestKotlin --no-daemon`
- `./gradlew :fraud-detection-examples:test --tests '*TinkerGraph*' :recommendation-examples:test --tests '*TinkerGraph*' :knowledge-graph-examples:test --tests '*TinkerGraph*' --no-daemon`
- `./gradlew :fraud-detection-examples:test :recommendation-examples:test :knowledge-graph-examples:test --no-daemon --continue`
- `actionlint .github/workflows/nightly.yml`
- `actionlint .github/workflows/ci.yml`
- `./gradlew build -x test --parallel --no-daemon`
- `rg -n -P "[가-힣]" examples/fraud-detection-examples/src/main examples/recommendation-examples/src/main examples/knowledge-graph-examples/src/main` returned no matches
- `git diff --check`

## Notes

IDE diagnostics were unavailable in this Codex session, so Gradle compile/test gates were used as fallback evidence.
