### PR TITLE
Split example builds into a dedicated workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
               - 'spring-boot/**'
             graph-ktor:
               - 'ktor/graph-ktor/**'
-              - 'examples/ktor-graph-examples/**'
             common:
               - 'buildSrc/**'
               - 'gradle/**'
@@ -311,13 +310,10 @@ jobs:
           cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
           restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
 
-      - name: Test graph-ktor and Ktor example
+      - name: Test graph-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew \
-              :graph-ktor:test \
-              :ktor-graph-examples:test \
-              --no-daemon --continue && break
+            ./gradlew :graph-ktor:test --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,132 @@
+name: Examples
+
+on:
+  schedule:
+    - cron: '0 21 * * *'  # Daily example coverage, UTC 21:00 (KST 06:00)
+  push:
+    branches: [develop, main]
+    paths:
+      - 'examples/**'
+      - 'graph/**'
+      - 'graph-io/**'
+      - 'ktor/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'settings.gradle.kts'
+      - '.github/actions/testcontainers-image-cache/**'
+      - '.github/scripts/docker-image-cache.sh'
+      - '.github/testcontainers-images.txt'
+      - '.github/workflows/examples.yml'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'examples/**'
+      - 'graph/**'
+      - 'graph-io/**'
+      - 'ktor/**'
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - '*.gradle.kts'
+      - 'settings.gradle.kts'
+      - '.github/actions/testcontainers-image-cache/**'
+      - '.github/scripts/docker-image-cache.sh'
+      - '.github/testcontainers-images.txt'
+      - '.github/workflows/examples.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'temurin'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  validate-wrapper:
+    name: Validate Gradle Wrapper
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v6
+
+  build-examples:
+    name: Build / All Examples (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: validate-wrapper
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
+      - name: Build and test example modules
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :code-graph-examples:build \
+              :linkedin-graph-examples:build \
+              :ktor-graph-examples:build \
+              :fraud-detection-examples:build \
+              :recommendation-examples:build \
+              :knowledge-graph-examples:build \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always() && github.event_name != 'pull_request'
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-examples
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
+  examples-status:
+    name: Examples Status
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - validate-wrapper
+      - build-examples
+    if: always()
+    steps:
+      - name: Check all jobs
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "Examples results: $RESULTS"
+          if echo "$RESULTS" | grep -qE "failure|cancelled"; then
+            echo "Examples workflow failed"
+            exit 1
+          fi
+          echo "Examples workflow passed"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -184,7 +184,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 4. Ktor Graph (Testcontainers + TinkerGraph example) ─────────────────
+  # ── 4. Ktor Graph (Testcontainers) ───────────────────────────────────────
   test-graph-ktor:
     name: Test / Ktor Graph (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -212,13 +212,10 @@ jobs:
           cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
           restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
 
-      - name: Test graph-ktor and Ktor example
+      - name: Test graph-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew \
-              :graph-ktor:test \
-              :ktor-graph-examples:test \
-              --no-daemon --continue && break
+            ./gradlew :graph-ktor:test --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -522,109 +519,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 9. Examples (Testcontainers) ──────────────────────────────────────────
-  test-examples:
-    name: Test / Examples (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: build
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          gradle-version: wrapper
-          cache-read-only: true
-
-      - name: Restore Testcontainers image cache
-        uses: ./.github/actions/testcontainers-image-cache
-        with:
-          mode: restore
-          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
-          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
-
-      - name: Test example modules
-        run: |
-          for attempt in 1 2 3; do
-            ./gradlew \
-              :code-graph-examples:test \
-              :linkedin-graph-examples:test \
-              --no-daemon --continue && break
-            echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
-          done
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
-          TESTCONTAINERS_RYUK_DISABLED: "true"
-          DOCKER_HOST: "unix:///var/run/docker.sock"
-
-      - name: Save Testcontainers image cache
-        if: always()
-        uses: ./.github/actions/testcontainers-image-cache
-        with:
-          mode: save
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-results-examples
-          path: '**/build/test-results/test/*.xml'
-          retention-days: 14
-
-  # ── 10. Domain Examples (Testcontainers) ─────────────────────────────────
-  test-domain-examples:
-    name: Test / Domain Examples (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    needs: build
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          gradle-version: wrapper
-          cache-read-only: true
-
-      - name: Test domain example modules
-        run: |
-          for attempt in 1 2 3; do
-            ./gradlew \
-              :fraud-detection-examples:test \
-              :recommendation-examples:test \
-              :knowledge-graph-examples:test \
-              --no-daemon --continue && break
-            echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
-          done
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
-          TESTCONTAINERS_RYUK_DISABLED: "true"
-          DOCKER_HOST: "unix:///var/run/docker.sock"
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-results-domain-examples
-          path: '**/build/test-results/test/*.xml'
-          retention-days: 14
-
-  # ── 11. 커버리지 집계 ─────────────────────────────────────────────────────
+  # ── 9. 커버리지 집계 ──────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
 
@@ -676,7 +571,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 30
 
-  # ── 12. 결과 집계 ─────────────────────────────────────────────────────────
+  # ── 10. 결과 집계 ─────────────────────────────────────────────────────────
   nightly-status:
     name: Nightly Status
     runs-on: ubuntu-latest
@@ -690,8 +585,6 @@ jobs:
       - test-graph-memgraph
       - test-graph-age
       - test-graph-falkordb
-      - test-examples
-      - test-domain-examples
       - coverage-report
     if: always()
     steps:

--- a/docs/lessons/2026-05-13-examples-workflow-split.md
+++ b/docs/lessons/2026-05-13-examples-workflow-split.md
@@ -1,0 +1,35 @@
+# Examples Workflow Split
+
+## Context
+
+Example modules were previously tested from Nightly jobs, with the Ktor example also coupled to the graph-ktor CI job.
+That mixed example adoption checks with core library/backend verification.
+
+## Decision
+
+Move all example module build/test coverage into a dedicated `Examples` GitHub Actions workflow. Trigger it daily, on
+example-relevant changes, and manually through `workflow_dispatch`.
+
+## Outcome
+
+Nightly now excludes example module tests. General CI no longer runs `:ktor-graph-examples:test` from the graph-ktor job.
+The new examples workflow owns all example module `build` tasks:
+
+- `:code-graph-examples:build`
+- `:linkedin-graph-examples:build`
+- `:ktor-graph-examples:build`
+- `:fraud-detection-examples:build`
+- `:recommendation-examples:build`
+- `:knowledge-graph-examples:build`
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml`
+- `actionlint .github/workflows/nightly.yml`
+- `actionlint .github/workflows/examples.yml`
+- `git diff --check`
+
+## Future Guidance
+
+When adding example modules, update `.github/workflows/examples.yml` instead of Nightly. Nightly should focus on backend
+and library validation, while the Examples workflow owns learning/adoption examples.


### PR DESCRIPTION
## Summary

- Add a dedicated `Examples` workflow that builds all example modules daily, on relevant changes, and manually.
- Remove example module execution from Nightly so Nightly stays focused on backend/library validation.
- Decouple `:ktor-graph-examples` from the `graph-ktor` CI job.
- Add a lesson documenting the workflow ownership decision.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/nightly.yml .github/workflows/examples.yml`
- `git diff --check`
- `./gradlew :code-graph-examples:build :linkedin-graph-examples:build :ktor-graph-examples:build :fraud-detection-examples:build :recommendation-examples:build :knowledge-graph-examples:build --dry-run --no-daemon`

## Notes

Full example builds are left to the PR workflow because these modules use container-backed integration tests.