### PR TITLE
Add graph-okio DAEAD chunk encryption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/
 

--- a/docs/lessons/2026-05-13-issue-49-graph-okio-daead.md
+++ b/docs/lessons/2026-05-13-issue-49-graph-okio-daead.md
@@ -1,0 +1,7 @@
+# Issue #49 graph-okio DAEAD Encryption
+
+- Context: Issue #49 needed encrypted graph I/O for `graph-okio`; `bluetape4k-okio` already exposes deterministic DAEAD chunk source/sink primitives in the current `1.8.0-SNAPSHOT` dependency line.
+- Decision: Reuse the existing DAEAD chunk format instead of introducing Tink Streaming AEAD. Keep high-level encrypted helpers limited to single-stream formats because CSV is a paired-file format.
+- Outcome: `graph-okio` now exposes DAEAD and GZip+DAEAD helpers for path/source/sink chaining plus synchronous bulk import/export convenience methods.
+- Verification: `./gradlew :graph-okio:compileKotlin :graph-okio:compileTestKotlin --no-daemon`, `./gradlew :graph-okio:test --no-daemon`, targeted DAEAD round-trip tests, `git diff --check`, and pattern greps for banned assertion/concurrency/KDoc language regressions.
+- Future rule: For encrypted OkIO work, validate the resolved dependency version with `dependencyInsight` and test both raw chunk helpers and end-to-end bulk graph round trips on `FakeFileSystem`.

--- a/docs/superpowers/plans/2026-05-13-issue-49-graph-okio-daead-plan.md
+++ b/docs/superpowers/plans/2026-05-13-issue-49-graph-okio-daead-plan.md
@@ -1,0 +1,57 @@
+# Issue #49 Graph OkIO DAEAD Chunk Encryption Plan
+
+- Issue: #49
+- Spec: `docs/superpowers/specs/2026-05-13-issue-49-graph-okio-daead-design.md`
+- Branch: `feat/issue-49-graph-okio-daead`
+- Worktree: `.worktrees/feat-issue-49-graph-okio-daead`
+- Status: Step 3-R reviewed
+
+## 1. Implementation Tasks
+
+- [ ] Add `bluetape4k-tink` version-catalog alias.
+- [ ] Add explicit `api(libs.bluetape4k.tink)` to `graph-io/okio/build.gradle.kts`.
+- [ ] Add DAEAD low-level helpers to `GraphIoOkioPaths`.
+- [ ] Add single-stream DAEAD and gzip+DAEAD helpers to `OkioGraphBulkImporter` and `OkioGraphBulkExporter`.
+- [ ] Add focused tests for low-level and high-level DAEAD paths.
+- [ ] Update `graph-io/okio/README.md` and `README.ko.md`.
+- [ ] Add/update a lesson entry.
+
+## 2. Validation Tasks
+
+- [ ] `./gradlew :graph-okio:compileKotlin :graph-okio:compileTestKotlin --no-daemon`
+- [ ] `./gradlew :graph-okio:test --no-daemon`
+- [ ] `git diff --check`
+- [ ] Review touched public KDoc for English wording.
+
+## 3. Design Guardrails
+
+- Do not add CSV encrypted convenience helpers in this PR.
+- Do not introduce Tink `StreamingAead`.
+- Keep helper names explicit: `Daead`, `GzipDaead`, `DaeadGzip`.
+- Keep wrong key/associated-data/corrupt input as hard failures.
+- Do not change existing gzip or plain import/export behavior.
+
+## 4. PR Notes
+
+PR body must mention:
+
+- DAEAD chunk encryption uses deterministic encryption and leaks repeated chunks.
+- CSV paired encrypted file convenience helpers are deferred.
+- Validation evidence from `:graph-okio` compile/test.
+
+## 5. Step 3-R Review Result
+
+Claude Code Opus advisor:
+
+- Artifact: `.omx/artifacts/claude-issue-49-spec-plan-20260513-093037.md`
+- Result: unavailable. The CLI produced no output for more than two minutes and was terminated.
+
+Codex review findings:
+
+| Priority | Finding | Decision |
+|---|---|---|
+| P1 | Version catalog update must precede code imports so compile errors identify real API issues, not missing aliases. | Accepted. Task order already starts with catalog/dependency. |
+| P1 | README updates must cover both locale files because this is library-user documentation. | Accepted. Plan includes both `README.md` and `README.ko.md`. |
+| P2 | Negative tests should include wrong associated data and truncated ciphertext. | Accepted. Covered by test task. |
+
+Gate result: P0 = 0, P1 = 0.

--- a/docs/superpowers/specs/2026-05-13-issue-49-graph-okio-daead-design.md
+++ b/docs/superpowers/specs/2026-05-13-issue-49-graph-okio-daead-design.md
@@ -1,0 +1,166 @@
+# Issue #49 Graph OkIO DAEAD Chunk Encryption Design
+
+- Issue: #49
+- Date: 2026-05-13
+- Scope: `graph-okio`
+- Status: Step 2-R reviewed
+
+## 1. Context
+
+`graph-okio` currently supports OkIO source/sink abstraction, streaming compression, and atomic path writes. The original OkIO
+spec deferred encryption because `bluetape4k-okio` only had `TinkEncryptSink` / `TinkDecryptSource`, and that path was not safe
+for large graph files.
+
+That prerequisite has changed. The current `bluetape4k-okio:1.8.0-SNAPSHOT` jar contains:
+
+- `io.bluetape4k.okio.tink.DaeadChunkEncryptSink`
+- `io.bluetape4k.okio.tink.DaeadChunkDecryptSource`
+- `Sink.asDaeadChunkEncryptSink(...)`
+- `Source.asDaeadChunkDecryptSource(...)`
+
+The matching `bluetape4k-tink:1.8.0-SNAPSHOT` jar contains:
+
+- `io.bluetape4k.tink.daead.TinkDeterministicAead`
+- `io.bluetape4k.tink.daead.TinkDaeads`
+
+Google Tink documentation states that Deterministic AEAD returns stable ciphertext for the same plaintext and associated data.
+That property is useful for some workloads, but it leaks repeated plaintext chunks. `graph-okio` must document that trade-off
+instead of presenting DAEAD chunk encryption as general-purpose randomized streaming encryption.
+
+## 2. Decision
+
+Implement #49 using the existing bluetape4k-okio DAEAD chunk format, not Tink `StreamingAead`.
+
+The issue text mentions `StreamingAead`, but the concrete bluetape4k prerequisite available today is DAEAD chunk encryption.
+Adopting it keeps the feature local, testable with `FakeFileSystem`, and aligned with the shared okio module. Tink
+`StreamingAead` can remain a future issue if a randomized streaming encryption API is needed.
+
+## 3. Public API
+
+Add low-level path helpers to `GraphIoOkioPaths`:
+
+```kotlin
+fun openDaeadEncryptedSink(
+    sink: BufferedSink,
+    daead: TinkDeterministicAead,
+    chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+    associatedData: ByteArray = ByteArray(0),
+): BufferedSink
+
+fun openDaeadDecryptedSource(
+    source: BufferedSource,
+    daead: TinkDeterministicAead,
+    associatedData: ByteArray = ByteArray(0),
+    maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
+): BufferedSource
+```
+
+Add convenience helpers:
+
+```kotlin
+fun openDaeadEncryptedSink(sink: OkioGraphExportSink, ...)
+fun openDaeadDecryptedSource(source: OkioGraphImportSource, ...)
+fun openGzipDaeadEncryptedSink(sink: OkioGraphExportSink, ...)
+fun openDaeadDecryptedGzipSource(source: OkioGraphImportSource, ...)
+```
+
+The compression/encryption order is:
+
+- export: `graph bytes -> gzip -> DAEAD chunk encrypt -> target`
+- import: `source -> DAEAD chunk decrypt -> gzip inflate -> graph bytes`
+
+This is compress-then-encrypt. The reverse order is not supported because encrypted output is not meaningfully compressible.
+
+Add high-level export/import helpers for single-stream formats:
+
+```kotlin
+fun OkioGraphBulkExporter.exportGraphDaead(...)
+fun OkioGraphBulkImporter.importGraphDaead(...)
+fun OkioGraphBulkExporter.exportGraphGzipDaead(...)
+fun OkioGraphBulkImporter.importGraphDaeadGzip(...)
+```
+
+CSV is a two-file format. For this PR, CSV DAEAD convenience helpers are not added to avoid designing paired encrypted
+file naming in the same slice. Callers can still use the low-level path helpers directly for custom CSV file pairs.
+
+## 4. Dependency Contract
+
+`graph-okio` will expose `TinkDeterministicAead` in public signatures. Therefore `gradle/libs.versions.toml` needs a
+`bluetape4k-tink` alias, and `graph-io/okio/build.gradle.kts` should declare:
+
+```kotlin
+api(libs.bluetape4k.tink)
+```
+
+Even if `bluetape4k-okio` already brings `bluetape4k-tink` transitively, this explicit API dependency prevents a public
+signature from depending on an incidental transitive edge.
+
+## 5. Security Notes
+
+- DAEAD chunk encryption is deterministic. Repeated plaintext chunks with the same key and associated data produce repeated
+  ciphertext chunks.
+- Associated data is authenticated but not encrypted.
+- `maxCiphertextLength` must remain exposed on decrypt helpers to bound per-chunk allocation for untrusted input.
+- This feature protects file contents at rest. It does not provide key management, key rotation, path sanitization, or audit
+  logging.
+- Wrong key, wrong associated data, truncated chunks, or corrupted ciphertext must fail loudly.
+
+## 6. Test Strategy
+
+Use fast `graph-okio` tests only:
+
+- Low-level DAEAD round trip with `Buffer`.
+- Low-level gzip + DAEAD round trip with `FakeFileSystem`.
+- High-level Jackson3 NDJSON export/import DAEAD round trip through `TinkerGraphOperations`.
+- High-level Jackson3 NDJSON export/import gzip+DAEAD round trip.
+- Negative tests for wrong associated data and truncated ciphertext.
+- Compile/test `:graph-okio`.
+
+Container-backed backend tests are not needed. This feature is graph-io path plumbing and can be verified with TinkerGraph.
+
+## 7. Documentation
+
+Update `graph-io/okio/README.md` and `README.ko.md`:
+
+- Add DAEAD chunk encryption examples.
+- Explain compress-then-encrypt order.
+- Document deterministic encryption leakage.
+- Mention that CSV two-file encrypted convenience helpers are intentionally out of scope.
+
+New or touched public KDoc must be English.
+
+## 8. Out Of Scope
+
+- Tink `StreamingAead`.
+- CSV paired encrypted file convenience naming.
+- Spring Boot auto-configuration.
+- Keyset loading or key management helpers.
+- Benchmarking encryption throughput.
+
+## 9. Review Notes
+
+Step 2-R review must verify:
+
+- Public API surface is small enough for #49.
+- Deterministic encryption limitations are explicit.
+- Dependency exposure is correct.
+- Compression/encryption order is correct and testable.
+- No mock-only validation is used.
+
+### Step 2-R Review Result
+
+Claude Code Opus advisor:
+
+- Artifact: `.omx/artifacts/claude-issue-49-spec-plan-20260513-093037.md`
+- Result: unavailable. The CLI produced no output for more than two minutes and was terminated.
+
+Codex review findings:
+
+| Priority | Finding | Decision |
+|---|---|---|
+| P1 | Public signatures expose `TinkDeterministicAead`; relying only on transitive `bluetape4k-okio` API dependency would be brittle. | Accepted. Spec requires explicit `api(libs.bluetape4k.tink)`. |
+| P1 | DAEAD is deterministic and can leak repeated chunks. | Accepted. Spec and docs tasks require explicit warning. |
+| P2 | CSV encrypted file-pair convenience helpers could expand naming/API scope. | Accepted. Deferred from this PR; low-level helpers remain available. |
+| P2 | Tests need a wrong associated-data/corruption path, not only happy-path round trips. | Accepted. Test strategy includes both. |
+
+Gate result: P0 = 0, P1 = 0.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,7 @@ bluetape4k-io = { module = "io.github.bluetape4k:bluetape4k-io", version.ref = "
 bluetape4k-jackson2 = { module = "io.github.bluetape4k:bluetape4k-jackson2", version.ref = "bluetape4k" }
 bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3", version.ref = "bluetape4k" }
 bluetape4k-okio = { module = "io.github.bluetape4k:bluetape4k-okio", version.ref = "bluetape4k" }
+bluetape4k-tink = { module = "io.github.bluetape4k:bluetape4k-tink", version.ref = "bluetape4k" }
 bluetape4k-assertions = { module = "io.github.bluetape4k:bluetape4k-assertions", version.ref = "bluetape4k" }
 
 # kotlin

--- a/graph-io/okio/README.ko.md
+++ b/graph-io/okio/README.ko.md
@@ -1,5 +1,7 @@
 # graph-okio (한국어)
 
+[English](README.md) | [한국어](README.ko.md)
+
 OkIO 기반 그래프 I/O 레이어. 기존 `graph-io-csv`, `graph-io-jackson2`, `graph-io-jackson3`, `graph-io-graphml` 모듈과 완벽하게 호환되면서 OkIO의 세그먼트 기반 스트리밍, 압축 체이닝, FileSystem 추상화를 제공한다.
 
 ## OkIO를 선택하는 이유
@@ -188,6 +190,43 @@ GraphIoOkioPaths.openCompressedSink(rawSink, Compressor.ZSTD)
 GraphIoOkioPaths.openDecompressedSource(rawSource, Compressor.ZSTD, maxDecompressedBytes = 1_073_741_824L)
 ```
 
+### DAEAD 청크 암호화
+
+`graph-okio`는 `bluetape4k-okio`의 deterministic DAEAD 청크 암호화를 단일 스트림 포맷에 체이닝할 수 있다.
+NDJSON 또는 GraphML payload를 OkIO 스트리밍 경로로 흘리면서 인증/암호화해야 할 때 사용한다.
+
+```kotlin
+val daead = TinkDaeads.AES256_SIV
+val associatedData = "tenant-a:graph-export".encodeToByteArray()
+
+exporter.exportGraphDaead(
+    sink = OkioGraphExportSink.PathSink("/data/graph.ndjson.enc".toPath()),
+    format = GraphIoFormat.NDJSON_JACKSON3,
+    daead = daead,
+    operations = graphOperations,
+    associatedData = associatedData,
+)
+
+importer.importGraphDaead(
+    source = OkioGraphImportSource.PathSource("/data/graph.ndjson.enc".toPath()),
+    format = GraphIoFormat.NDJSON_JACKSON3,
+    daead = daead,
+    operations = graphOperations,
+    associatedData = associatedData,
+)
+```
+
+압축 후 암호화가 필요하면 다음 편의 함수를 사용한다.
+
+```kotlin
+exporter.exportGraphGzipDaead(sink, GraphIoFormat.NDJSON_JACKSON3, daead, graphOperations)
+importer.importGraphDaeadGzip(source, GraphIoFormat.NDJSON_JACKSON3, daead, graphOperations)
+```
+
+CSV는 정점/간선 파일이 분리되는 paired-file 포맷이므로 high-level 암호화 편의 함수는 `GraphIoFormat.CSV`를
+거부한다. 커스텀 CSV 파일 쌍을 암호화하려면 `GraphIoOkioPaths.openDaeadEncryptedSink()`와
+`openDaeadDecryptedSource()`를 직접 조합한다.
+
 ### 원자적 쓰기
 
 `PathSink(atomicWrite = true)` (기본값)이면:
@@ -277,6 +316,9 @@ class MyGraphIoTest {
 - **Decompression bomb 방지**: `BombGuardSource`가 해제 바이트를 추적하여 `maxDecompressedBytes` 초과 시 `IOException` 발생
   - 기본 한계: 512 MiB (`DEFAULT_MAX_DECOMPRESSED_BYTES`)
   - 커스텀 한계: `openDecompressedSource(source, compressor, maxDecompressedBytes = 1L * 1024 * 1024 * 1024)` (1 GiB)
+- **DAEAD deterministic encryption**: 같은 키와 associated data로 같은 평문 청크를 암호화하면 같은 암호문
+  청크가 생성된다. associated data는 테넌트/용도/스키마 버전처럼 의도적인 경계값으로 정하고, 키 생성/보관/회전은
+  이 모듈 밖에서 관리한다.
 - **CSV Gzip 스트리밍**: `importGraphGzip` / `exportGraphGzip` 모두 단일 패스 스트리밍 — 중간 버퍼링 없음
 
 ## Gradle 의존성

--- a/graph-io/okio/README.md
+++ b/graph-io/okio/README.md
@@ -1,5 +1,7 @@
 # graph-okio
 
+[English](README.md) | [한국어](README.ko.md)
+
 OkIO 기반 그래프 I/O 레이어. 기존 `graph-io-csv`, `graph-io-jackson2`, `graph-io-jackson3`, `graph-io-graphml` 모듈과 완벽하게 호환되면서 OkIO의 세그먼트 기반 스트리밍, 압축 체이닝, FileSystem 추상화를 제공한다.
 
 ## 지원 포맷
@@ -146,6 +148,44 @@ GraphIoOkioPaths.openCompressedSink(sink, Compressor.ZSTD)
 GraphIoOkioPaths.openDecompressedSource(source, Compressor.ZSTD, maxDecompressedBytes = 1_073_741_824L)
 ```
 
+### DAEAD Chunk Encryption
+
+`graph-okio` can wrap single-stream formats with deterministic DAEAD chunk encryption from `bluetape4k-okio`.
+Use this for NDJSON or GraphML payloads that must be authenticated and encrypted while still flowing through
+OkIO streaming APIs.
+
+```kotlin
+val daead = TinkDaeads.AES256_SIV
+val associatedData = "tenant-a:graph-export".encodeToByteArray()
+
+exporter.exportGraphDaead(
+    sink = OkioGraphExportSink.PathSink("/data/graph.ndjson.enc".toPath()),
+    format = GraphIoFormat.NDJSON_JACKSON3,
+    daead = daead,
+    operations = graphOperations,
+    associatedData = associatedData,
+)
+
+importer.importGraphDaead(
+    source = OkioGraphImportSource.PathSource("/data/graph.ndjson.enc".toPath()),
+    format = GraphIoFormat.NDJSON_JACKSON3,
+    daead = daead,
+    operations = graphOperations,
+    associatedData = associatedData,
+)
+```
+
+For smaller encrypted artifacts, prefer compress-then-encrypt:
+
+```kotlin
+exporter.exportGraphGzipDaead(sink, GraphIoFormat.NDJSON_JACKSON3, daead, graphOperations)
+importer.importGraphDaeadGzip(source, GraphIoFormat.NDJSON_JACKSON3, daead, graphOperations)
+```
+
+CSV is a paired-file format, so the high-level encrypted helpers intentionally reject `GraphIoFormat.CSV`.
+Use `GraphIoOkioPaths.openDaeadEncryptedSink()` and `openDaeadDecryptedSource()` directly if you need a custom
+encrypted CSV file-pair layout.
+
 ### 원자적 쓰기
 
 `PathSink(atomicWrite = true)` (기본값)이면:
@@ -157,6 +197,9 @@ GraphIoOkioPaths.openDecompressedSource(source, Compressor.ZSTD, maxDecompressed
 
 - **XXE 방지**: GraphML StAX 파서에 `IS_SUPPORTING_EXTERNAL_ENTITIES=false`, `SUPPORT_DTD=false` 적용 (기존 구현 위임)
 - **Decompression bomb 방지**: `BombGuardSource`가 해제 바이트를 추적하여 `maxDecompressedBytes` 초과 시 `IOException` 발생
+- **DAEAD deterministic encryption**: encrypted chunks are deterministic. Repeated plaintext chunks encrypted
+  with the same key and associated data produce repeated ciphertext chunks. Choose associated data deliberately
+  and rotate/manage keys outside this module.
 
 ## Gradle 의존성
 

--- a/graph-io/okio/build.gradle.kts
+++ b/graph-io/okio/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     api(project(":graph-io-core"))
     api(libs.bluetape4k.okio)
+    api(libs.bluetape4k.tink)
 
     // 기존 graph-io 모듈 — 포맷별 임포터/익스포터 위임
     implementation(project(":graph-io-csv"))

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
@@ -3,6 +3,12 @@ package io.bluetape4k.graph.io.okio
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.okio.compress.Compressable
+import io.bluetape4k.okio.tink.DEFAULT_DAEAD_CHUNK_SIZE
+import io.bluetape4k.okio.tink.DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH
+import io.bluetape4k.okio.tink.asDaeadChunkDecryptSource
+import io.bluetape4k.okio.tink.asDaeadChunkEncryptSink
+import io.bluetape4k.support.requirePositiveNumber
+import io.bluetape4k.tink.daead.TinkDeterministicAead
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
@@ -20,40 +26,43 @@ import java.io.IOException
 import java.util.UUID
 
 /**
- * OkIO 기반 그래프 I/O 경로 헬퍼.
+ * Opens OkIO graph import sources and export sinks.
  *
- * [OkioGraphImportSource] / [OkioGraphExportSink]를 [BufferedSource] / [BufferedSink]로 열고,
- * 압축 체이닝 및 원자적 쓰기(atomicWrite)를 지원한다.
+ * This helper converts [OkioGraphImportSource] and [OkioGraphExportSink] into [BufferedSource] and
+ * [BufferedSink] instances, then applies optional compression, DAEAD chunk encryption, and atomic writes.
  *
- * ### 압축 규칙
- * 모든 압축 경로는 [io.bluetape4k.io.compressor.Compressors.Streaming] 변형을 사용한다.
- * `Compressable.Sinks.gzip()` 등 배치 변형은 대용량 그래프 export 시 메모리를 전량 버퍼링하므로 사용하지 않는다.
+ * ### Compression
+ * All compression paths use [io.bluetape4k.io.compressor.Compressors.Streaming] variants. Batch helpers such
+ * as `Compressable.Sinks.gzip()` are intentionally avoided because large graph exports must not buffer the
+ * full payload in heap memory.
  *
- * ### close 책임
- * 반환된 [BufferedSource] / [BufferedSink]는 호출자가 닫아야 한다.
- * `PathSource` / `PathSink`는 라이브러리 소유 — close 시 파일 핸들이 해제된다.
- * `SourceBased` / `SinkBased` / `InputStreamBased` / `OutputStreamBased`는 `ownsXxx` 파라미터에 따라 결정된다.
+ * ### Close ownership
+ * Callers must close the returned [BufferedSource] or [BufferedSink]. `PathSource` and `PathSink` are library
+ * owned, so closing releases the opened file handle. Source-, sink-, input-stream-, and output-stream-backed
+ * variants follow their `ownsXxx` flag.
  *
- * ### atomicWrite (PathSink)
- * `atomicWrite=true`(기본)이면 임시 파일에 기록 후 성공 시 atomic move. 실패 시 임시 파일 삭제.
- * 부분 기록으로 인한 대상 파일 손상을 방지한다.
+ * ### Atomic writes
+ * `PathSink.atomicWrite=true` writes to a temporary path first, then atomically moves it into place on success.
+ * Failed writes delete the temporary file and leave the target path untouched.
  *
- * ### v2 예정
- * 암호화 지원 (bluetape4k-projects #240 완료 후) — `TinkEncryptSink` / `TinkDecryptSource` 체이닝 추가 예정.
+ * ### Encryption
+ * DAEAD chunk encryption delegates to `bluetape4k-okio`'s `DaeadChunkEncryptSink` and
+ * `DaeadChunkDecryptSource`. The encrypted format is deterministic: repeated plaintext chunks encrypted with
+ * the same key and associated data produce repeated ciphertext chunks.
  */
 object GraphIoOkioPaths : KLogging() {
 
-    /** 압축 해제 기본 최대 크기 (512 MiB). decompression bomb 방지. */
+    /** Default decompression budget: 512 MiB. */
     const val DEFAULT_MAX_DECOMPRESSED_BYTES: Long = 512L * 1024 * 1024
 
-    // ─── Source 열기 ───────────────────────────────────────────────────────────
+    // ─── Source opening ──────────────────────────────────────────────────────
 
     /**
-     * [source]로부터 [BufferedSource]를 연다.
+     * Opens [source] as a [BufferedSource].
      *
-     * 반환된 [BufferedSource]는 호출자가 닫아야 한다.
+     * The caller must close the returned source.
      *
-     * @throws IOException 파일을 찾을 수 없거나 읽기 권한 없을 때
+     * @throws IOException when the path cannot be opened for reading
      */
     @Throws(IOException::class)
     fun openSource(source: OkioGraphImportSource): BufferedSource = when (source) {
@@ -69,15 +78,15 @@ object GraphIoOkioPaths : KLogging() {
             else nonClosingSource(source.inputStream.source()).buffer()
     }
 
-    // ─── Sink 열기 ─────────────────────────────────────────────────────────────
+    // ─── Sink opening ────────────────────────────────────────────────────────
 
     /**
-     * [sink]로부터 [BufferedSink]를 연다.
+     * Opens [sink] as a [BufferedSink].
      *
-     * `PathSink.atomicWrite=true`(기본)이면 임시 파일에 기록 후 성공 시 atomic move.
-     * 반환된 [BufferedSink]는 호출자가 닫아야 한다.
+     * `PathSink.atomicWrite=true` writes to a temporary path first and moves it atomically on success.
+     * The caller must close the returned sink.
      *
-     * @throws IOException 파일 생성/열기 실패 시
+     * @throws IOException when the path cannot be opened for writing
      */
     @Throws(IOException::class)
     fun openSink(sink: OkioGraphExportSink): BufferedSink = when (sink) {
@@ -94,16 +103,16 @@ object GraphIoOkioPaths : KLogging() {
         }
     }
 
-    // ─── 압축 체이닝 ───────────────────────────────────────────────────────────
+    // ─── Compression chaining ────────────────────────────────────────────────
 
     /**
-     * [sink]에 [compressor] 압축을 체이닝한 [BufferedSink]를 반환한다.
+     * Wraps [sink] with [compressor] and returns a compressed [BufferedSink].
      *
-     * 스트리밍 압축기([io.bluetape4k.io.compressor.Compressors.Streaming])를 사용한다.
-     * 선택 의존성(LZ4/Snappy/Zstd/Bzip2)이 클래스패스에 없으면 [IllegalStateException].
+     * Optional compressors such as LZ4, Snappy, Zstd, and Bzip2 require their runtime dependency on the
+     * classpath.
      *
-     * @throws IOException 압축 스트림 초기화 실패 시
-     * @throws IllegalStateException 선택 의존성 누락 시
+     * @throws IOException when the compressed stream cannot be initialized
+     * @throws IllegalStateException when an optional compressor dependency is missing
      */
     @Throws(IOException::class)
     fun openCompressedSink(sink: BufferedSink, compressor: Compressor): BufferedSink {
@@ -112,13 +121,12 @@ object GraphIoOkioPaths : KLogging() {
     }
 
     /**
-     * [source]에 [compressor] 압축 해제를 체이닝한 [BufferedSource]를 반환한다.
+     * Wraps [source] with [compressor] decompression and a decompression budget guard.
      *
-     * [maxDecompressedBytes]를 초과하면 [IOException]("decompression budget exceeded")을 던진다.
-     * decompression bomb 공격 방지.
+     * [maxDecompressedBytes] limits inflated bytes to reduce decompression-bomb risk.
      *
-     * @throws IOException 압축 해제 중 오류 또는 폭탄 탐지 시
-     * @throws IllegalStateException 선택 의존성 누락 시
+     * @throws IOException when decompression fails or the budget is exceeded
+     * @throws IllegalStateException when an optional compressor dependency is missing
      */
     @Throws(IOException::class)
     fun openDecompressedSource(
@@ -126,17 +134,61 @@ object GraphIoOkioPaths : KLogging() {
         compressor: Compressor,
         maxDecompressedBytes: Long = DEFAULT_MAX_DECOMPRESSED_BYTES,
     ): BufferedSource {
-        require(maxDecompressedBytes > 0) { "maxDecompressedBytes must be positive: $maxDecompressedBytes" }
+        maxDecompressedBytes.requirePositiveNumber("maxDecompressedBytes")
         val streaming = compressor.streamingCompressor()
         val decompressed = Compressable.Sources.decompressableSource(source, streaming)
         return BombGuardSource(decompressed, maxDecompressedBytes).buffer()
     }
 
+    // ─── DAEAD chunk encryption chaining ─────────────────────────────────────
+
     /**
-     * GZip 압축 체이닝 편의 함수.
+     * Wraps [sink] with DAEAD chunk encryption.
      *
-     * 내부적으로 `Compressors.Streaming.GZip`을 사용한다.
-     * 압축 초기화 실패 시 underlying sink를 닫고 예외를 재던진다.
+     * The returned sink writes `[8-byte ciphertext length][ciphertext]` frames through
+     * `bluetape4k-okio`'s deterministic DAEAD chunk format. This is not randomized streaming encryption:
+     * repeated plaintext chunks encrypted with the same key and [associatedData] produce repeated ciphertext chunks.
+     *
+     * @param sink target sink receiving encrypted frames
+     * @param daead deterministic AEAD primitive used for chunk encryption
+     * @param chunkSize plaintext chunk size before encryption
+     * @param associatedData authenticated associated data; it is not encrypted
+     * @return buffered sink accepting plaintext bytes
+     */
+    @Throws(IOException::class)
+    fun openDaeadEncryptedSink(
+        sink: BufferedSink,
+        daead: TinkDeterministicAead,
+        chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+        associatedData: ByteArray = ByteArray(0),
+    ): BufferedSink =
+        sink.asDaeadChunkEncryptSink(daead, chunkSize, associatedData).buffer()
+
+    /**
+     * Wraps [source] with DAEAD chunk decryption.
+     *
+     * [maxCiphertextLength] limits per-chunk allocation for untrusted input. Wrong keys, wrong associated
+     * data, truncated chunks, or corrupted ciphertext fail loudly.
+     *
+     * @param source source containing DAEAD chunk frames
+     * @param daead deterministic AEAD primitive used for chunk decryption
+     * @param associatedData authenticated associated data used during encryption
+     * @param maxCiphertextLength maximum accepted ciphertext frame length
+     * @return buffered source yielding plaintext bytes
+     */
+    @Throws(IOException::class)
+    fun openDaeadDecryptedSource(
+        source: BufferedSource,
+        daead: TinkDeterministicAead,
+        associatedData: ByteArray = ByteArray(0),
+        maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
+    ): BufferedSource =
+        source.asDaeadChunkDecryptSource(daead, associatedData, maxCiphertextLength).buffer()
+
+    /**
+     * Opens [sink] and wraps it with GZip compression.
+     *
+     * The underlying sink is closed if compression setup fails.
      */
     @Throws(IOException::class)
     fun openGzipSink(sink: OkioGraphExportSink): BufferedSink {
@@ -150,11 +202,54 @@ object GraphIoOkioPaths : KLogging() {
     }
 
     /**
-     * GZip 압축 해제 체이닝 편의 함수.
+     * Opens [sink] and wraps it with DAEAD chunk encryption.
      *
-     * 압축 초기화 실패 시 underlying source를 닫고 예외를 재던진다.
+     * The returned sink accepts plaintext bytes and writes encrypted DAEAD chunk frames to [sink].
+     */
+    @Throws(IOException::class)
+    fun openDaeadEncryptedSink(
+        sink: OkioGraphExportSink,
+        daead: TinkDeterministicAead,
+        chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+        associatedData: ByteArray = ByteArray(0),
+    ): BufferedSink {
+        val bs = openSink(sink)
+        return try {
+            openDaeadEncryptedSink(bs, daead, chunkSize, associatedData)
+        } catch (e: Throwable) {
+            try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after DAEAD init failure" } }
+            throw e
+        }
+    }
+
+    /**
+     * Opens [sink] as a compress-then-encrypt GZip + DAEAD chunk sink.
      *
-     * @param maxDecompressedBytes decompression bomb 방지 한계 (기본 512 MiB)
+     * Write plaintext graph bytes to the returned sink. The bytes are compressed first and then encrypted.
+     */
+    @Throws(IOException::class)
+    fun openGzipDaeadEncryptedSink(
+        sink: OkioGraphExportSink,
+        daead: TinkDeterministicAead,
+        chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+        associatedData: ByteArray = ByteArray(0),
+    ): BufferedSink {
+        val bs = openSink(sink)
+        return try {
+            val encrypted = openDaeadEncryptedSink(bs, daead, chunkSize, associatedData)
+            openCompressedSink(encrypted, Compressor.GZIP)
+        } catch (e: Throwable) {
+            try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip+DAEAD init failure" } }
+            throw e
+        }
+    }
+
+    /**
+     * Opens [source] and wraps it with GZip decompression.
+     *
+     * The underlying source is closed if decompression setup fails.
+     *
+     * @param maxDecompressedBytes inflated-byte budget used to reduce decompression-bomb risk
      */
     @Throws(IOException::class)
     fun openGzipSource(
@@ -170,19 +265,61 @@ object GraphIoOkioPaths : KLogging() {
         }
     }
 
-    // ─── 내부 헬퍼 ─────────────────────────────────────────────────────────────
+    /**
+     * Opens [source] and wraps it with DAEAD chunk decryption.
+     */
+    @Throws(IOException::class)
+    fun openDaeadDecryptedSource(
+        source: OkioGraphImportSource,
+        daead: TinkDeterministicAead,
+        associatedData: ByteArray = ByteArray(0),
+        maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
+    ): BufferedSource {
+        val bs = openSource(source)
+        return try {
+            openDaeadDecryptedSource(bs, daead, associatedData, maxCiphertextLength)
+        } catch (e: Throwable) {
+            try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close source after DAEAD init failure" } }
+            throw e
+        }
+    }
 
-    /** PathSink: atomicWrite 전략 적용하여 BufferedSink를 연다. */
+    /**
+     * Opens [source] as a decrypt-then-inflate DAEAD chunk + GZip source.
+     *
+     * The input must have been written by [openGzipDaeadEncryptedSink].
+     */
+    @Throws(IOException::class)
+    fun openDaeadDecryptedGzipSource(
+        source: OkioGraphImportSource,
+        daead: TinkDeterministicAead,
+        associatedData: ByteArray = ByteArray(0),
+        maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
+        maxDecompressedBytes: Long = DEFAULT_MAX_DECOMPRESSED_BYTES,
+    ): BufferedSource {
+        val bs = openSource(source)
+        return try {
+            val decrypted = openDaeadDecryptedSource(bs, daead, associatedData, maxCiphertextLength)
+            openDecompressedSource(decrypted, Compressor.GZIP, maxDecompressedBytes)
+        } catch (e: Throwable) {
+            try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close source after DAEAD+gzip init failure" } }
+            throw e
+        }
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────────────
+
+    /** Opens a [OkioGraphExportSink.PathSink] and applies the atomic-write strategy when requested. */
     @Throws(IOException::class)
     private fun openPathSink(sink: OkioGraphExportSink.PathSink): BufferedSink {
         val fs = sink.fileSystem
         val target = sink.path
 
         if (sink.mustExist) {
-            check(fs.exists(target)) { "PathSink.mustExist=true 이지만 대상 파일이 없음: $target" }
+            check(fs.exists(target)) { "PathSink.mustExist=true but target path does not exist: $target" }
         }
         if (sink.mustCreate) {
-            check(!fs.exists(target)) { "PathSink.mustCreate=true 이지만 대상 파일이 이미 존재함: $target" }
+            check(!fs.exists(target)) { "PathSink.mustCreate=true but target path already exists: $target" }
         }
         if (sink.createParentDirectories) {
             target.parent?.let { fs.createDirectories(it) }
@@ -192,7 +329,7 @@ object GraphIoOkioPaths : KLogging() {
             return fs.sink(target, mustCreate = false).buffer()
         }
 
-        // atomicWrite=true: 임시파일 → atomicMove
+        // atomicWrite=true: temporary path, then atomicMove.
         val tmpName = "${target.filename}.tmp.${UUID.randomUUID()}"
         val tmpPath = target.parent?.let { it / tmpName }
             ?: ("${target}.tmp.${UUID.randomUUID()}".toPath())
@@ -201,20 +338,20 @@ object GraphIoOkioPaths : KLogging() {
         return AtomicMoveSink(rawSink, tmpPath, target, fs).buffer()
     }
 
-    /** close 시 underlying source를 닫지 않는 래퍼 (호출자 소유). */
+    /** Wrapper that does not close the underlying caller-owned source. */
     private fun nonClosingSource(delegate: Source): Source = object : ForwardingSource(delegate) {
         override fun close() { /* caller owns the source — do not close */ }
     }
 
-    /** close 시 underlying sink를 닫지 않는 래퍼 (호출자 소유). */
+    /** Wrapper that does not close the underlying caller-owned sink. */
     private fun nonClosingSink(delegate: Sink): Sink = object : ForwardingSink(delegate) {
         override fun close() { /* caller owns the sink — do not close */ }
     }
 
     /**
-     * decompression bomb 방지용 Source 래퍼.
+     * Source wrapper that enforces a decompression budget.
      *
-     * [maxBytes]를 초과하면 [IOException]을 던진다. 단일 스레드 전용.
+     * Throws [IOException] once reads exceed [maxBytes]. Intended for single-threaded reads.
      */
     private class BombGuardSource(
         delegate: Source,
@@ -236,9 +373,9 @@ object GraphIoOkioPaths : KLogging() {
     }
 
     /**
-     * close 시 임시 파일을 target으로 atomic move하는 Sink 래퍼.
+     * Sink wrapper that atomically moves a temporary file to the target path on close.
      *
-     * close 전 예외 발생 시 tmpPath를 삭제한다.
+     * If the write fails before close completes, the temporary path is deleted.
      */
     private class AtomicMoveSink(
         delegate: Sink,
@@ -279,6 +416,6 @@ object GraphIoOkioPaths : KLogging() {
     }
 }
 
-// ─── okio.Path 편의 확장 ───────────────────────────────────────────────────────
-/** OkIO Path의 파일명 부분 (마지막 세그먼트). */
+// ─── okio.Path convenience extension ─────────────────────────────────────────
+/** Last segment of an OkIO path. */
 private val okio.Path.filename: String get() = segments.last()

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/OkioGraphBulkExporter.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/OkioGraphBulkExporter.kt
@@ -14,18 +14,21 @@ import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.okio.tink.DEFAULT_DAEAD_CHUNK_SIZE
+import io.bluetape4k.tink.daead.TinkDeterministicAead
+import okio.BufferedSink
 import okio.FileSystem
 import java.io.IOException
 
 /**
- * OkIO 기반 동기 벌크 익스포터.
+ * Synchronous graph bulk exporter backed by OkIO sources and sinks.
  *
- * 포맷은 호출자가 [GraphIoFormat]으로 명시적으로 지정한다. 확장자 기반 스니핑은 지원하지 않는다.
+ * The caller must pass [GraphIoFormat] explicitly. File-extension sniffing is intentionally unsupported.
  *
- * ### CSV 제약
- * CSV 포맷은 정점/간선 파일을 분리해야 하므로, [OkioGraphExportSink.PathSink]만 지원한다.
- * 파일 경로 `{stem}` 기준으로 `{stem}_vertices.csv` 와 `{stem}_edges.csv` 에 쓴다.
- * SinkBased/OutputStreamBased + CSV 조합은 [UnsupportedOperationException]을 던진다.
+ * ### CSV constraint
+ * CSV requires separate vertex and edge files, so this facade supports CSV only for
+ * [OkioGraphExportSink.PathSink]. The target stem produces `{stem}_vertices.csv` and `{stem}_edges.csv`.
+ * Stream-backed sinks throw [UnsupportedOperationException].
  */
 class OkioGraphBulkExporter(
     private val csvExporter: CsvGraphBulkExporter = CsvGraphBulkExporter(),
@@ -37,7 +40,7 @@ class OkioGraphBulkExporter(
     companion object : KLogging()
 
     /**
-     * OkIO 싱크로 그래프를 동기 익스포트한다. 포맷 기본값: NDJSON_JACKSON3.
+     * Exports a graph to an OkIO sink using [GraphIoFormat.NDJSON_JACKSON3].
      */
     override fun exportGraph(
         sink: OkioGraphExportSink,
@@ -46,11 +49,11 @@ class OkioGraphBulkExporter(
     ): GraphExportReport = exportGraph(sink, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
     /**
-     * 포맷을 명시적으로 지정하여 익스포트한다.
+     * Exports a graph to an OkIO sink using the explicit [format].
      *
-     * @param format 익스포트 포맷. 확장자 기반 추론 없음 — 호출자가 반드시 지정.
-     * @throws IOException I/O 오류 시
-     * @throws UnsupportedOperationException CSV + 스트림 기반 싱크 조합 시
+     * @param format export format; no extension-based inference is performed
+     * @throws IOException when an I/O error occurs
+     * @throws UnsupportedOperationException when CSV is used with a stream-backed sink
      */
     @Throws(IOException::class)
     fun exportGraph(
@@ -74,9 +77,57 @@ class OkioGraphBulkExporter(
         }
     }
 
-    // ─── 내부 헬퍼 ─────────────────────────────────────────────────────────────
+    /**
+     * Exports a single-stream graph format through DAEAD chunk encryption.
+     *
+     * CSV is intentionally unsupported because it is a paired-file format. Use the low-level
+     * [GraphIoOkioPaths.openDaeadEncryptedSink] helpers directly for custom CSV file pairs.
+     *
+     * @throws IOException I/O or encryption failure
+     * @throws UnsupportedOperationException when [format] is [GraphIoFormat.CSV]
+     */
+    @Throws(IOException::class)
+    fun exportGraphDaead(
+        sink: OkioGraphExportSink,
+        format: GraphIoFormat,
+        daead: TinkDeterministicAead,
+        operations: GraphOperations,
+        options: GraphExportOptions = GraphExportOptions(),
+        chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+        associatedData: ByteArray = ByteArray(0),
+    ): GraphExportReport {
+        requireSingleStreamFormat(format)
+        log.debug { "Starting OkIO DAEAD export: format=$format, sink=${describeSink(sink)}" }
+        return GraphIoOkioPaths.openDaeadEncryptedSink(sink, daead, chunkSize, associatedData).use { bs ->
+            exportSingleStream(bs, format, operations, options)
+        }
+    }
 
-    /** 단일 스트림 익스포트 — OkIO sink를 OutputStream으로 변환하여 [block]에 전달한다. */
+    /**
+     * Exports a single-stream graph format using compress-then-encrypt GZip + DAEAD chunk encryption.
+     *
+     * The inverse import path is [OkioGraphBulkImporter.importGraphDaeadGzip].
+     */
+    @Throws(IOException::class)
+    fun exportGraphGzipDaead(
+        sink: OkioGraphExportSink,
+        format: GraphIoFormat,
+        daead: TinkDeterministicAead,
+        operations: GraphOperations,
+        options: GraphExportOptions = GraphExportOptions(),
+        chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
+        associatedData: ByteArray = ByteArray(0),
+    ): GraphExportReport {
+        requireSingleStreamFormat(format)
+        log.debug { "Starting OkIO gzip+DAEAD export: format=$format, sink=${describeSink(sink)}" }
+        return GraphIoOkioPaths.openGzipDaeadEncryptedSink(sink, daead, chunkSize, associatedData).use { bs ->
+            exportSingleStream(bs, format, operations, options)
+        }
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────────────
+
+    /** Exports a single-stream format after adapting the OkIO sink to an output stream. */
     private inline fun exportSingleStream(
         sink: OkioGraphExportSink,
         block: (java.io.OutputStream) -> GraphExportReport,
@@ -86,11 +137,28 @@ class OkioGraphBulkExporter(
         }
     }
 
+    private fun exportSingleStream(
+        sink: BufferedSink,
+        format: GraphIoFormat,
+        operations: GraphOperations,
+        options: GraphExportOptions,
+    ): GraphExportReport =
+        sink.asClosingOutputStream().use { os ->
+            when (format) {
+                GraphIoFormat.NDJSON_JACKSON2 ->
+                    jackson2Exporter.exportGraph(GraphExportSink.OutputStreamSink(os, closeOutput = false), operations, options)
+                GraphIoFormat.NDJSON_JACKSON3 ->
+                    jackson3Exporter.exportGraph(GraphExportSink.OutputStreamSink(os, closeOutput = false), operations, options)
+                GraphIoFormat.GRAPHML ->
+                    graphmlExporter.exportGraph(GraphExportSink.OutputStreamSink(os, closeOutput = false), operations, options)
+                GraphIoFormat.CSV -> unsupportedCsvEncrypted()
+            }
+        }
+
     /**
-     * CSV 익스포트: PathSink 기준으로 `{stem}_vertices.csv` + `{stem}_edges.csv` 파생.
+     * Exports CSV by deriving `{stem}_vertices.csv` and `{stem}_edges.csv` from a [OkioGraphExportSink.PathSink].
      *
-     * CSV 는 정점/간선 파일을 분리하는 포맷이므로 PathSink 만 지원한다.
-     * SinkBased/OutputStreamBased 는 [UnsupportedOperationException] 을 던진다.
+     * CSV is a paired-file format, so stream-backed sinks throw [UnsupportedOperationException].
      */
     private fun exportCsv(
         sink: OkioGraphExportSink,
@@ -100,9 +168,9 @@ class OkioGraphBulkExporter(
         return when (sink) {
             is OkioGraphExportSink.PathSink -> {
                 require(sink.fileSystem == FileSystem.SYSTEM) {
-                    "CSV export은 시스템 파일시스템(FileSystem.SYSTEM)만 지원합니다. " +
-                        "커스텀 FileSystem(FakeFileSystem 등)을 사용하려면 CsvGraphBulkExporter를 직접 사용하세요. " +
-                        "제공된 FileSystem: ${sink.fileSystem}"
+                    "CSV export supports only FileSystem.SYSTEM. " +
+                        "Use CsvGraphBulkExporter directly for custom FileSystem instances. " +
+                        "Provided FileSystem: ${sink.fileSystem}"
                 }
                 val stem = sink.path.toString().removeSuffix(".csv")
                 val verticesSink = GraphExportSink.PathSink(java.nio.file.Paths.get("${stem}_vertices.csv"))
@@ -110,8 +178,8 @@ class OkioGraphBulkExporter(
                 csvExporter.exportGraph(CsvGraphExportSink(verticesSink, edgesSink), operations, options)
             }
             else -> throw UnsupportedOperationException(
-                "CSV 포맷은 두 파일(vertices/edges)이 필요하므로 PathSink 만 지원합니다. " +
-                    "스트림 기반 싱크에서는 CsvGraphBulkExporter 를 직접 사용하세요."
+                "CSV requires two files for vertices and edges, so OkioGraphBulkExporter supports only PathSink. " +
+                    "Use CsvGraphBulkExporter directly for stream-backed sinks."
             )
         }
     }
@@ -121,4 +189,15 @@ class OkioGraphBulkExporter(
         is OkioGraphExportSink.SinkBased -> "<Sink>"
         is OkioGraphExportSink.OutputStreamBased -> "<OutputStream>"
     }
+
+    private fun requireSingleStreamFormat(format: GraphIoFormat) {
+        if (format == GraphIoFormat.CSV) {
+            unsupportedCsvEncrypted()
+        }
+    }
+
+    private fun unsupportedCsvEncrypted(): Nothing =
+        throw UnsupportedOperationException(
+            "CSV is a paired-file format. Use low-level DAEAD helpers directly for custom CSV file pairs."
+        )
 }

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/OkioGraphBulkImporter.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/OkioGraphBulkImporter.kt
@@ -14,23 +14,26 @@ import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.okio.tink.DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH
+import io.bluetape4k.tink.daead.TinkDeterministicAead
+import okio.BufferedSource
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.io.IOException
 
 /**
- * OkIO 기반 동기 벌크 임포터.
+ * Synchronous graph bulk importer backed by OkIO sources.
  *
- * 포맷은 호출자가 [GraphIoFormat]으로 명시적으로 지정한다. 확장자 기반 스니핑은 지원하지 않는다.
+ * The caller must pass [GraphIoFormat] explicitly. File-extension sniffing is intentionally unsupported.
  *
- * ### CSV 제약
- * CSV 포맷은 정점/간선 파일을 분리해야 하므로, [OkioGraphImportSource.PathSource]만 지원한다.
- * 파일 경로 `{stem}` 기준으로 `{stem}_vertices.csv` 와 `{stem}_edges.csv` 를 자동으로 파생한다.
- * SourceBased/InputStreamBased + CSV 조합은 [UnsupportedOperationException]을 던진다.
+ * ### CSV constraint
+ * CSV requires separate vertex and edge files, so this facade supports CSV only for
+ * [OkioGraphImportSource.PathSource]. The source stem derives `{stem}_vertices.csv` and `{stem}_edges.csv`.
+ * Stream-backed sources throw [UnsupportedOperationException].
  *
- * ### 위임 구조
- * 각 포맷별 기존 BulkImporter (CSV/Jackson2/Jackson3/GraphML) 에게 InputStream 으로 위임한다.
- * OkIO 의 이점(압축 체이닝, FileSystem 추상화)은 [GraphIoOkioPaths]에서 적용된다.
+ * ### Delegation
+ * Format-specific importers for CSV, Jackson 2, Jackson 3, and GraphML receive an adapted input stream.
+ * OkIO-specific behavior such as compression chaining and [okio.FileSystem] support lives in [GraphIoOkioPaths].
  */
 class OkioGraphBulkImporter(
     private val csvImporter: CsvGraphBulkImporter = CsvGraphBulkImporter(),
@@ -42,13 +45,13 @@ class OkioGraphBulkImporter(
     companion object : KLogging()
 
     /**
-     * OkIO 소스로부터 [format] 포맷으로 그래프를 동기 임포트한다.
+     * Imports a graph from an OkIO source using [GraphIoFormat.NDJSON_JACKSON3].
      *
-     * @param source OkIO 기반 임포트 소스
-     * @param operations 임포트 대상 그래프 API
-     * @param options 중복/미존재 엔드포인트 정책, 기본 레이블, 배치 크기 등
-     * @throws IOException I/O 오류 시
-     * @throws UnsupportedOperationException CSV + 스트림 기반 소스 조합 시
+     * @param source OkIO import source
+     * @param operations target graph operations
+     * @param options duplicate handling, missing endpoint handling, default labels, and batch size
+     * @throws IOException when an I/O error occurs
+     * @throws UnsupportedOperationException when CSV is used with a stream-backed source
      */
     override fun importGraph(
         source: OkioGraphImportSource,
@@ -57,9 +60,9 @@ class OkioGraphBulkImporter(
     ): GraphImportReport = importGraph(source, GraphIoFormat.NDJSON_JACKSON3, operations, options)
 
     /**
-     * 포맷을 명시적으로 지정하여 임포트한다.
+     * Imports a graph from an OkIO source using the explicit [format].
      *
-     * @param format 임포트 포맷. 확장자 기반 추론 없음 — 호출자가 반드시 지정.
+     * @param format import format; no extension-based inference is performed
      */
     @Throws(IOException::class)
     fun importGraph(
@@ -83,9 +86,61 @@ class OkioGraphBulkImporter(
         }
     }
 
-    // ─── 내부 헬퍼 ─────────────────────────────────────────────────────────────
+    /**
+     * Imports a single-stream graph format through DAEAD chunk decryption.
+     *
+     * CSV is intentionally unsupported because it is a paired-file format. Use low-level DAEAD helpers directly
+     * for custom CSV file pairs.
+     */
+    @Throws(IOException::class)
+    fun importGraphDaead(
+        source: OkioGraphImportSource,
+        format: GraphIoFormat,
+        daead: TinkDeterministicAead,
+        operations: GraphOperations,
+        options: GraphImportOptions = GraphImportOptions(),
+        associatedData: ByteArray = ByteArray(0),
+        maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
+    ): GraphImportReport {
+        requireSingleStreamFormat(format)
+        log.debug { "Starting OkIO DAEAD import: format=$format, source=${describeSource(source)}" }
+        return GraphIoOkioPaths.openDaeadDecryptedSource(source, daead, associatedData, maxCiphertextLength).use { bs ->
+            importSingleStream(bs, format, operations, options)
+        }
+    }
 
-    /** 단일 스트림 임포트 — OkIO source를 InputStream으로 변환하여 [block]에 전달한다. */
+    /**
+     * Imports a single-stream graph format using decrypt-then-inflate DAEAD chunk + GZip source.
+     *
+     * The input must have been written by [OkioGraphBulkExporter.exportGraphGzipDaead].
+     */
+    @Throws(IOException::class)
+    fun importGraphDaeadGzip(
+        source: OkioGraphImportSource,
+        format: GraphIoFormat,
+        daead: TinkDeterministicAead,
+        operations: GraphOperations,
+        options: GraphImportOptions = GraphImportOptions(),
+        associatedData: ByteArray = ByteArray(0),
+        maxCiphertextLength: Long = DEFAULT_DAEAD_MAX_CIPHERTEXT_LENGTH,
+        maxDecompressedBytes: Long = GraphIoOkioPaths.DEFAULT_MAX_DECOMPRESSED_BYTES,
+    ): GraphImportReport {
+        requireSingleStreamFormat(format)
+        log.debug { "Starting OkIO DAEAD+gzip import: format=$format, source=${describeSource(source)}" }
+        return GraphIoOkioPaths.openDaeadDecryptedGzipSource(
+            source = source,
+            daead = daead,
+            associatedData = associatedData,
+            maxCiphertextLength = maxCiphertextLength,
+            maxDecompressedBytes = maxDecompressedBytes,
+        ).use { bs ->
+            importSingleStream(bs, format, operations, options)
+        }
+    }
+
+    // ─── Internal helpers ────────────────────────────────────────────────────
+
+    /** Imports a single-stream format after adapting the OkIO source to an input stream. */
     private inline fun importSingleStream(
         source: OkioGraphImportSource,
         block: (java.io.InputStream) -> GraphImportReport,
@@ -95,11 +150,28 @@ class OkioGraphBulkImporter(
         }
     }
 
+    private fun importSingleStream(
+        source: BufferedSource,
+        format: GraphIoFormat,
+        operations: GraphOperations,
+        options: GraphImportOptions,
+    ): GraphImportReport =
+        source.toInputStream().use { is_ ->
+            when (format) {
+                GraphIoFormat.NDJSON_JACKSON2 ->
+                    jackson2Importer.importGraph(GraphImportSource.InputStreamSource(is_, closeInput = false), operations, options)
+                GraphIoFormat.NDJSON_JACKSON3 ->
+                    jackson3Importer.importGraph(GraphImportSource.InputStreamSource(is_, closeInput = false), operations, options)
+                GraphIoFormat.GRAPHML ->
+                    graphmlImporter.importGraph(GraphImportSource.InputStreamSource(is_, closeInput = false), operations, options)
+                GraphIoFormat.CSV -> unsupportedCsvEncrypted()
+            }
+        }
+
     /**
-     * CSV 임포트: PathSource 기준으로 `{stem}_vertices.csv` + `{stem}_edges.csv` 파생.
+     * Imports CSV by deriving `{stem}_vertices.csv` and `{stem}_edges.csv` from a [OkioGraphImportSource.PathSource].
      *
-     * CSV 는 정점/간선 파일을 분리하는 포맷이므로 PathSource 만 지원한다.
-     * SourceBased/InputStreamBased 는 [UnsupportedOperationException] 을 던진다.
+     * CSV is a paired-file format, so stream-backed sources throw [UnsupportedOperationException].
      */
     private fun importCsv(
         source: OkioGraphImportSource,
@@ -109,9 +181,9 @@ class OkioGraphBulkImporter(
         return when (source) {
             is OkioGraphImportSource.PathSource -> {
                 require(source.fileSystem == FileSystem.SYSTEM) {
-                    "CSV import은 시스템 파일시스템(FileSystem.SYSTEM)만 지원합니다. " +
-                        "커스텀 FileSystem(FakeFileSystem 등)을 사용하려면 CsvGraphBulkImporter를 직접 사용하세요. " +
-                        "제공된 FileSystem: ${source.fileSystem}"
+                    "CSV import supports only FileSystem.SYSTEM. " +
+                        "Use CsvGraphBulkImporter directly for custom FileSystem instances. " +
+                        "Provided FileSystem: ${source.fileSystem}"
                 }
                 val stem = source.path.toString().removeSuffix(".csv")
                 val verticesPath = "${stem}_vertices.csv".toPath()
@@ -123,8 +195,8 @@ class OkioGraphBulkImporter(
                 csvImporter.importGraph(csvSource, operations, options)
             }
             else -> throw UnsupportedOperationException(
-                "CSV 포맷은 두 파일(vertices/edges)이 필요하므로 PathSource 만 지원합니다. " +
-                    "스트림 기반 소스에서는 CsvGraphBulkImporter 를 직접 사용하세요."
+                "CSV requires two files for vertices and edges, so OkioGraphBulkImporter supports only PathSource. " +
+                    "Use CsvGraphBulkImporter directly for stream-backed sources."
             )
         }
     }
@@ -134,4 +206,15 @@ class OkioGraphBulkImporter(
         is OkioGraphImportSource.SourceBased -> "<Source>"
         is OkioGraphImportSource.InputStreamBased -> "<InputStream>"
     }
+
+    private fun requireSingleStreamFormat(format: GraphIoFormat) {
+        if (format == GraphIoFormat.CSV) {
+            unsupportedCsvEncrypted()
+        }
+    }
+
+    private fun unsupportedCsvEncrypted(): Nothing =
+        throw UnsupportedOperationException(
+            "CSV is a paired-file format. Use low-level DAEAD helpers directly for custom CSV file pairs."
+        )
 }

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
@@ -3,11 +3,13 @@ package io.bluetape4k.graph.io.okio
 import okio.Buffer
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import io.bluetape4k.assertions.invoking
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.tink.daead.TinkDaeads
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.io.IOException
+import java.security.GeneralSecurityException
+import kotlin.test.assertFailsWith
 
 class GraphIoOkioPathsTest {
 
@@ -79,7 +81,9 @@ class GraphIoOkioPathsTest {
         val target = "/tmp/missing.txt".toPath()
         val sink = OkioGraphExportSink.PathSink(target, fakeFs, mustExist = true)
 
-        invoking { GraphIoOkioPaths.openSink(sink) } shouldThrow IllegalStateException::class
+        assertFailsWith<IllegalStateException> {
+            GraphIoOkioPaths.openSink(sink)
+        }
     }
 
     @Test
@@ -89,7 +93,9 @@ class GraphIoOkioPathsTest {
         fakeFs.write(target) { writeUtf8("x") }
         val sink = OkioGraphExportSink.PathSink(target, fakeFs, mustCreate = true)
 
-        invoking { GraphIoOkioPaths.openSink(sink) } shouldThrow IllegalStateException::class
+        assertFailsWith<IllegalStateException> {
+            GraphIoOkioPaths.openSink(sink)
+        }
     }
 
     @Test
@@ -108,7 +114,9 @@ class GraphIoOkioPathsTest {
         val target = "/nonexistent/out.txt".toPath()
         val sink = OkioGraphExportSink.PathSink(target, fakeFs, createParentDirectories = false)
 
-        invoking { GraphIoOkioPaths.openSink(sink) } shouldThrow Exception::class
+        assertFailsWith<Exception> {
+            GraphIoOkioPaths.openSink(sink)
+        }
     }
 
     // ─── openGzipSink / openGzipSource ────────────────────────────────────────
@@ -130,6 +138,75 @@ class GraphIoOkioPathsTest {
         result shouldBeEqualTo data
     }
 
+    // ─── DAEAD chunk encryption ─────────────────────────────────────────────
+
+    @Test
+    fun `DAEAD chunk round trip with FakeFileSystem`() {
+        ensureTmpDir()
+        val path = "/tmp/graph.enc".toPath()
+        val associatedData = "graph-okio".encodeToByteArray()
+        val data = "encrypted graph data\n".repeat(100)
+
+        GraphIoOkioPaths.openDaeadEncryptedSink(
+            sink = OkioGraphExportSink.PathSink(path, fakeFs),
+            daead = TinkDaeads.AES256_SIV,
+            associatedData = associatedData,
+        ).use { bs -> bs.writeUtf8(data) }
+
+        val ciphertext = fakeFs.read(path) { readByteArray() }
+        (ciphertext.contentEquals(data.encodeToByteArray())) shouldBeEqualTo false
+
+        val result = GraphIoOkioPaths.openDaeadDecryptedSource(
+            source = OkioGraphImportSource.PathSource(path, fakeFs),
+            daead = TinkDaeads.AES256_SIV,
+            associatedData = associatedData,
+        ).use { bs -> bs.readUtf8() }
+
+        result shouldBeEqualTo data
+    }
+
+    @Test
+    fun `gzip DAEAD chunk round trip with FakeFileSystem`() {
+        ensureTmpDir()
+        val path = "/tmp/graph.ndjson.gz.enc".toPath()
+        val associatedData = "gzip-daead".encodeToByteArray()
+        val data = """{"id":1,"label":"Person"}""" + "\n"
+
+        GraphIoOkioPaths.openGzipDaeadEncryptedSink(
+            sink = OkioGraphExportSink.PathSink(path, fakeFs),
+            daead = TinkDaeads.AES256_SIV,
+            associatedData = associatedData,
+        ).use { bs -> bs.writeUtf8(data.repeat(100)) }
+
+        val result = GraphIoOkioPaths.openDaeadDecryptedGzipSource(
+            source = OkioGraphImportSource.PathSource(path, fakeFs),
+            daead = TinkDaeads.AES256_SIV,
+            associatedData = associatedData,
+        ).use { bs -> bs.readUtf8() }
+
+        result shouldBeEqualTo data.repeat(100)
+    }
+
+    @Test
+    fun `DAEAD decryption fails with wrong associated data`() {
+        ensureTmpDir()
+        val path = "/tmp/graph-wrong-ad.enc".toPath()
+
+        GraphIoOkioPaths.openDaeadEncryptedSink(
+            sink = OkioGraphExportSink.PathSink(path, fakeFs),
+            daead = TinkDaeads.AES256_SIV,
+            associatedData = "right".encodeToByteArray(),
+        ).use { bs -> bs.writeUtf8("secret") }
+
+        assertFailsWith<GeneralSecurityException> {
+            GraphIoOkioPaths.openDaeadDecryptedSource(
+                source = OkioGraphImportSource.PathSource(path, fakeFs),
+                daead = TinkDaeads.AES256_SIV,
+                associatedData = "wrong".encodeToByteArray(),
+            ).use { bs -> bs.readUtf8() }
+        }
+    }
+
     // ─── BombGuardSource ─────────────────────────────────────────────────────
 
     @Test
@@ -142,13 +219,13 @@ class GraphIoOkioPathsTest {
             OkioGraphExportSink.PathSink(path, fakeFs)
         ).use { bs -> bs.writeUtf8(largeData) }
 
-        invoking {
+        assertFailsWith<IOException> {
             GraphIoOkioPaths.openDecompressedSource(
                 source = GraphIoOkioPaths.openSource(OkioGraphImportSource.PathSource(path, fakeFs)),
                 compressor = Compressor.GZIP,
                 maxDecompressedBytes = 100L,
             ).use { it.readUtf8() }
-        } shouldThrow IOException::class
+        }
     }
 
     @Test

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/OkioRoundTripTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/OkioRoundTripTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.tink.daead.TinkDaeads
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -133,6 +134,66 @@ class OkioRoundTripTest {
             val isSource = OkioGraphImportSource.InputStreamBased(is_, ownsStream = false)
             importer.importGraph(isSource, GraphIoFormat.NDJSON_JACKSON3, target, GraphImportOptions())
         }
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 3L
+        report.edgesCreated shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `NDJSON Jackson3 DAEAD round trip`() {
+        val path = "/graph.ndjson.enc".toPath()
+        val associatedData = "graph-okio-daead".encodeToByteArray()
+        val src = buildSourceGraph()
+
+        exporter.exportGraphDaead(
+            sink = OkioGraphExportSink.PathSink(path, fakeFs),
+            format = GraphIoFormat.NDJSON_JACKSON3,
+            daead = TinkDaeads.AES256_SIV,
+            operations = src,
+            options = exportOptions,
+            associatedData = associatedData,
+        ).status shouldBeEqualTo GraphIoStatus.COMPLETED
+
+        val target = TinkerGraphOperations()
+        val report = importer.importGraphDaead(
+            source = OkioGraphImportSource.PathSource(path, fakeFs),
+            format = GraphIoFormat.NDJSON_JACKSON3,
+            daead = TinkDaeads.AES256_SIV,
+            operations = target,
+            options = GraphImportOptions(),
+            associatedData = associatedData,
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 3L
+        report.edgesCreated shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `NDJSON Jackson3 gzip DAEAD round trip`() {
+        val path = "/graph.ndjson.gz.enc".toPath()
+        val associatedData = "graph-okio-gzip-daead".encodeToByteArray()
+        val src = buildSourceGraph()
+
+        exporter.exportGraphGzipDaead(
+            sink = OkioGraphExportSink.PathSink(path, fakeFs),
+            format = GraphIoFormat.NDJSON_JACKSON3,
+            daead = TinkDaeads.AES256_SIV,
+            operations = src,
+            options = exportOptions,
+            associatedData = associatedData,
+        ).status shouldBeEqualTo GraphIoStatus.COMPLETED
+
+        val target = TinkerGraphOperations()
+        val report = importer.importGraphDaeadGzip(
+            source = OkioGraphImportSource.PathSource(path, fakeFs),
+            format = GraphIoFormat.NDJSON_JACKSON3,
+            daead = TinkDaeads.AES256_SIV,
+            operations = target,
+            options = GraphImportOptions(),
+            associatedData = associatedData,
+        )
 
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 3L


### PR DESCRIPTION
## Summary

- Add DAEAD chunk encryption and GZip+DAEAD chaining helpers to `GraphIoOkioPaths`.
- Add synchronous single-stream encrypted import/export methods for NDJSON and GraphML through `OkioGraphBulkExporter` and `OkioGraphBulkImporter`.
- Document the encrypted graph I/O API in `README.md` and `README.ko.md`, and capture the #49 design/plan/lesson artifacts.
- Pin the CI gitleaks installer to a deterministic release URL after the previous latest-download path returned 404 in GitHub Actions.

## Design Notes

- Reuses the existing `bluetape4k-okio` deterministic DAEAD chunk format instead of introducing Tink Streaming AEAD.
- High-level encrypted helpers intentionally reject CSV because CSV is a paired-file format; callers can combine low-level DAEAD source/sink helpers for a custom encrypted CSV file-pair layout.

## Verification

- `./gradlew :graph-okio:compileKotlin :graph-okio:compileTestKotlin --no-daemon`
- `./gradlew :graph-okio:test --tests 'io.bluetape4k.graph.io.okio.GraphIoOkioPathsTest' --tests 'io.bluetape4k.graph.io.okio.OkioRoundTripTest' --no-daemon`
- `./gradlew :graph-okio:test --no-daemon` (96 passing)
- `./gradlew :graph-okio:dependencyInsight --dependency bluetape4k-okio --configuration compileClasspath --no-daemon`
- `actionlint .github/workflows/ci.yml`
- `gitleaks detect --no-banner --redact --no-git --source . --config .gitleaks.toml`
- pinned gitleaks tarball path check: `tar -tzf ... | rg '^gitleaks$'`
- `git diff --check`
- Pattern checks: no `invoking` / `shouldThrow` / `assertThrows` in changed OkIO tests; no Korean text remains in changed public main-source files.

Closes #49
