### PR TITLE
Fix graph-okio DAEAD review gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,12 @@ jobs:
       - name: Install gitleaks
         run: |
           GITLEAKS_VERSION=8.30.1
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz gitleaks
+          GITLEAKS_ARCHIVE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          GITLEAKS_CHECKSUMS="gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          curl -sSfLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_ARCHIVE}"
+          curl -sSfLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_CHECKSUMS}"
+          grep " ${GITLEAKS_ARCHIVE}$" "${GITLEAKS_CHECKSUMS}" | sha256sum -c -
+          tar -xzf "${GITLEAKS_ARCHIVE}" gitleaks
           sudo mv gitleaks /usr/local/bin/
 
       - name: Run gitleaks

--- a/docs/lessons/2026-05-13-issue-49-daead-review-followup.md
+++ b/docs/lessons/2026-05-13-issue-49-daead-review-followup.md
@@ -1,0 +1,39 @@
+# Issue #49 DAEAD Review Follow-up
+
+- Date: 2026-05-13
+- Scope: `graph-okio`, CI gitleaks installer
+
+## Context
+
+PR #114 was merged after adding graph-okio DAEAD chunk encryption, but the follow-up 6-tier Codex + Claude review found two P1 gaps:
+
+- touched tests used `kotlin.test.assertFailsWith` instead of `io.bluetape4k.assertions.assertFailsWith`
+- the spec/plan promised a truncated ciphertext negative test, but only wrong associated data was covered
+
+The same review also found a missing CSV unsupported-contract test and a CI supply-chain hardening gap for the gitleaks tarball download.
+
+## Decision
+
+Fix the review gaps in a narrow follow-up branch:
+
+- migrate touched exception assertions to bluetape4k assertions
+- add a truncated DAEAD ciphertext failure test
+- add DAEAD/gzip+DAEAD CSV rejection tests for export and import
+- verify the pinned gitleaks archive against the upstream checksum file before installing it
+
+## Outcome
+
+The P1 review gaps were closed without changing production DAEAD behavior.
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml`
+- `git diff --check`
+- gitleaks checksum script smoke test: `gitleaks_8.30.1_linux_x64.tar.gz: OK`
+- `./gradlew :graph-okio:compileKotlin :graph-okio:compileTestKotlin --no-daemon`
+- `./gradlew :graph-okio:test --tests 'io.bluetape4k.graph.io.okio.GraphIoOkioPathsTest' --tests 'io.bluetape4k.graph.io.okio.OkioRoundTripTest' --no-daemon`
+- `./gradlew :graph-okio:test --no-daemon` -> 101 passing
+
+## Future Guard
+
+When a spec/plan explicitly accepts a negative-path test, grep the final test diff for that exact failure mode before merge. For touched tests, grep `kotlin.test.assertFailsWith`, `assertThrows`, `invoking`, and `shouldThrow` before review sign-off.

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
@@ -3,13 +3,14 @@ package io.bluetape4k.graph.io.okio
 import okio.Buffer
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.tink.daead.TinkDaeads
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import java.io.EOFException
 import java.io.IOException
 import java.security.GeneralSecurityException
-import kotlin.test.assertFailsWith
 
 class GraphIoOkioPathsTest {
 
@@ -203,6 +204,32 @@ class GraphIoOkioPathsTest {
                 source = OkioGraphImportSource.PathSource(path, fakeFs),
                 daead = TinkDaeads.AES256_SIV,
                 associatedData = "wrong".encodeToByteArray(),
+            ).use { bs -> bs.readUtf8() }
+        }
+    }
+
+    @Test
+    fun `DAEAD decryption fails with truncated ciphertext`() {
+        ensureTmpDir()
+        val path = "/tmp/graph-truncated.enc".toPath()
+        val associatedData = "truncate-check".encodeToByteArray()
+
+        GraphIoOkioPaths.openDaeadEncryptedSink(
+            sink = OkioGraphExportSink.PathSink(path, fakeFs),
+            daead = TinkDaeads.AES256_SIV,
+            associatedData = associatedData,
+        ).use { bs -> bs.writeUtf8("secret payload") }
+
+        val ciphertext = fakeFs.read(path) { readByteArray() }
+        fakeFs.write(path) {
+            write(ciphertext, offset = 0, byteCount = ciphertext.size - 1)
+        }
+
+        assertFailsWith<EOFException> {
+            GraphIoOkioPaths.openDaeadDecryptedSource(
+                source = OkioGraphImportSource.PathSource(path, fakeFs),
+                daead = TinkDaeads.AES256_SIV,
+                associatedData = associatedData,
             ).use { bs -> bs.readUtf8() }
         }
     }

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/OkioRoundTripTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/OkioRoundTripTest.kt
@@ -5,14 +5,13 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.tink.daead.TinkDaeads
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
 
 class OkioRoundTripTest {
 
@@ -198,5 +197,53 @@ class OkioRoundTripTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 3L
         report.edgesCreated shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `DAEAD export rejects CSV paired format`() {
+        assertFailsWith<UnsupportedOperationException> {
+            exporter.exportGraphDaead(
+                sink = OkioGraphExportSink.PathSink("/graph.enc".toPath(), fakeFs),
+                format = GraphIoFormat.CSV,
+                daead = TinkDaeads.AES256_SIV,
+                operations = buildSourceGraph(),
+            )
+        }
+    }
+
+    @Test
+    fun `gzip DAEAD export rejects CSV paired format`() {
+        assertFailsWith<UnsupportedOperationException> {
+            exporter.exportGraphGzipDaead(
+                sink = OkioGraphExportSink.PathSink("/graph.gz.enc".toPath(), fakeFs),
+                format = GraphIoFormat.CSV,
+                daead = TinkDaeads.AES256_SIV,
+                operations = buildSourceGraph(),
+            )
+        }
+    }
+
+    @Test
+    fun `DAEAD import rejects CSV paired format`() {
+        assertFailsWith<UnsupportedOperationException> {
+            importer.importGraphDaead(
+                source = OkioGraphImportSource.PathSource("/graph.enc".toPath(), fakeFs),
+                format = GraphIoFormat.CSV,
+                daead = TinkDaeads.AES256_SIV,
+                operations = TinkerGraphOperations(),
+            )
+        }
+    }
+
+    @Test
+    fun `gzip DAEAD import rejects CSV paired format`() {
+        assertFailsWith<UnsupportedOperationException> {
+            importer.importGraphDaeadGzip(
+                source = OkioGraphImportSource.PathSource("/graph.gz.enc".toPath(), fakeFs),
+                format = GraphIoFormat.CSV,
+                daead = TinkDaeads.AES256_SIV,
+                operations = TinkerGraphOperations(),
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace touched `kotlin.test.assertFailsWith` usage with `io.bluetape4k.assertions.assertFailsWith` in graph-okio tests.
- Add the missing truncated DAEAD ciphertext negative test promised by the #49 spec/plan.
- Add CSV rejection coverage for DAEAD and gzip+DAEAD high-level import/export helpers.
- Verify the pinned gitleaks archive against the upstream checksum file before installing it in CI.

## Review Follow-up

This closes the P1 findings from the six-tier Codex + Claude follow-up review of PR #114:

- P1: touched tests used the wrong exception assertion API.
- P1: truncated ciphertext negative coverage was missing even though the spec/plan accepted it.

P0/P1 after this patch: 0 known.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `gitleaks detect --no-banner --redact --no-git --source . --config .gitleaks.toml`
- gitleaks checksum smoke test: `gitleaks_8.30.1_linux_x64.tar.gz: OK`
- IntelliJ index MCP `ide_diagnostics` on:
  - `GraphIoOkioPathsTest.kt` -> `problemCount=0`
  - `OkioRoundTripTest.kt` -> `problemCount=0`
- `./gradlew :graph-okio:compileKotlin :graph-okio:compileTestKotlin --no-daemon`
- `./gradlew :graph-okio:test --tests 'io.bluetape4k.graph.io.okio.GraphIoOkioPathsTest' --tests 'io.bluetape4k.graph.io.okio.OkioRoundTripTest' --no-daemon` -> 25 passing
- `./gradlew :graph-okio:test --no-daemon` -> 101 passing
