### PR TITLE
docs: align license text on MIT

### DIFF
--- a/graph/graph-neo4j/README.md
+++ b/graph/graph-neo4j/README.md
@@ -305,4 +305,4 @@ scores.collect { println(it) }
 
 ## License
 
-Apache License 2.0
+MIT License


### PR DESCRIPTION
## Summary
- normalize README license references to MIT License
- align root LICENSE files on MIT where needed
- remove stale Apache license mentions from README/LICENSE artifacts

## Verification
- `rg -n -i "Apache License|Apache-2\\.0|Apache 2\\.0|License-Apache" --glob 'README*.md' --glob 'LICENSE*' .` returned no matches from the workspace root
- all immediate workspace repositories' root `LICENSE` files start with `MIT License`

## Notes
- Documentation/license text only; Gradle builds were not run.
