### PR TITLE
docs: 0.3.0 docs polish — graph-ktor KDoc, CHANGELOG finalization, graph-okio README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 0.3.0-SNAPSHOT
+## [Unreleased]
+
+---
+
+## [0.3.0] - 2026-05-16
 
 ### Added
 
@@ -14,46 +18,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Domain example modules**: Added fraud detection, recommendation, and knowledge graph examples on top of the stable graph API and existing backend test pattern ([#10](https://github.com/bluetape4k/bluetape4k-graph/issues/10), [PR #110](https://github.com/bluetape4k/bluetape4k-graph/pull/110)).
 - **Public API KDoc examples**: Added callable English Kotlin examples across public APIs ([#16](https://github.com/bluetape4k/bluetape4k-graph/issues/16), [PR #109](https://github.com/bluetape4k/bluetape4k-graph/pull/109)).
 - **`graph-okio` DAEAD streaming**: Added DAEAD chunk encryption/decryption for OkIO graph streams, including gzip+DAEAD chaining and negative-path tests for wrong associated data and truncated ciphertext ([#49](https://github.com/bluetape4k/bluetape4k-graph/issues/49), [PR #114](https://github.com/bluetape4k/bluetape4k-graph/pull/114), [PR #115](https://github.com/bluetape4k/bluetape4k-graph/pull/115)).
-- **`graph-ktor`**: Ktor 3.x `GraphPlugin` module과 TinkerGraph 기반 `ktor-graph-examples`를 추가했습니다. `Application`/`ApplicationCall` extension으로 `GraphOperations`와 `GraphSuspendOperations`에 접근하고, TinkerGraph/Neo4j/Memgraph/AGE/FalkorDB backend helper를 제공합니다 ([#96](https://github.com/bluetape4k/bluetape4k-graph/issues/96)).
-- **`graph-bom` README 문서**: BOM 사용법을 English/Korean README로 정리했습니다 ([PR #70](https://github.com/bluetape4k/bluetape4k-graph/pull/70)).
-- **`graph-okio`**: OkIO 기반 스트리밍 그래프 I/O 레이어를 추가했습니다. CSV/GraphML/Jackson 계열 I/O에 Source/Sink 기반 확장 지점을 제공합니다 ([PR #48](https://github.com/bluetape4k/bluetape4k-graph/pull/48)).
-- **Weighted graph support**: Dijkstra/A* shortest path 지원을 추가했습니다 ([PR #39](https://github.com/bluetape4k/bluetape4k-graph/pull/39)).
-- **`graph-core` 모델 빌더 유틸리티** (`graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/`)
-  - `graphElementIdOf(Any)`: 임의 타입에서 `GraphElementId` 생성 — `String`, `Long`, `Int`, `GraphElementId` 모두 안전하게 변환
-  - `graphVertexOf(Any, label, properties)`: id·label·프로퍼티 맵으로 `GraphVertex` 생성 유틸
-  - `graphPathOf(vertices, edges)` / `graphPathOf(vertices)`: `GraphPath` 빌더 오버로드
-  - `emptyGraphPath()`: 빈 경로 생성 (기존 `emptyGraphPathOf()` 대체)
-  - `GraphPath.toCycle()`: 경로를 `GraphCycle`로 변환하는 확장 메서드
-- **`graph-core` 모델 테스트 클래스 신규 추가** (`graph/graph-core/src/test/`)
-  - `GraphElementIdTest`: `graphElementIdOf` 4개 케이스 (이중 변환 방어 포함)
-  - `GraphVertexTest`: `graphVertexOf` 6개 케이스
-  - `GraphPathTest`: `graphPathOf` 8개 케이스 + `emptyGraphPath`
-  - `GraphCycleTest`: `toCycle()`, `length`, 동등 비교 7개 케이스
-- **`graph-core` README 모델 빌더 유틸리티 섹션** (`graph/graph-core/README.md`, `README.ko.md`)
-- **Transaction DSL first slice**: `GraphOperations.transaction { }` 확장과 capability contract를 추가하고 Neo4j, Memgraph, AGE, TinkerGraph 동기 백엔드에 1차 구현을 연결했습니다. suspend transaction capability도 동일 백엔드에 연결하고, FalkorDB는 중간 결과를 즉시 반환해야 하는 repository DSL 특성상 명시적 미지원으로 고정했습니다.
-- **`graph-core` capability docs**: `SchemaManager`, `GraphMergeOperations`, `GraphTransactionScope` / `GraphSuspendTransactionScope` 사용 예제를 root README, backend README, KDoc에 동기화했습니다.
+- **`graph-ktor`**: Added a Ktor 3.x `GraphPlugin` module and TinkerGraph-based `ktor-graph-examples`. `Application`/`ApplicationCall` extensions provide access to `GraphOperations` and `GraphSuspendOperations`, and backend helpers cover TinkerGraph, Neo4j, Memgraph, AGE, and FalkorDB ([#96](https://github.com/bluetape4k/bluetape4k-graph/issues/96)).
+- **`graph-bom` README**: Documented BOM usage in English and Korean READMEs ([PR #70](https://github.com/bluetape4k/bluetape4k-graph/pull/70)).
+- **`graph-okio`**: Added an OkIO-based streaming graph I/O layer with `Source`/`Sink` entry points for CSV, GraphML, and Jackson family formats ([PR #48](https://github.com/bluetape4k/bluetape4k-graph/pull/48)).
+- **Weighted graph support**: Added Dijkstra/A* shortest path APIs ([PR #39](https://github.com/bluetape4k/bluetape4k-graph/pull/39)).
+- **`graph-core` model builder utilities** (`graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/`)
+  - `graphElementIdOf(Any)`: creates a `GraphElementId` from any type — `String`, `Long`, `Int`, and `GraphElementId` all convert safely.
+  - `graphVertexOf(Any, label, properties)`: builder utility that creates a `GraphVertex` from an id, label, and property map.
+  - `graphPathOf(vertices, edges)` / `graphPathOf(vertices)`: `GraphPath` builder overloads.
+  - `emptyGraphPath()`: creates an empty path (replaces the former `emptyGraphPathOf()`).
+  - `GraphPath.toCycle()`: extension that converts a path to a `GraphCycle`.
+- **`graph-core` model test classes** (`graph/graph-core/src/test/`)
+  - `GraphElementIdTest`: 4 cases for `graphElementIdOf`, including double-conversion guard.
+  - `GraphVertexTest`: 6 cases for `graphVertexOf`.
+  - `GraphPathTest`: 8 cases for `graphPathOf` + `emptyGraphPath`.
+  - `GraphCycleTest`: 7 cases covering `toCycle()`, `length`, and equality.
+- **`graph-core` README — model builder utilities section** (`graph/graph-core/README.md`, `README.ko.md`).
+- **Transaction DSL first slice**: Added the `GraphOperations.transaction { }` extension and capability contract, wired to Neo4j, Memgraph, AGE, and TinkerGraph sync backends. The suspend transaction capability is wired to the same backends. FalkorDB is explicitly unsupported because its repository DSL must return intermediate results immediately.
+- **`graph-core` capability docs**: Synchronized `SchemaManager`, `GraphMergeOperations`, and `GraphTransactionScope` / `GraphSuspendTransactionScope` usage examples across the root README, backend READMEs, and KDoc.
 
 ### Fixed
 
-- **`graphElementIdOf(Any)` 이중 `toString()` 변환 버그**: `GraphElementId` 값을 다시 `graphElementIdOf`에 전달하면 `"GraphElementId(value=x)"` 문자열로 오염되던 문제 수정 — `is GraphElementId` 타입 체크로 조기 반환
-- `AStarRunner` 성능과 불변식 검증을 보강하고 관련 테스트/KDoc을 정리했습니다 ([PR #62](https://github.com/bluetape4k/bluetape4k-graph/pull/62)).
-- `FakeFileSystem` 동시 접근 시 발생하던 `ConcurrentModificationException`을 수정했습니다 ([PR #53](https://github.com/bluetape4k/bluetape4k-graph/pull/53)).
-- CI artifact 경로와 모듈별 Kover 리포트 경로를 현재 빌드 레이아웃에 맞게 수정했습니다 ([PR #55](https://github.com/bluetape4k/bluetape4k-graph/pull/55), [PR #56](https://github.com/bluetape4k/bluetape4k-graph/pull/56)).
+- **`graphElementIdOf(Any)` double-`toString()` conversion bug**: passing a `GraphElementId` value back into `graphElementIdOf` previously produced `"GraphElementId(value=x)"` string corruption. Fixed with an `is GraphElementId` early-return check.
+- Reinforced `AStarRunner` performance and invariant validation; cleaned up related tests and KDoc ([PR #62](https://github.com/bluetape4k/bluetape4k-graph/pull/62)).
+- Fixed `ConcurrentModificationException` on concurrent `FakeFileSystem` access ([PR #53](https://github.com/bluetape4k/bluetape4k-graph/pull/53)).
+- Fixed CI artifact paths and per-module Kover report paths to match the current build layout ([PR #55](https://github.com/bluetape4k/bluetape4k-graph/pull/55), [PR #56](https://github.com/bluetape4k/bluetape4k-graph/pull/56)).
 
 ### Changed
 
 - Refreshed `WIP.md`, `AGENTS.md`, and `CLAUDE.md` to reflect the current open issue queue, Java 21 runtime, version catalog dependencies, renamed Spring Boot module, graph-okio DAEAD support, examples workflow, and active module layout.
 - Renamed the Spring Boot integration from `graph-spring-boot4-starter` (`spring-boot4/graph-spring-boot4-starter`, package `io.bluetape4k.graph.spring.boot4`) to `graph-spring-boot` (`spring-boot/graph-spring-boot`, package `io.bluetape4k.graph.spring.boot`) to publish a stable version-neutral module contract ([#99](https://github.com/bluetape4k/bluetape4k-graph/issues/99)).
-- `graph-io-okio` Gradle project/artifact identity를 `graph-okio`로 변경했습니다 ([#76](https://github.com/bluetape4k/bluetape4k-graph/issues/76)).
+- Renamed `graph-io-okio` Gradle project/artifact to `graph-okio` ([#76](https://github.com/bluetape4k/bluetape4k-graph/issues/76)).
 - Gradle dependency declarations migrated from `buildSrc/Libs.kt` to Version Catalog (`gradle/libs.versions.toml`) ([PR #63](https://github.com/bluetape4k/bluetape4k-graph/pull/63)).
 - CI now uses paths-filter, Docker-specific jobs, and retry configuration for container-heavy workflows ([PR #68](https://github.com/bluetape4k/bluetape4k-graph/pull/68)).
 - Removed the `tanvd.kosogor` plugin from the build ([PR #57](https://github.com/bluetape4k/bluetape4k-graph/pull/57)).
-- `graph-io-core` test coverage was raised from 65% to 93% ([PR #58](https://github.com/bluetape4k/bluetape4k-graph/pull/58)).
-- `emptyGraphPathOf()` → `emptyGraphPath()` 이름 변경 (Kotlin 팩토리 함수 관례 준수)
-- `graphVertexOf(Any, label)` → `graphVertexOf(Any, label, properties)`: `properties` 파라미터 추가 및 `graphElementIdOf` 경유로 이중 변환 제거
-- `graphPathOf` 단일-arg 중복 오버로드 제거, 명시적 파라미터 오버로드만 유지
-- `AStarRunner` companion object 콜론 앞 공백 추가 (ktlint 규칙 준수)
-- 테스트 코드의 bluetape4k-assertions 의존성을 `bluetape4k-assertions`로 마이그레이션하고 Gradle 테스트 의존성을 교체했습니다. PR #69에서 `./gradlew compileTestKotlin --no-daemon` 성공으로 검증했으며, issue #66은 완료 처리했습니다.
+- `graph-io-core` test coverage raised from 65% to 93% ([PR #58](https://github.com/bluetape4k/bluetape4k-graph/pull/58)).
+- Renamed `emptyGraphPathOf()` → `emptyGraphPath()` to follow Kotlin factory function conventions.
+- `graphVertexOf(Any, label)` → `graphVertexOf(Any, label, properties)`: added `properties` parameter and eliminated the double-conversion path via `graphElementIdOf`.
+- Removed the single-arg duplicate `graphPathOf` overload; only explicit-parameter overloads remain.
+- Added missing space before colon in `AStarRunner` companion object to satisfy ktlint rules.
+- Migrated test-code assertions dependency to `bluetape4k-assertions` and replaced Gradle test dependencies accordingly. Verified with `./gradlew compileTestKotlin --no-daemon` in PR #69; issue #66 closed.
 
 ---
 

--- a/docs/lessons/2026-05-16-0.3.0-docs-polish.md
+++ b/docs/lessons/2026-05-16-0.3.0-docs-polish.md
@@ -1,0 +1,48 @@
+# 2026-05-16 — 0.3.0 Docs Polish: KDoc, CHANGELOG, README Localization
+
+## Context
+
+0.3.0 release preparation required three documentation tasks:
+
+- **#118** — `graph-io/okio` README was entirely Korean; needed English canonical + Korean locale.
+- **#121** — CHANGELOG `[Unreleased]` section had mixed Korean/English entries; needed finalization as `[0.3.0]`.
+- **#122** — `graph-ktor` public API KDoc and runtime messages were Korean; violates the contributor-facing English policy.
+
+## Decisions and Rationale
+
+### Language policy enforcement scope
+
+Applied the policy ("public/contributor-facing KDoc and runtime messages must be English") only to:
+- **New or meaningfully changed** public APIs
+- **Runtime log messages and exception messages** visible in production (these are never exempt)
+
+Historical CHANGELOG entries in `[0.2.0]` and `[0.1.0]` sections were left in Korean — the policy document explicitly exempts historical content from bulk rewrite.
+
+Language-switch anchor text (`[한국어](README.ko.md)`) in README headers is intentionally Korean; it is navigational UI, not documentation prose. Do not flag or change these.
+
+### README structure for graph-okio
+
+graph-okio covers multiple orthogonal concerns: stream abstraction, compression, encryption, virtual threads, coroutines, and FakeFileSystem testing. Chose a single canonical English `README.md` with:
+- Architecture overview → format matrix → core types (sealed interfaces, ownership policy) → usage patterns (sync/async/chaining/DAEAD/atomic) → performance tables → security → dependency block
+- Korean `README.ko.md` kept as a translation that tracks the English version.
+
+### CHANGELOG format
+
+Followed Keep-a-Changelog convention:
+- `## [Unreleased]` becomes a blank placeholder at the top.
+- Released version section: `## [0.3.0] - YYYY-MM-DD` with the date the release was finalized.
+- Translated entries verbatim (meaning-preserving, not paraphrased) from Korean to English.
+
+## Verification
+
+```
+./gradlew :graph-ktor:build :graph-okio:build -x test
+```
+
+Both modules compiled clean. No new runtime errors. KDoc syntax verified through compiler (any invalid `@param`/`@return` generates a warning).
+
+## Future Guidance
+
+- Run a KDoc language sweep before each release milestone. `rg '^\s*\*\s+[가-힣]' ktor/ graph-io/` catches Korean prose in KDoc blocks.
+- When translating CHANGELOG entries, commit the English translation alongside any new 0.x.0 entries to avoid accumulating Korean debt per release.
+- `graph-ktor` runtime log messages (started/stopped) should remain in `GraphPlugin.kt:startInterceptor`; if the logging library is swapped the messages travel with the code, not with a config file.

--- a/graph-io/okio/README.ko.md
+++ b/graph-io/okio/README.ko.md
@@ -1,4 +1,4 @@
-# graph-okio (한국어)
+# graph-okio
 
 [English](README.md) | [한국어](README.ko.md)
 

--- a/graph-io/okio/README.md
+++ b/graph-io/okio/README.md
@@ -2,30 +2,43 @@
 
 [English](README.md) | [한국어](README.ko.md)
 
-OkIO 기반 그래프 I/O 레이어. 기존 `graph-io-csv`, `graph-io-jackson2`, `graph-io-jackson3`, `graph-io-graphml` 모듈과 완벽하게 호환되면서 OkIO의 세그먼트 기반 스트리밍, 압축 체이닝, FileSystem 추상화를 제공한다.
+OkIO-based graph I/O layer. Fully compatible with the existing `graph-io-csv`,
+`graph-io-jackson2`, `graph-io-jackson3`, and `graph-io-graphml` modules while
+adding OkIO segment-based streaming, compression chaining, and `FileSystem`
+abstraction.
 
-## 지원 포맷
+## Why OkIO
 
-| 포맷 | `GraphIoFormat` | 설명 |
-|------|----------------|------|
-| CSV | `CSV` | 정점/간선 파일 분리 (`{stem}_vertices.csv` + `{stem}_edges.csv`) |
+| java.io approach | OkIO approach |
+|-----------------|---------------|
+| Loads entire file into heap | 64 KB segment streaming — heap-efficient |
+| Compression requires extra stream wrapping | Declarative chaining via `Compressors.Streaming.*` |
+| File paths only | Three entry points: `PathSource`, `BufferedSource`, `InputStream` |
+| No atomic writes | `PathSink(atomicWrite=true)` prevents partial-write corruption by default |
+| No `FakeFileSystem` | `okio-fakefilesystem` simplifies tests |
+
+## Supported Formats
+
+| Format | `GraphIoFormat` | Description |
+|--------|----------------|-------------|
+| CSV | `CSV` | Separate vertex/edge files (`{stem}_vertices.csv` + `{stem}_edges.csv`) |
 | NDJSON (Jackson 2) | `NDJSON_JACKSON2` | Newline-delimited JSON, Jackson 2.x |
 | NDJSON (Jackson 3) | `NDJSON_JACKSON3` | Newline-delimited JSON, Jackson 3.x |
-| GraphML | `GRAPHML` | XML/StAX 기반 그래프 교환 포맷 |
+| GraphML | `GRAPHML` | XML/StAX-based graph interchange format |
 
-## 주요 타입
+## Core Types
 
-### 소스/싱크 sealed interface
+### Source / Sink sealed interfaces
 
 ```kotlin
-// 임포트 소스 — 3가지 변형
+// Import source — three variants
 sealed interface OkioGraphImportSource {
     data class PathSource(val path: Path, val fileSystem: FileSystem = FileSystem.SYSTEM) : OkioGraphImportSource
     data class SourceBased(val source: Source, val ownsSource: Boolean = false) : OkioGraphImportSource
     data class InputStreamBased(val inputStream: InputStream, val ownsStream: Boolean = false) : OkioGraphImportSource
 }
 
-// 익스포트 싱크 — 3가지 변형
+// Export sink — three variants
 sealed interface OkioGraphExportSink {
     data class PathSink(
         val path: Path,
@@ -33,49 +46,89 @@ sealed interface OkioGraphExportSink {
         val mustCreate: Boolean = false,
         val mustExist: Boolean = false,
         val createParentDirectories: Boolean = true,
-        val atomicWrite: Boolean = true,   // 기본값: 원자적 쓰기 활성화
+        val atomicWrite: Boolean = true,   // default: atomic write enabled
     ) : OkioGraphExportSink
     data class SinkBased(val sink: Sink, val ownsSink: Boolean = false) : OkioGraphExportSink
     data class OutputStreamBased(val outputStream: OutputStream, val ownsStream: Boolean = false) : OkioGraphExportSink
 }
 ```
 
-### 압축 지원
+### Ownership Policy
+
+| Variant | Default owner | Meaning |
+|---------|--------------|---------|
+| `PathSource` / `PathSink` | **Library** | Library opens and closes the file |
+| `SourceBased(ownsSource=false)` | **Caller** | Source is not closed after import |
+| `SinkBased(ownsSink=false)` | **Caller** | Sink is not closed after export |
+| `SourceBased(ownsSource=true)` | **Library** | Library closes the Source on completion |
+
+`ownsXxx=false` is the default, so externally-provided `Source`/`Sink`/`Stream`
+instances are managed by the caller.
+
+### Compression
 
 ```kotlin
 enum class Compressor { GZIP, DEFLATE, LZ4, SNAPPY, ZSTD, BZIP2 }
 ```
 
-- `GZIP`, `DEFLATE`, `BZIP2`: JDK 내장 — 별도 의존성 없음
-- `LZ4`: `lz4-java` 선택적 의존성
-- `SNAPPY`: `snappy-java` 선택적 의존성
-- `ZSTD`: `zstd-jni` 선택적 의존성
+| Compressor | Dependency | Always available |
+|-----------|-----------|:---------------:|
+| `GZIP` | JDK built-in | ✅ |
+| `DEFLATE` | JDK built-in | ✅ |
+| `LZ4` | `org.lz4:lz4-java` | Optional |
+| `SNAPPY` | `org.xerial.snappy:snappy-java` | Optional |
+| `ZSTD` | `com.github.luben:zstd-jni` | Optional |
+| `BZIP2` | `org.apache.commons:commons-compress` | Optional |
 
-## 사용법
+Using LZ4/Snappy/Zstd/Bzip2 without the optional dependency throws
+`IllegalStateException` with a `build.gradle.kts` snippet to resolve it.
+
+## Usage
 
 ### Sync API
 
 ```kotlin
-// OkioGraphBulkImporter / OkioGraphBulkExporter 직접 사용
 val importer = OkioGraphBulkImporter()
 val exporter = OkioGraphBulkExporter()
 
-// 파일 시스템 경로로 익스포트 (원자적 쓰기 기본)
+// Export to file path (atomic write by default)
 exporter.exportGraph(
     OkioGraphExportSink.PathSink("/data/graph.ndjson".toPath()),
     GraphIoFormat.NDJSON_JACKSON3,
     graphOperations,
+    GraphExportOptions(vertexLabels = setOf("Person"), edgeLabels = setOf("KNOWS")),
 )
 
-// 파일 시스템 경로로 임포트
+// Import from file path
 importer.importGraph(
     OkioGraphImportSource.PathSource("/data/graph.ndjson".toPath()),
     GraphIoFormat.NDJSON_JACKSON3,
     graphOperations,
+    GraphImportOptions(),
 )
 ```
 
-### 포맷별 Extension Functions
+### GZIP Compression
+
+```kotlin
+// export → .ndjson.gz
+exporter.exportGraphGzip(
+    OkioGraphExportSink.PathSink("/data/graph.ndjson.gz".toPath()),
+    GraphIoFormat.NDJSON_JACKSON3,
+    graphOperations,
+    exportOptions,
+)
+
+// import ← .ndjson.gz
+importer.importGraphGzip(
+    OkioGraphImportSource.PathSource("/data/graph.ndjson.gz".toPath()),
+    GraphIoFormat.NDJSON_JACKSON3,
+    graphOperations,
+    importOptions,
+)
+```
+
+### Format-specific Extension Functions
 
 ```kotlin
 // Jackson 2/3
@@ -90,12 +143,12 @@ graphMlExporter.exportGraphGzip(sink, operations, options)
 graphMlImporter.importGraph(source, operations, options)
 graphMlImporter.importGraphGzip(source, operations, options)
 
-// CSV (PathSource/PathSink 전용)
+// CSV (PathSource/PathSink only)
 csvExporter.exportGraph(sink, operations, options)
 csvImporter.importGraph(source, operations, options)
 ```
 
-### Virtual Thread (비동기)
+### Virtual Thread (async)
 
 ```kotlin
 val adapter = VirtualThreadGraphIoOkioBulkAdapter()
@@ -107,21 +160,21 @@ val future: CompletableFuture<GraphImportReport> = adapter.importGraphAsync(
     source, GraphIoFormat.NDJSON_JACKSON3, operations, options
 )
 
-// Extension function 변형
+// Extension function variants
 exporter.exportGraphAsync(sink, operations, options)
 importer.importGraphAsync(source, operations, options)
 ```
 
-### Coroutine (suspend/Flow)
+### Coroutine (suspend / Flow)
 
 ```kotlin
 val adapter = SuspendGraphIoOkioBulkAdapter()
 
-// 완료 보고서 반환
+// Returns a completion report
 val report: GraphExportReport = adapter.exportGraphAwait(sink, GraphIoFormat.NDJSON_JACKSON3, ops, options)
 val report: GraphImportReport = adapter.importGraphAwait(source, GraphIoFormat.NDJSON_JACKSON3, ops, options)
 
-// 진행 상태 Flow
+// Progress as Flow
 adapter.exportGraph(sink, GraphIoFormat.NDJSON_JACKSON3, ops, options).collect { progress ->
     println("exported: ${progress.exported}")
 }
@@ -129,30 +182,31 @@ adapter.importGraph(source, GraphIoFormat.NDJSON_JACKSON3, ops, options).collect
     println("processed: ${progress.processed}")
 }
 
-// Extension function 변형
+// Extension function variants
 exporter.exportGraphAwait(sink, operations, options)
 exporter.exportGraphFlow(sink, operations, options)
 importer.importGraphAwait(source, operations, options)
 importer.importGraphFlow(source, operations, options)
 ```
 
-### 압축 체이닝
+### Compression Chaining
 
 ```kotlin
-// GZIP 편의 함수
-GraphIoOkioPaths.openGzipSink(sink)      // BufferedSink (GZIP 압축)
-GraphIoOkioPaths.openGzipSource(source)  // BufferedSource (GZIP 해제, 512 MiB 한계)
+// GZIP convenience
+GraphIoOkioPaths.openGzipSink(sink)      // BufferedSink (GZIP-compressed)
+GraphIoOkioPaths.openGzipSource(source)  // BufferedSource (GZIP-decompressed, 512 MiB limit)
 
-// 범용 압축
-GraphIoOkioPaths.openCompressedSink(sink, Compressor.ZSTD)
-GraphIoOkioPaths.openDecompressedSource(source, Compressor.ZSTD, maxDecompressedBytes = 1_073_741_824L)
+// Generic compression
+GraphIoOkioPaths.openCompressedSink(rawSink, Compressor.ZSTD)
+GraphIoOkioPaths.openDecompressedSource(rawSource, Compressor.ZSTD, maxDecompressedBytes = 1_073_741_824L)
 ```
 
 ### DAEAD Chunk Encryption
 
-`graph-okio` can wrap single-stream formats with deterministic DAEAD chunk encryption from `bluetape4k-okio`.
-Use this for NDJSON or GraphML payloads that must be authenticated and encrypted while still flowing through
-OkIO streaming APIs.
+`graph-okio` can wrap single-stream formats with deterministic DAEAD chunk
+encryption from `bluetape4k-okio`. Use this for NDJSON or GraphML payloads
+that must be authenticated and encrypted while still flowing through OkIO
+streaming APIs.
 
 ```kotlin
 val daead = TinkDaeads.AES256_SIV
@@ -175,43 +229,132 @@ importer.importGraphDaead(
 )
 ```
 
-For smaller encrypted artifacts, prefer compress-then-encrypt:
+For compress-then-encrypt pipelines, use the convenience helpers:
 
 ```kotlin
 exporter.exportGraphGzipDaead(sink, GraphIoFormat.NDJSON_JACKSON3, daead, graphOperations)
 importer.importGraphDaeadGzip(source, GraphIoFormat.NDJSON_JACKSON3, daead, graphOperations)
 ```
 
-CSV is a paired-file format, so the high-level encrypted helpers intentionally reject `GraphIoFormat.CSV`.
-Use `GraphIoOkioPaths.openDaeadEncryptedSink()` and `openDaeadDecryptedSource()` directly if you need a custom
-encrypted CSV file-pair layout.
+CSV is a paired-file format, so the high-level encrypted helpers intentionally
+reject `GraphIoFormat.CSV`. Use `GraphIoOkioPaths.openDaeadEncryptedSink()` and
+`openDaeadDecryptedSource()` directly to build a custom encrypted CSV file-pair
+layout.
 
-### 원자적 쓰기
+### Atomic Writes
 
-`PathSink(atomicWrite = true)` (기본값)이면:
-1. `{target}.tmp.{UUID}` 임시 파일에 쓰기
-2. 성공 시 → `atomicMove(tmp, target)`
-3. 실패 시 → 임시 파일 삭제, 대상 파일 손상 없음
+When `PathSink(atomicWrite = true)` (the default):
 
-## 보안
+1. Writes to `{target}.tmp.{UUID}` temporary file.
+2. On success → `atomicMove(tmp, target)`.
+3. On failure → temp file deleted; target file remains untouched.
 
-- **XXE 방지**: GraphML StAX 파서에 `IS_SUPPORTING_EXTERNAL_ENTITIES=false`, `SUPPORT_DTD=false` 적용 (기존 구현 위임)
-- **Decompression bomb 방지**: `BombGuardSource`가 해제 바이트를 추적하여 `maxDecompressedBytes` 초과 시 `IOException` 발생
-- **DAEAD deterministic encryption**: encrypted chunks are deterministic. Repeated plaintext chunks encrypted
-  with the same key and associated data produce repeated ciphertext chunks. Choose associated data deliberately
-  and rotate/manage keys outside this module.
+```kotlin
+// Disable atomic writes (direct write)
+val sink = OkioGraphExportSink.PathSink(path, atomicWrite = false)
+```
 
-## Gradle 의존성
+### FakeFileSystem Testing Pattern
+
+```kotlin
+class MyGraphIoTest {
+    private val fakeFs = FakeFileSystem()
+
+    @AfterEach
+    fun cleanup() {
+        fakeFs.checkNoOpenFiles()  // detect file handle leaks
+    }
+
+    @Test
+    fun `round trip test`() {
+        val path = "/graph.ndjson".toPath()
+        val exporter = OkioGraphBulkExporter()
+
+        exporter.exportGraph(
+            OkioGraphExportSink.PathSink(path, fakeFs),
+            GraphIoFormat.NDJSON_JACKSON3,
+            myOperations,
+            exportOptions,
+        )
+
+        // import + verify
+    }
+}
+```
+
+## Performance (JMH — `small`: 1K vertices / 2K edges | `medium`: 10K vertices / 20K edges)
+
+> Run with `./gradlew :graph-io-benchmark:benchmark`.
+> Environment: Java 25, Apple M3 Pro, 1 warmup / 3 iterations / 2 s each (quick measurement).
+> For production-grade numbers, use defaults (3 warmup / 5 iterations / 3 s).
+
+### NDJSON (Jackson3) — Export (AverageTime, ms/op, lower is better)
+
+| Scenario | small | medium |
+|----------|------:|-------:|
+| `jackson3JavaIoExport` (baseline) | 1.23 | 18.06 |
+| `jackson3OkioExport` | 1.53 | 19.69 |
+| `jackson3OkioGzipExport` | 3.09 | 39.87 |
+| `jackson3VtOkioExport` (VirtualThread) | 1.47 | 19.34 |
+
+### NDJSON (Jackson3) — Import / RoundTrip
+
+| Scenario | small | medium |
+|----------|------:|-------:|
+| `jackson3JavaIoImport` (baseline) | 17.26 | 183.93 |
+| `jackson3OkioImport` | 17.40 | 184.61 |
+| `jackson3OkioGzipImport` | 20.06 | 226.40 |
+| `jackson3OkioRoundTrip` | 17.34 | 192.44 |
+| `jackson3OkioGzipRoundTrip` | 20.04 | 212.96 |
+| `jackson3VtOkioImport` (VirtualThread) | 16.99 | 184.68 |
+| `jackson3VtOkioRoundTrip` | 17.27 | 191.34 |
+
+### GraphML (StAX) — Export / Import / RoundTrip
+
+| Scenario | small | medium |
+|----------|------:|-------:|
+| `graphMlJavaIoExport` (baseline) | 2.37 | 33.88 |
+| `graphMlOkioExport` | 3.70 | 39.36 |
+| `graphMlJavaIoImport` (baseline) | 18.74 | 215.44 |
+| `graphMlOkioImport` | 19.93 | 220.84 |
+| `graphMlOkioRoundTrip` | 20.75 | 215.05 |
+
+**Observations:**
+- NDJSON OkIO export is +25% slower (small) / +9% (medium) vs java.io baseline; import is on par.
+- Virtual Thread overhead is negligible (same as sync OkIO).
+- GZIP export is ~2× slower than plain; GZIP import is only +15%.
+- GraphML OkIO adds +10–15% overhead due to StAX → InputStream adapter conversion.
+
+## Security
+
+- **XXE prevention**: GraphML StAX parser applies `SUPPORT_DTD=false` and
+  `IS_SUPPORTING_EXTERNAL_ENTITIES=false` (delegated to the existing implementation).
+- **Decompression bomb protection**: `BombGuardSource` tracks decompressed bytes and
+  throws `IOException` when `maxDecompressedBytes` is exceeded.
+  - Default limit: 512 MiB (`DEFAULT_MAX_DECOMPRESSED_BYTES`)
+  - Custom limit: `openDecompressedSource(source, compressor, maxDecompressedBytes = 1L * 1024 * 1024 * 1024)`
+- **DAEAD deterministic encryption**: Repeated plaintext chunks encrypted with the same
+  key and associated data produce repeated ciphertext chunks. Choose associated data
+  deliberately (tenant / purpose / schema version) and manage keys outside this module.
+- **CSV GZIP streaming**: Both `importGraphGzip` and `exportGraphGzip` are single-pass
+  streaming — no intermediate buffering.
+
+## Gradle Dependency
 
 ```kotlin
 // build.gradle.kts
 dependencies {
     implementation("io.github.bluetape4k.graph:graph-okio:VERSION")
 
-    // 선택적 압축 라이브러리 (필요한 것만 추가)
+    // Optional compression libraries — add only what you need
     implementation("org.lz4:lz4-java:1.8.0")
     implementation("org.xerial.snappy:snappy-java:1.1.10.7")
     implementation("com.github.luben:zstd-jni:1.5.6-6")
     implementation("org.apache.commons:commons-compress:1.27.1")
 }
 ```
+
+## Roadmap
+
+- **v2**: Tink encryption support (`bluetape4k-projects #240`) — AES-GCM based, small-file only (`TinkEncryptSink` / `TinkDecryptSource`)
+- **v2**: Stream-based CSV without `PathSource`/`PathSink` constraint

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/AgeGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/AgeGraphPluginConfig.kt
@@ -5,12 +5,12 @@ import io.bluetape4k.graph.age.AgeGraphSuspendOperations
 import io.bluetape4k.support.requireNotBlank
 
 /**
- * Ktor [GraphPlugin]을 Apache AGE backend로 설정합니다.
+ * Configures [GraphPlugin] to use an Apache AGE backend.
  *
- * ## 동작/계약
- * - 호출 전에 caller가 Exposed `Database.connect(...)`를 완료해야 합니다.
- * - 이 helper는 Exposed `Database`, `DataSource`, connection pool lifecycle을 소유하거나 닫지 않습니다.
- * - [graphName]은 blank가 아니어야 하며 AGE safe identifier 검증은 backend constructor가 수행합니다.
+ * ## Behavior / Contract
+ * - The caller must complete `Database.connect(...)` before calling this helper.
+ * - This helper does not own or close the Exposed `Database`, `DataSource`, or connection pool lifecycle.
+ * - [graphName] must not be blank; AGE safe-identifier validation is performed by the backend constructor.
  *
  * ```kotlin
  * fun Application.module() {

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ApplicationExt.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ApplicationExt.kt
@@ -6,39 +6,39 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 
 /**
- * 현재 [Application]에 설치된 [GraphPlugin]의 [GraphPluginState]를 조회합니다.
+ * Returns the [GraphPluginState] of the [GraphPlugin] installed in this [Application].
  *
- * ## 동작/계약
- * - [GraphPlugin]이 설치되지 않은 경우 [IllegalStateException]을 던집니다.
+ * ## Behavior / Contract
+ * - Throws [IllegalStateException] if [GraphPlugin] has not been installed.
  *
- * @throws IllegalStateException plugin 미설치 시
+ * @throws IllegalStateException if the plugin is not installed
  */
 fun Application.graphPluginState(): GraphPluginState =
     attributes.getOrNull(GraphPluginStateKey)
-        ?: error("GraphPlugin이 Application에 설치되지 않았습니다.")
+        ?: error("GraphPlugin is not installed in this Application.")
 
 /**
- * 현재 [Application]에서 blocking [GraphOperations]를 조회합니다.
+ * Returns the blocking [GraphOperations] from the current [Application].
  *
- * ## 동작/계약
- * - Ktor route의 suspend context에서는 [graphSuspendOperations]를 우선 사용하세요.
- * - plugin 미설치 시 [IllegalStateException]을 던집니다.
+ * ## Behavior / Contract
+ * - Prefer [graphSuspendOperations] inside Ktor route suspend contexts.
+ * - Throws [IllegalStateException] if the plugin is not installed.
  */
 fun Application.graphOperations(): GraphOperations =
     graphPluginState().graphOperations
 
 /**
- * 현재 [Application]에서 coroutine-first [GraphSuspendOperations]를 조회합니다.
+ * Returns the coroutine-first [GraphSuspendOperations] from the current [Application].
  *
- * ## 동작/계약
- * - Ktor route handler와 coroutine service에서 우선 사용할 facade입니다.
- * - plugin 미설치 시 [IllegalStateException]을 던집니다.
+ * ## Behavior / Contract
+ * - This is the preferred facade for Ktor route handlers and coroutine services.
+ * - Throws [IllegalStateException] if the plugin is not installed.
  */
 fun Application.graphSuspendOperations(): GraphSuspendOperations =
     graphPluginState().graphSuspendOperations
 
 /**
- * route handler의 [ApplicationCall]에서 blocking [GraphOperations]를 조회합니다.
+ * Returns the blocking [GraphOperations] from an [ApplicationCall] in a route handler.
  *
  * ```kotlin
  * routing {
@@ -52,7 +52,7 @@ fun ApplicationCall.graphOperations(): GraphOperations =
     application.graphOperations()
 
 /**
- * route handler의 [ApplicationCall]에서 coroutine-first [GraphSuspendOperations]를 조회합니다.
+ * Returns the coroutine-first [GraphSuspendOperations] from an [ApplicationCall] in a route handler.
  *
  * ```kotlin
  * routing {

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/FalkorDBGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/FalkorDBGraphPluginConfig.kt
@@ -6,11 +6,11 @@ import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.support.requireNotBlank
 
 /**
- * Ktor [GraphPlugin]을 FalkorDB backend로 설정합니다.
+ * Configures [GraphPlugin] to use a FalkorDB backend.
  *
- * ## 동작/계약
- * - [driver]는 caller-owned resource입니다. 이 helper는 driver를 닫지 않습니다.
- * - [graphName] 기본값은 [FalkorDBGraphOperations.DEFAULT_GRAPH_NAME]입니다.
+ * ## Behavior / Contract
+ * - [driver] is a caller-owned resource; this helper does not close it.
+ * - [graphName] defaults to [FalkorDBGraphOperations.DEFAULT_GRAPH_NAME].
  *
  * ```kotlin
  * fun Application.module(driver: Driver) {

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPlugin.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPlugin.kt
@@ -10,13 +10,14 @@ import io.ktor.server.application.hooks.MonitoringEvent
 import io.ktor.util.AttributeKey
 
 /**
- * Ktor 3.x application에서 `bluetape4k-graph` facade를 설치하는 plugin 진입점입니다.
+ * Entry point for installing the `bluetape4k-graph` facade as a Ktor 3.x application plugin.
  *
- * ## 동작/계약
- * - `install(GraphPlugin) { tinkerGraph() }` 또는 `install(GraphPlugin) { operations(sync, suspend) }`로 설치합니다.
- * - backend가 명시적으로 선택되지 않으면 install 시점에 [IllegalArgumentException]이 발생합니다.
- * - resolve된 [GraphPluginState]는 [Application.attributes]에 저장됩니다.
- * - stop 시점에는 설정에 등록된 close action만 실행합니다. caller-owned driver나 `DataSource`는 닫지 않습니다.
+ * ## Behavior / Contract
+ * - Install with `install(GraphPlugin) { tinkerGraph() }` or `install(GraphPlugin) { operations(sync, suspend) }`.
+ * - Throws [IllegalArgumentException] at install time if no backend is selected.
+ * - The resolved [GraphPluginState] is stored in [Application.attributes].
+ * - On stop, only close actions registered during configuration run; caller-owned drivers and `DataSource`
+ *   instances are not closed.
  *
  * ```kotlin
  * fun Application.module() {
@@ -37,13 +38,13 @@ val GraphPlugin = createApplicationPlugin(
 
     on(MonitoringEvent(ApplicationStarted)) { application ->
         GraphPluginInternals.log.info {
-            "GraphPlugin 시작 - application=${application.javaClass.simpleName}"
+            "GraphPlugin started - application=${application.javaClass.simpleName}"
         }
     }
 
     on(MonitoringEvent(ApplicationStopped)) { application ->
         GraphPluginInternals.log.info {
-            "GraphPlugin 종료 - application=${application.javaClass.simpleName}"
+            "GraphPlugin stopped - application=${application.javaClass.simpleName}"
         }
         state.close()
     }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPluginConfig.kt
@@ -5,14 +5,15 @@ import io.bluetape4k.graph.repository.GraphSuspendOperations
 import java.util.IdentityHashMap
 
 /**
- * [GraphPlugin] 설정 클래스입니다.
+ * Configuration class for [GraphPlugin].
  *
- * ## 동작/계약
- * - `install(GraphPlugin) { ... }` 블록에서 backend를 반드시 한 번 선택해야 합니다.
- * - [operations]는 이미 생성된 [GraphOperations] / [GraphSuspendOperations]를 Ktor application에 연결합니다.
- * - 기본적으로 caller-owned operations를 닫지 않습니다. `closeOnStop`을 `true`로 지정한 경우에만
- *   [io.ktor.server.application.ApplicationStopped] 시점에 전달된 operations를 닫습니다.
- * - 두 operations가 내부 delegate를 공유한다면 caller가 idempotent close를 보장하거나 `closeOnStop`을 꺼야 합니다.
+ * ## Behavior / Contract
+ * - Exactly one backend must be selected inside the `install(GraphPlugin) { ... }` block.
+ * - [operations] wires already-constructed [GraphOperations] / [GraphSuspendOperations] into the Ktor application.
+ * - Caller-owned operations are not closed by default. Pass `closeOnStop = true` to close them on
+ *   [io.ktor.server.application.ApplicationStopped].
+ * - If both operations share an internal delegate, the caller must ensure idempotent close or keep
+ *   `closeOnStop = false`.
  *
  * ```kotlin
  * fun Application.module(syncOps: GraphOperations, suspendOps: GraphSuspendOperations) {
@@ -33,17 +34,17 @@ class GraphPluginConfig {
     internal val closeActions: MutableList<GraphPluginCloseAction> = mutableListOf()
 
     /**
-     * 이미 구성된 graph facade pair를 plugin state로 등록합니다.
+     * Registers an already-constructed graph facade pair as the plugin state.
      *
-     * ## 동작/계약
-     * - [graphOperations]와 [graphSuspendOperations]는 모두 필수입니다.
-     * - `closeOnStop` 기본값은 `false`입니다. 외부 DI/container가 lifecycle을 소유하는 경우 기본값을 유지합니다.
-     * - `closeOnStop`이 `true`이면 두 객체를 object identity 기준으로 중복 제거한 뒤 한 번씩 닫습니다.
+     * ## Behavior / Contract
+     * - Both [graphOperations] and [graphSuspendOperations] are required.
+     * - `closeOnStop` defaults to `false`. Keep the default when an external DI container owns the lifecycle.
+     * - When `closeOnStop` is `true`, both objects are deduplicated by object identity and closed exactly once.
      *
-     * @param graphOperations 동기 graph facade
-     * @param graphSuspendOperations 코루틴 graph facade
-     * @param closeOnStop application stop 시 operations를 닫을지 여부
-     * @throws IllegalArgumentException backend가 이미 설정된 경우
+     * @param graphOperations sync graph facade
+     * @param graphSuspendOperations coroutine graph facade
+     * @param closeOnStop whether to close the operations on application stop
+     * @throws IllegalArgumentException if a backend has already been configured
      */
     fun operations(
         graphOperations: GraphOperations,
@@ -69,7 +70,7 @@ class GraphPluginConfig {
         closeActions: List<GraphPluginCloseAction> = emptyList(),
     ) {
         require(this.graphOperationsFactory == null && this.graphSuspendOperationsFactory == null) {
-            "GraphPlugin backend는 한 번만 설정할 수 있습니다. 이미 설정된 backend를 확인하세요: $backendName"
+            "GraphPlugin backend can only be configured once. Already configured backend: $backendName"
         }
 
         this.graphOperationsFactory = graphOperationsFactory
@@ -79,9 +80,9 @@ class GraphPluginConfig {
 
     internal fun resolveState(): GraphPluginState {
         val graphOperations = graphOperationsFactory?.invoke()
-            ?: throw IllegalArgumentException("GraphPlugin 설치 전 graph backend를 명시적으로 선택해야 합니다.")
+            ?: throw IllegalArgumentException("A graph backend must be selected before installing GraphPlugin.")
         val graphSuspendOperations = graphSuspendOperationsFactory?.invoke()
-            ?: throw IllegalArgumentException("GraphPlugin 설치 전 graph suspend backend를 명시적으로 선택해야 합니다.")
+            ?: throw IllegalArgumentException("A graph suspend backend must be selected before installing GraphPlugin.")
 
         return GraphPluginState(
             graphOperations = graphOperations,

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPluginState.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/GraphPluginState.kt
@@ -6,12 +6,13 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 
 /**
- * [GraphPlugin]이 resolve한 graph integration state입니다.
+ * Graph integration state resolved by [GraphPlugin].
  *
- * ## 동작/계약
- * - [graphOperations]는 blocking compatibility API입니다.
- * - [graphSuspendOperations]는 Ktor route와 coroutine code에서 우선 사용할 coroutine API입니다.
- * - [close]는 등록된 close action을 독립적으로 실행합니다. 하나의 close 실패가 나머지 close를 막지 않습니다.
+ * ## Behavior / Contract
+ * - [graphOperations] is the blocking compatibility API.
+ * - [graphSuspendOperations] is the preferred coroutine API for Ktor routes and coroutine code.
+ * - [close] executes registered close actions independently; a failure in one action does not
+ *   prevent the remaining actions from running.
  *
  * ```kotlin
  * val state = application.graphPluginState()

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/MemgraphGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/MemgraphGraphPluginConfig.kt
@@ -6,11 +6,12 @@ import io.bluetape4k.support.requireNotBlank
 import org.neo4j.driver.Driver
 
 /**
- * Ktor [GraphPlugin]을 Memgraph backend로 설정합니다.
+ * Configures [GraphPlugin] to use a Memgraph backend.
  *
- * ## 동작/계약
- * - [driver]는 caller-owned resource입니다. 이 helper는 driver를 닫지 않습니다.
- * - [database] 기본값은 `MemgraphGraphOperations`와 Spring Boot properties가 사용하는 `"memgraph"`입니다.
+ * ## Behavior / Contract
+ * - [driver] is a caller-owned resource; this helper does not close it.
+ * - [database] defaults to `"memgraph"`, matching the default used by `MemgraphGraphOperations`
+ *   and Spring Boot properties.
  *
  * ```kotlin
  * fun Application.module(driver: Driver) {

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/Neo4jGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/Neo4jGraphPluginConfig.kt
@@ -6,11 +6,11 @@ import io.bluetape4k.support.requireNotBlank
 import org.neo4j.driver.Driver
 
 /**
- * Ktor [GraphPlugin]을 Neo4j backend로 설정합니다.
+ * Configures [GraphPlugin] to use a Neo4j backend.
  *
- * ## 동작/계약
- * - [driver]는 caller-owned resource입니다. 이 helper는 driver를 닫지 않습니다.
- * - [database]는 blank가 아니어야 합니다.
+ * ## Behavior / Contract
+ * - [driver] is a caller-owned resource; this helper does not close it.
+ * - [database] must not be blank.
  *
  * ```kotlin
  * fun Application.module(driver: Driver) {

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/TinkerGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/TinkerGraphPluginConfig.kt
@@ -4,12 +4,12 @@ import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 
 /**
- * Ktor [GraphPlugin]을 in-memory TinkerGraph backend로 설정합니다.
+ * Configures [GraphPlugin] to use an in-memory TinkerGraph backend.
  *
- * ## 동작/계약
- * - plugin이 [TinkerGraphOperations] delegate를 직접 생성합니다.
- * - [TinkerGraphSuspendOperations]는 같은 delegate를 공유합니다.
- * - application stop 시 shared delegate를 정확히 한 번만 닫습니다.
+ * ## Behavior / Contract
+ * - The plugin creates the [TinkerGraphOperations] delegate internally.
+ * - [TinkerGraphSuspendOperations] shares the same delegate.
+ * - The shared delegate is closed exactly once on application stop.
  *
  * ```kotlin
  * fun Application.module() {


### PR DESCRIPTION
## Summary

Addresses three 0.3.0 milestone documentation tasks:

- **#118** — `graph-io/okio` README rewritten in English (was entirely Korean)
- **#121** — CHANGELOG `[Unreleased]` finalized as `[0.3.0] - 2026-05-16`; Korean entries translated
- **#122** — All `graph-ktor` public KDoc and runtime messages translated to English

## Changes

### graph-ktor (closes #122)
- `GraphPlugin.kt`: KDoc translated; log messages `"GraphPlugin 시작..."` → `"GraphPlugin started..."` etc.
- `GraphPluginConfig.kt`: class KDoc, `operations()` KDoc, and all three error messages translated
- `GraphPluginState.kt`: KDoc translated
- `ApplicationExt.kt`: all function KDoc + error message translated
- `TinkerGraphPluginConfig.kt`, `Neo4jGraphPluginConfig.kt`, `MemgraphGraphPluginConfig.kt`, `AgeGraphPluginConfig.kt`, `FalkorDBGraphPluginConfig.kt`: KDoc translated

### CHANGELOG (closes #121)
- `## [Unreleased] — 0.3.0-SNAPSHOT` promoted to `## [0.3.0] - 2026-05-16`
- Blank `## [Unreleased]` placeholder added at top per Keep-a-Changelog convention
- All Korean entries in the 0.3.0 section translated to English
- Historical entries in `[0.2.0]` and `[0.1.0]` left unchanged (policy exempts historical content)

### graph-io/okio README (closes #118)
- `README.md`: full English rewrite — architecture overview, format matrix, core types (sealed Source/Sink interfaces, ownership policy), usage patterns (sync/GZIP/virtual-thread/coroutine/compression chaining/DAEAD/atomic writes/FakeFileSystem), JMH performance tables, security notes, Gradle dependency block, roadmap
- `README.ko.md`: fixed header to `# graph-okio` (removed erroneous parenthetical)

## Verification

```bash
./gradlew :graph-ktor:build :graph-okio:build -x test
```

Both modules compiled clean.

## Language Policy Notes

- Language-switch anchor text (`[한국어](README.ko.md)`) is intentionally Korean navigational UI — not flagged.
- Historical CHANGELOG entries in `[0.2.0]`/`[0.1.0]` are exempt from bulk rewrite per policy.
- Runtime error/log messages in `graph-ktor` are not exempt (always must be English).

## Checklist

- [x] Build passes (`:graph-ktor:build :graph-okio:build -x test`)
- [x] All changed public KDoc is English
- [x] CHANGELOG 0.3.0 section fully in English
- [x] README.md and README.ko.md structurally in sync
- [x] Lessons doc committed (`docs/lessons/2026-05-16-0.3.0-docs-polish.md`)
- [x] PR title/body are English
- [x] Closes #118, #121, #122

Milestone: 0.3.0