### PR TITLE
feat: add FalkorDB backend example to ktor-graph-examples

### DIFF
--- a/docs/lessons/2026-05-16-ktor-falkordb-example.md
+++ b/docs/lessons/2026-05-16-ktor-falkordb-example.md
@@ -1,0 +1,33 @@
+# 2026-05-16 — FalkorDB Ktor Example: Driver Ownership and Graph Name Coupling
+
+## Context
+
+Added `FalkorDBKtorGraphApp.kt` and `FalkorDBKtorGraphAppTest.kt` to `ktor-graph-examples` (issue #123).
+
+## Key Decisions
+
+### Driver ownership follows the plugin contract
+
+`FalkorDBGraphPluginConfig.falkorDB()` is explicitly caller-owned ("driver is a caller-owned resource; this helper does not close it"). The first implementation created a driver internally from `host: String, port: Int`, which violated this contract and caused a Jedis connection pool leak on `testApplication` teardown.
+
+Fix: change `falkorDbModule(host, port)` → `falkorDbModule(driver: Driver)`. Caller creates and owns the driver. In tests, use a single `by lazy` driver in `companion object` reused across test methods.
+
+### Do not expose configurable graph name when routes are hardcoded
+
+The initial version exposed `graphName: String = DEMO_GRAPH_NAME` as a parameter. Codex review caught that `graphDemoRoutes()` always calls `DemoCityGraph.reset()` which hard-codes the graph name `"demo"`. Passing any non-default name silently misroutes reset: the plugin writes to graph X, but reset always drops/creates graph "demo", so repeated resets accumulate vertices.
+
+Fix: remove the `graphName` parameter. When routes and graph name must be configurable together, the caller should configure `GraphPlugin` directly instead of using the convenience module.
+
+## Verification
+
+```
+./gradlew :ktor-graph-examples:test --tests "*.FalkorDBKtorGraphAppTest"
+2 tests, 0 failures — BUILD SUCCESSFUL
+```
+
+Codex review: CRITICAL=0, HIGH=0.
+
+## Future Guidance
+
+- When writing an `Application.someModule()` convenience function, verify that all routes, graph names, and reset operations target the same logical resource. Mismatches are silent at compile time.
+- Testcontainers-backed driver for Ktor examples: always declare as `companion object { val driver by lazy { ... } }` to avoid per-`testApplication` connection pool creation.

--- a/examples/ktor-graph-examples/build.gradle.kts
+++ b/examples/ktor-graph-examples/build.gradle.kts
@@ -19,6 +19,7 @@ dependencyManagement {
 dependencies {
     implementation(project(":graph-ktor"))
     implementation(project(":graph-tinkerpop"))
+    implementation(project(":graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.bluetape4k.logging)
@@ -32,4 +33,5 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.kotlinx.coroutines.test.lib)
+    testImplementation(testFixtures(project(":graph-falkordb")))
 }

--- a/examples/ktor-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphApp.kt
+++ b/examples/ktor-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphApp.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.graph.examples.ktor
+
+import com.falkordb.FalkorDB
+import io.bluetape4k.graph.ktor.GraphPlugin
+import io.bluetape4k.graph.ktor.falkorDB
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+
+/**
+ * Ktor application module using a FalkorDB backend.
+ *
+ * ## Behavior / Contract
+ * - Installs [GraphPlugin] with the FalkorDB backend, binding to the `"demo"` graph
+ *   that [graphDemoRoutes] operates on.
+ * - Exposes the same demo routes as [module] (health, reset, city count, city path).
+ * - The [host] and [port] are resolved from the caller (typically a Testcontainers
+ *   singleton in tests, or environment configuration in production).
+ *
+ * ```kotlin
+ * embeddedServer(CIO, port = 8080) {
+ *     falkorDbModule(host = "localhost", port = 6379)
+ * }.start(wait = true)
+ * ```
+ */
+fun Application.falkorDbModule(host: String, port: Int) {
+    val driver = FalkorDB.driver(host, port)
+    install(GraphPlugin) {
+        falkorDB(driver, graphName = DEMO_GRAPH_NAME)
+    }
+    routing {
+        graphDemoRoutes()
+    }
+}
+
+/**
+ * The graph name used by [falkorDbModule] and matched by [graphDemoRoutes].
+ *
+ * Must equal `DemoCityGraph.GRAPH_NAME` so that the FalkorDB operations instance
+ * writes vertices and edges to the same Redis key that [graphDemoRoutes] queries.
+ */
+internal const val DEMO_GRAPH_NAME: String = "demo"

--- a/examples/ktor-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphApp.kt
+++ b/examples/ktor-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphApp.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.examples.ktor
 
-import com.falkordb.FalkorDB
+import com.falkordb.Driver
 import io.bluetape4k.graph.ktor.GraphPlugin
 import io.bluetape4k.graph.ktor.falkorDB
 import io.ktor.server.application.Application
@@ -11,22 +11,24 @@ import io.ktor.server.routing.routing
  * Ktor application module using a FalkorDB backend.
  *
  * ## Behavior / Contract
- * - Installs [GraphPlugin] with the FalkorDB backend, binding to the `"demo"` graph
- *   that [graphDemoRoutes] operates on.
+ * - [driver] is a caller-owned resource; this module does not close it.
+ * - Installs [GraphPlugin] with the FalkorDB backend, binding to the [graphName] graph.
  * - Exposes the same demo routes as [module] (health, reset, city count, city path).
- * - The [host] and [port] are resolved from the caller (typically a Testcontainers
- *   singleton in tests, or environment configuration in production).
  *
  * ```kotlin
+ * val driver = FalkorDB.driver("localhost", 6379)
  * embeddedServer(CIO, port = 8080) {
- *     falkorDbModule(host = "localhost", port = 6379)
+ *     falkorDbModule(driver)
  * }.start(wait = true)
+ * // Caller is responsible for driver.close() on shutdown.
  * ```
  */
-fun Application.falkorDbModule(host: String, port: Int) {
-    val driver = FalkorDB.driver(host, port)
+fun Application.falkorDbModule(
+    driver: Driver,
+    graphName: String = DEMO_GRAPH_NAME,
+) {
     install(GraphPlugin) {
-        falkorDB(driver, graphName = DEMO_GRAPH_NAME)
+        falkorDB(driver, graphName = graphName)
     }
     routing {
         graphDemoRoutes()
@@ -34,7 +36,7 @@ fun Application.falkorDbModule(host: String, port: Int) {
 }
 
 /**
- * The graph name used by [falkorDbModule] and matched by [graphDemoRoutes].
+ * The graph name matched by [graphDemoRoutes] operations.
  *
  * Must equal `DemoCityGraph.GRAPH_NAME` so that the FalkorDB operations instance
  * writes vertices and edges to the same Redis key that [graphDemoRoutes] queries.

--- a/examples/ktor-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphApp.kt
+++ b/examples/ktor-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphApp.kt
@@ -12,8 +12,10 @@ import io.ktor.server.routing.routing
  *
  * ## Behavior / Contract
  * - [driver] is a caller-owned resource; this module does not close it.
- * - Installs [GraphPlugin] with the FalkorDB backend, binding to the [graphName] graph.
+ * - Installs [GraphPlugin] with the FalkorDB backend, bound to [DEMO_GRAPH_NAME].
  * - Exposes the same demo routes as [module] (health, reset, city count, city path).
+ * - The graph name is fixed to [DEMO_GRAPH_NAME] so that [graphDemoRoutes] reset
+ *   and query operations always target the same graph.
  *
  * ```kotlin
  * val driver = FalkorDB.driver("localhost", 6379)
@@ -23,12 +25,9 @@ import io.ktor.server.routing.routing
  * // Caller is responsible for driver.close() on shutdown.
  * ```
  */
-fun Application.falkorDbModule(
-    driver: Driver,
-    graphName: String = DEMO_GRAPH_NAME,
-) {
+fun Application.falkorDbModule(driver: Driver) {
     install(GraphPlugin) {
-        falkorDB(driver, graphName = graphName)
+        falkorDB(driver, graphName = DEMO_GRAPH_NAME)
     }
     routing {
         graphDemoRoutes()

--- a/examples/ktor-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphAppTest.kt
+++ b/examples/ktor-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphAppTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.graph.examples.ktor
 
+import com.falkordb.FalkorDB
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.graph.falkordb.FalkorDBServer
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -17,13 +18,13 @@ import org.junit.jupiter.api.TestInstance
  *
  * ## Behavior / Contract
  * - Uses the singleton [FalkorDBServer.Launcher.falkordb] Testcontainers instance.
- * - Each test creates a fresh [testApplication] scope; state is isolated by
- *   calling `POST /demo/reset` before any assertion.
+ * - The shared [driver] is caller-owned and reused across tests; it is not closed
+ *   between test methods.
+ * - Each test calls `POST /demo/reset` before asserting state to ensure isolation.
  *
  * ```kotlin
- * val server = FalkorDBServer.Launcher.falkordb
  * testApplication {
- *     application { falkorDbModule(server.host, server.port) }
+ *     application { falkorDbModule(driver) }
  * }
  * ```
  */
@@ -32,13 +33,14 @@ class FalkorDBKtorGraphAppTest {
 
     companion object : KLogging() {
         private val server = FalkorDBServer.Launcher.falkordb
+        private val driver by lazy { FalkorDB.driver(server.host, server.port) }
     }
 
     @Test
     fun `health route returns UP`() = runSuspendIO {
         testApplication {
             application {
-                falkorDbModule(server.host, server.port)
+                falkorDbModule(driver)
             }
             startApplication()
 
@@ -52,7 +54,7 @@ class FalkorDBKtorGraphAppTest {
     fun `demo reset and city count and path work with FalkorDB`() = runSuspendIO {
         testApplication {
             application {
-                falkorDbModule(server.host, server.port)
+                falkorDbModule(driver)
             }
             startApplication()
 

--- a/examples/ktor-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphAppTest.kt
+++ b/examples/ktor-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphAppTest.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.graph.examples.ktor
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Integration tests for the FalkorDB-backed Ktor application module.
+ *
+ * ## Behavior / Contract
+ * - Uses the singleton [FalkorDBServer.Launcher.falkordb] Testcontainers instance.
+ * - Each test creates a fresh [testApplication] scope; state is isolated by
+ *   calling `POST /demo/reset` before any assertion.
+ *
+ * ```kotlin
+ * val server = FalkorDBServer.Launcher.falkordb
+ * testApplication {
+ *     application { falkorDbModule(server.host, server.port) }
+ * }
+ * ```
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FalkorDBKtorGraphAppTest {
+
+    companion object : KLogging() {
+        private val server = FalkorDBServer.Launcher.falkordb
+    }
+
+    @Test
+    fun `health route returns UP`() = runSuspendIO {
+        testApplication {
+            application {
+                falkorDbModule(server.host, server.port)
+            }
+            startApplication()
+
+            val response = client.get("/health")
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.bodyAsText() shouldBeEqualTo "UP"
+        }
+    }
+
+    @Test
+    fun `demo reset and city count and path work with FalkorDB`() = runSuspendIO {
+        testApplication {
+            application {
+                falkorDbModule(server.host, server.port)
+            }
+            startApplication()
+
+            val resetResponse = client.post("/demo/reset")
+            resetResponse.status shouldBeEqualTo HttpStatusCode.OK
+            resetResponse.bodyAsText() shouldBeEqualTo "reset"
+
+            val countResponse = client.get("/cities/count")
+            countResponse.status shouldBeEqualTo HttpStatusCode.OK
+            countResponse.bodyAsText() shouldBeEqualTo "3"
+
+            val pathResponse = client.get("/cities/path")
+            pathResponse.status shouldBeEqualTo HttpStatusCode.OK
+            pathResponse.bodyAsText() shouldBeEqualTo "Seoul -> Daejeon -> Busan"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #123

Adds a FalkorDB-backed Ktor application module and integration tests to `examples/ktor-graph-examples`.

## Changes

### `FalkorDBKtorGraphApp.kt` (new)
- `Application.falkorDbModule(host, port)` installs `GraphPlugin` with the FalkorDB backend
- Binds to graph name `"demo"` (same as `DemoCityGraph.GRAPH_NAME`) to ensure vertex/edge ops land on the correct Redis key
- Wires the shared `graphDemoRoutes()` (health, reset, city count, city path)

### `FalkorDBKtorGraphAppTest.kt` (new)
- `@TestInstance(PER_CLASS)`, `companion object : KLogging()`, `runSuspendIO`, `shouldBeEqualTo`
- Uses `FalkorDBServer.Launcher.falkordb` Testcontainers singleton
- Covers `/health`, `POST /demo/reset`, `GET /cities/count`, `GET /cities/path`

### `build.gradle.kts`
- `implementation(project(":graph-falkordb"))`
- `testImplementation(testFixtures(project(":graph-falkordb")))` for `FalkorDBServer`

## Test Results

```
./gradlew :ktor-graph-examples:test --tests "*.FalkorDBKtorGraphAppTest"
2 tests, 0 failures — BUILD SUCCESSFUL (1.8s)
```

## Checklist
- [x] Public KDoc in English
- [x] `@TestInstance(PER_CLASS)`, `companion object : KLogging()`
- [x] `runSuspendIO` (not runBlocking)
- [x] Testcontainers singleton pattern (`Launcher.falkordb`)
- [x] Closes #123