### PR TITLE
feat: add FalkorDB health indicator test and README documentation

### DIFF
--- a/docs/lessons/2026-05-16-spring-falkordb-health.md
+++ b/docs/lessons/2026-05-16-spring-falkordb-health.md
@@ -1,0 +1,33 @@
+# 2026-05-16 — Spring Boot FalkorDB Health Indicator: Test Gap and README Omission
+
+## Context
+
+Issue #125: `GraphFalkorDBAutoConfiguration.HealthConfig` was implemented in PR #106 but had no test and was absent from README documentation.
+
+## Key Decisions
+
+### ConditionalOnClass requires the class on the test classpath
+
+`HealthConfig` is guarded by `@ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])`. In `ApplicationContextRunner` tests, the class must actually be on the test classpath or the conditional skips the nested `@Configuration` entirely and no `HealthIndicator` bean is registered.
+
+Fix: add `testImplementation("org.springframework.boot:spring-boot-health")` to `build.gradle.kts`. Without this the test passes vacuously (no exception from `getBean`, just no bean), so the test becomes a false negative.
+
+### Backend enum values must be kept in sync across all documentation
+
+The "Common properties" table listed `backend` allowed values as `tinkergraph | neo4j | memgraph | age` in both README.md and README.ko.md. `falkordb` was missing even though the FalkorDB auto-configuration section was correctly added in five other locations.
+
+Pattern: whenever a new backend is added, check the Common properties table explicitly — it is a catch-all that is easy to miss when adding backend-specific sections.
+
+## Verification
+
+```
+./gradlew :graph-spring-boot:test --tests "*.GraphFalkorDBAutoConfigurationTest"
+5 tests, 0 failures — BUILD SUCCESSFUL
+```
+
+Codex review: CRITICAL=0, HIGH=0 (21 total tests passing).
+
+## Future Guidance
+
+- When adding or verifying a `@ConditionalOnClass`-guarded Spring Boot bean in `ApplicationContextRunner` tests, verify the guarded class is in `testImplementation` scope.
+- README "Common properties" tables listing enum values are the most likely place to miss a new backend — add a checklist item for it in the PR template.

--- a/spring-boot/graph-spring-boot/README.ko.md
+++ b/spring-boot/graph-spring-boot/README.ko.md
@@ -15,6 +15,7 @@
 | Neo4j | `neo4j` | `graph-neo4j` |
 | Memgraph | `memgraph` | `graph-memgraph` |
 | Apache AGE (PostgreSQL) | `age` | `graph-age` |
+| FalkorDB (Redis 모듈) | `falkordb` | `graph-falkordb` |
 
 ## 시작하기
 
@@ -81,6 +82,21 @@ bluetape4k:
 
 > AGE는 JDBC `DataSource` 빈이 필요하다. 의존성에 `spring-boot-jdbc`를 추가하라.
 
+**FalkorDB (Redis 기반 그래프 데이터베이스):**
+```yaml
+bluetape4k:
+  graph:
+    backend: falkordb
+    falkordb:
+      host: localhost
+      port: 6379
+      username: ""        # 인증 없이 접속할 경우 빈 문자열
+      password: ""
+      graph-name: my_graph
+      register-suspend: true
+      register-virtual-thread: true
+```
+
 ### 3. 주입 후 사용
 
 ```kotlin
@@ -104,7 +120,7 @@ class MyGraphService(
 | `GraphOperations` | 백엔드 활성화 시 항상 등록 |
 | `GraphSuspendOperations` | `register-suspend=true` (기본값) |
 | `GraphVirtualThreadOperations` | `register-virtual-thread=true` (기본값) |
-| `HealthIndicator` (Neo4j/Memgraph) | `spring-boot-health` 클래스패스 존재 시 |
+| `HealthIndicator` (Neo4j/Memgraph/AGE/TinkerGraph/FalkorDB) | `spring-boot-health` 클래스패스 존재 시 |
 
 모든 빈은 `@ConditionalOnMissingBean`을 사용하므로, 직접 빈을 등록하면 자동 구성이 건너뛰어진다.
 
@@ -140,6 +156,18 @@ Neo4j와 동일한 프로퍼티 구조, 프리픽스는 `bluetape4k.graph.memgra
 | `register-suspend` | `true` | `GraphSuspendOperations` 등록 여부 |
 | `register-virtual-thread` | `true` | `GraphVirtualThreadOperations` 등록 여부 |
 
+### FalkorDB (`bluetape4k.graph.falkordb.*`)
+
+| 프로퍼티 | 기본값 | 설명 |
+|---------|-------|------|
+| `host` | `localhost` | FalkorDB 호스트 주소 |
+| `port` | `6379` | FalkorDB Redis 포트 |
+| `username` | *(빈 문자열)* | 인증 사용자명 (빈 문자열이면 인증 없음) |
+| `password` | *(빈 문자열)* | 인증 비밀번호 (빈 문자열이면 인증 없음) |
+| `graph-name` | `bluetape4k` | 대상 그래프 이름 |
+| `register-suspend` | `true` | `GraphSuspendOperations` 등록 여부 |
+| `register-virtual-thread` | `true` | `GraphVirtualThreadOperations` 등록 여부 |
+
 ## Auto-Configuration 클래스
 
 | 클래스 | 활성화 조건 |
@@ -149,6 +177,7 @@ Neo4j와 동일한 프로퍼티 구조, 프리픽스는 `bluetape4k.graph.memgra
 | `GraphNeo4jAutoConfiguration` | `backend=neo4j` |
 | `GraphMemgraphAutoConfiguration` | `backend=memgraph` |
 | `GraphAgeAutoConfiguration` | `backend=age` |
+| `GraphFalkorDBAutoConfiguration` | `backend=falkordb` |
 
 ## Spring Boot 4 참고 사항
 

--- a/spring-boot/graph-spring-boot/README.ko.md
+++ b/spring-boot/graph-spring-boot/README.ko.md
@@ -130,7 +130,7 @@ class MyGraphService(
 
 | 프로퍼티 | 기본값 | 설명 |
 |---------|-------|------|
-| `bluetape4k.graph.backend` | *(없음 — TinkerGraph가 기본 활성화)* | 활성 백엔드: `tinkergraph` \| `neo4j` \| `memgraph` \| `age` |
+| `bluetape4k.graph.backend` | *(없음 — TinkerGraph가 기본 활성화)* | 활성 백엔드: `tinkergraph` \| `neo4j` \| `memgraph` \| `age` \| `falkordb` |
 
 ### Neo4j (`bluetape4k.graph.neo4j.*`)
 

--- a/spring-boot/graph-spring-boot/README.md
+++ b/spring-boot/graph-spring-boot/README.md
@@ -130,7 +130,7 @@ All beans use `@ConditionalOnMissingBean` — provide your own bean to override.
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `bluetape4k.graph.backend` | *(none — TinkerGraph activates by default)* | Active backend: `tinkergraph` \| `neo4j` \| `memgraph` \| `age` |
+| `bluetape4k.graph.backend` | *(none — TinkerGraph activates by default)* | Active backend: `tinkergraph` \| `neo4j` \| `memgraph` \| `age` \| `falkordb` |
 
 ### Neo4j (`bluetape4k.graph.neo4j.*`)
 

--- a/spring-boot/graph-spring-boot/README.md
+++ b/spring-boot/graph-spring-boot/README.md
@@ -15,6 +15,7 @@ for the selected backend via a single property.
 | Neo4j | `neo4j` | `graph-neo4j` |
 | Memgraph | `memgraph` | `graph-memgraph` |
 | Apache AGE (PostgreSQL) | `age` | `graph-age` |
+| FalkorDB (Redis module) | `falkordb` | `graph-falkordb` |
 
 ## Getting Started
 
@@ -81,6 +82,21 @@ bluetape4k:
 
 > AGE requires a JDBC `DataSource` bean. Add `spring-boot-jdbc` to your dependencies.
 
+**FalkorDB (Redis-based graph database):**
+```yaml
+bluetape4k:
+  graph:
+    backend: falkordb
+    falkordb:
+      host: localhost
+      port: 6379
+      username: ""        # leave blank for unauthenticated access
+      password: ""
+      graph-name: my_graph
+      register-suspend: true
+      register-virtual-thread: true
+```
+
 ### 3. Inject and use
 
 ```kotlin
@@ -104,7 +120,7 @@ class MyGraphService(
 | `GraphOperations` | Always when backend is active |
 | `GraphSuspendOperations` | `register-suspend=true` (default) |
 | `GraphVirtualThreadOperations` | `register-virtual-thread=true` (default) |
-| `HealthIndicator` (Neo4j/Memgraph) | When `spring-boot-health` is on classpath |
+| `HealthIndicator` (Neo4j/Memgraph/AGE/TinkerGraph/FalkorDB) | When `spring-boot-health` is on classpath |
 
 All beans use `@ConditionalOnMissingBean` — provide your own bean to override.
 
@@ -140,6 +156,18 @@ Same properties as Neo4j with prefix `bluetape4k.graph.memgraph`. Default databa
 | `register-suspend` | `true` | Register `GraphSuspendOperations` |
 | `register-virtual-thread` | `true` | Register `GraphVirtualThreadOperations` |
 
+### FalkorDB (`bluetape4k.graph.falkordb.*`)
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `host` | `localhost` | FalkorDB host address |
+| `port` | `6379` | FalkorDB Redis port |
+| `username` | *(empty)* | Authentication username (blank = no-auth) |
+| `password` | *(empty)* | Authentication password (blank = no-auth) |
+| `graph-name` | `bluetape4k` | Target graph name |
+| `register-suspend` | `true` | Register `GraphSuspendOperations` |
+| `register-virtual-thread` | `true` | Register `GraphVirtualThreadOperations` |
+
 ## Auto-Configuration Classes
 
 | Class | Activated when |
@@ -149,6 +177,7 @@ Same properties as Neo4j with prefix `bluetape4k.graph.memgraph`. Default databa
 | `GraphNeo4jAutoConfiguration` | `backend=neo4j` |
 | `GraphMemgraphAutoConfiguration` | `backend=memgraph` |
 | `GraphAgeAutoConfiguration` | `backend=age` |
+| `GraphFalkorDBAutoConfiguration` | `backend=falkordb` |
 
 ## Spring Boot 4 Notes
 

--- a/spring-boot/graph-spring-boot/build.gradle.kts
+++ b/spring-boot/graph-spring-boot/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(libs.neo4j.java.driver)
     testRuntimeOnly(libs.postgresql.driver)
     testImplementation(libs.hikaricp)
+    testImplementation("org.springframework.boot:spring-boot-health")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfigurationTest.kt
@@ -78,4 +78,12 @@ class GraphFalkorDBAutoConfigurationTest {
                     .isInstanceOf(NoSuchBeanDefinitionException::class.java)
             }
     }
+
+    @Test
+    fun `backend=falkordb 이면 HealthIndicator 빈 등록`() {
+        runner.withPropertyValues(*falkordbProperties)
+            .run { ctx ->
+                ctx.getBean(org.springframework.boot.health.contributor.HealthIndicator::class.java).shouldNotBeNull()
+            }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #125

The `GraphFalkorDBAutoConfiguration.HealthConfig` inner class (added in PR #106) was already implemented but lacked a test and README documentation.

## Changes

### `GraphFalkorDBAutoConfigurationTest.kt`
- Added `backend=falkordb 이면 HealthIndicator 빈 등록` test
- `ApplicationContextRunner` verifies `HealthIndicator` bean is registered when `spring-boot-health` is on classpath and `backend=falkordb`

### `build.gradle.kts`
- Added `testImplementation("org.springframework.boot:spring-boot-health")`
- Required for `@ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])` to activate in test context

### `README.md` (5 locations)
- Supported Backends table: added FalkorDB row (`falkordb` / `graph-falkordb`)
- Getting Started: added FalkorDB `application.yml` example block
- Registered Beans table: updated HealthIndicator entry to list all 5 backends
- Configuration Properties: added `### FalkorDB` section (7 properties)
- Auto-Configuration Classes table: added `GraphFalkorDBAutoConfiguration`

### `README.ko.md`
- Same 5 locations updated in Korean

## Test Results

```
./gradlew :graph-spring-boot:test --tests "*.GraphFalkorDBAutoConfigurationTest"
5 tests, 0 failures — BUILD SUCCESSFUL (2.845s)
```

## Checklist
- [x] Health indicator already implemented (PR #106) — test now verifies it
- [x] `shouldNotBeNull()` assertion (bluetape4k-assertions)
- [x] README.md + README.ko.md structurally in sync
- [x] Closes #125