### PR TITLE
refactor: rename module artifact IDs to bluetape4k-graph-* convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,14 +168,14 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             ./gradlew \
-              :graph-core:test \
-              :graph-tinkerpop:test \
-              :graph-io-core:test \
-              :graph-io-csv:test \
-              :graph-io-jackson2:test \
-              :graph-io-jackson3:test \
-              :graph-io-graphml:test \
-              :graph-okio:test \
+              :bluetape4k-graph-core:test \
+              :bluetape4k-graph-tinkerpop:test \
+              :bluetape4k-graph-io-core:test \
+              :bluetape4k-graph-io-csv:test \
+              :bluetape4k-graph-io-jackson2:test \
+              :bluetape4k-graph-io-jackson3:test \
+              :bluetape4k-graph-io-graphml:test \
+              :bluetape4k-graph-okio:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
@@ -187,14 +187,14 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :graph-core:koverXmlReport \
-            :graph-tinkerpop:koverXmlReport \
-            :graph-io-core:koverXmlReport \
-            :graph-io-csv:koverXmlReport \
-            :graph-io-jackson2:koverXmlReport \
-            :graph-io-jackson3:koverXmlReport \
-            :graph-io-graphml:koverXmlReport \
-            :graph-okio:koverXmlReport \
+            :bluetape4k-graph-core:koverXmlReport \
+            :bluetape4k-graph-tinkerpop:koverXmlReport \
+            :bluetape4k-graph-io-core:koverXmlReport \
+            :bluetape4k-graph-io-csv:koverXmlReport \
+            :bluetape4k-graph-io-jackson2:koverXmlReport \
+            :bluetape4k-graph-io-jackson3:koverXmlReport \
+            :bluetape4k-graph-io-graphml:koverXmlReport \
+            :bluetape4k-graph-okio:koverXmlReport \
             --no-daemon --continue
         continue-on-error: true
 
@@ -246,7 +246,7 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             ./gradlew \
-              :graph-spring-boot:test \
+              :bluetape4k-graph-spring-boot:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
@@ -259,7 +259,7 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :graph-spring-boot:koverXmlReport \
+            :bluetape4k-graph-spring-boot:koverXmlReport \
             --no-daemon
         continue-on-error: true
 
@@ -317,7 +317,7 @@ jobs:
       - name: Test graph-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-ktor:test --no-daemon --continue && break
+            ./gradlew :bluetape4k-graph-ktor:test --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -334,7 +334,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-ktor:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-ktor:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -387,7 +387,7 @@ jobs:
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-neo4j:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-neo4j:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -404,7 +404,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-neo4j:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -457,7 +457,7 @@ jobs:
       - name: Test graph-memgraph
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-memgraph:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-memgraph:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -474,7 +474,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-memgraph:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-memgraph:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -527,7 +527,7 @@ jobs:
       - name: Test graph-age
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-age:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-age:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -544,7 +544,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-age:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-age:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -597,7 +597,7 @@ jobs:
       - name: Test graph-falkordb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-falkordb:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-falkordb:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -614,7 +614,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-falkordb:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-falkordb:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,14 +87,14 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             ./gradlew \
-              :graph-core:test \
-              :graph-tinkerpop:test \
-              :graph-io-core:test \
-              :graph-io-csv:test \
-              :graph-io-jackson2:test \
-              :graph-io-jackson3:test \
-              :graph-io-graphml:test \
-              :graph-okio:test \
+              :bluetape4k-graph-core:test \
+              :bluetape4k-graph-tinkerpop:test \
+              :bluetape4k-graph-io-core:test \
+              :bluetape4k-graph-io-csv:test \
+              :bluetape4k-graph-io-jackson2:test \
+              :bluetape4k-graph-io-jackson3:test \
+              :bluetape4k-graph-io-graphml:test \
+              :bluetape4k-graph-okio:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
@@ -106,9 +106,9 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :graph-core:koverXmlReport \
-            :graph-tinkerpop:koverXmlReport \
-            :graph-okio:koverXmlReport \
+            :bluetape4k-graph-core:koverXmlReport \
+            :bluetape4k-graph-tinkerpop:koverXmlReport \
+            :bluetape4k-graph-okio:koverXmlReport \
             --no-daemon
         continue-on-error: true
 
@@ -151,7 +151,7 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             ./gradlew \
-              :graph-spring-boot:test \
+              :bluetape4k-graph-spring-boot:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
@@ -164,7 +164,7 @@ jobs:
         if: always()
         run: |
           ./gradlew \
-            :graph-spring-boot:koverXmlReport \
+            :bluetape4k-graph-spring-boot:koverXmlReport \
             --no-daemon
         continue-on-error: true
 
@@ -215,7 +215,7 @@ jobs:
       - name: Test graph-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-ktor:test --no-daemon --continue && break
+            ./gradlew :bluetape4k-graph-ktor:test --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -232,7 +232,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-ktor:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-ktor:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -282,7 +282,7 @@ jobs:
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-neo4j:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-neo4j:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -299,7 +299,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-neo4j:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -349,7 +349,7 @@ jobs:
       - name: Test graph-memgraph
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-memgraph:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-memgraph:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -366,7 +366,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-memgraph:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-memgraph:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -416,7 +416,7 @@ jobs:
       - name: Test graph-age
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-age:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-age:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -433,7 +433,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-age:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-age:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -483,7 +483,7 @@ jobs:
       - name: Test graph-falkordb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :graph-falkordb:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-falkordb:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -500,7 +500,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :graph-falkordb:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-graph-falkordb:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,13 +55,13 @@ examples/
 ```bash
 ./gradlew build -x test
 ./gradlew test
-./gradlew :graph-neo4j:build
+./gradlew :bluetape4k-graph-neo4j:build
 ./gradlew :graph-okio:test
 ./gradlew :code-graph-examples:test
 ./gradlew :fraud-detection-examples:test
 ./gradlew :knowledge-graph-examples:test
 ./gradlew :recommendation-examples:test
-./gradlew :graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
+./gradlew :bluetape4k-graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
 ./gradlew publishBluetapeGraphPublicationToMavenLocalRepository
 ./gradlew publishAggregationToCentralPortal
 ```
@@ -97,11 +97,11 @@ Schema DSL uses Exposed Table-style declarations through `VertexLabel` and
 
 | Module | Driver | Query language | Local verification |
 |---|---|---|---|
-| `graph-neo4j` | Neo4j Java Driver | Cypher | Testcontainers `neo4j:5` |
-| `graph-memgraph` | Neo4j Java Driver compatible | Cypher | Testcontainers `memgraph/memgraph` |
-| `graph-age` | PostgreSQL JDBC + Exposed | Cypher-over-SQL | Testcontainers `apache/age:PG16_latest` |
-| `graph-tinkerpop` | TinkerGraph | Gremlin | In-memory JVM graph |
-| `graph-falkordb` | jfalkordb 0.7.0, Jedis-based | openCypher subset | Testcontainers `falkordb/falkordb:v4.18.1` |
+| `bluetape4k-graph-neo4j` | Neo4j Java Driver | Cypher | Testcontainers `neo4j:5` |
+| `bluetape4k-graph-memgraph` | Neo4j Java Driver compatible | Cypher | Testcontainers `memgraph/memgraph` |
+| `bluetape4k-graph-age` | PostgreSQL JDBC + Exposed | Cypher-over-SQL | Testcontainers `apache/age:PG16_latest` |
+| `bluetape4k-graph-tinkerpop` | TinkerGraph | Gremlin | In-memory JVM graph |
+| `bluetape4k-graph-falkordb` | jfalkordb 0.7.0, Jedis-based | openCypher subset | Testcontainers `falkordb/falkordb:v4.18.1` |
 
 Amazon Neptune work is intentionally blocked by issue #113 until local or
 reliable integration testability is proven. Do not implement a backend against
@@ -109,7 +109,7 @@ mocks only.
 
 ## graph-io
 
-- `graph-io-core` owns shared contracts, records, options, path helpers, and
+- `bluetape4k-graph-io-core` owns shared contracts, records, options, path helpers, and
   external ID mapping.
 - CSV, Jackson2 NDJSON, Jackson3 NDJSON, and GraphML provide sync,
   virtual-thread, and coroutine import/export paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,20 +56,20 @@ examples/
 ```bash
 ./gradlew build -x test
 ./gradlew test
-./gradlew :graph-neo4j:build
+./gradlew :bluetape4k-graph-neo4j:build
 ./gradlew :graph-okio:test
 ./gradlew :code-graph-examples:test
 ./gradlew :fraud-detection-examples:test
 ./gradlew :knowledge-graph-examples:test
 ./gradlew :recommendation-examples:test
-./gradlew :graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
+./gradlew :bluetape4k-graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
 ./gradlew publishBluetapeGraphPublicationToMavenLocalRepository
 ./gradlew publishAggregationToCentralPortal
 ```
 
 ## Architecture
 
-`graph-core` owns the common model and contracts. Backend modules implement
+`bluetape4k-graph-core` owns the common model and contracts. Backend modules implement
 those contracts with each database's driver and query language.
 
 ```text
@@ -91,11 +91,11 @@ Core concepts:
 
 | Module | Driver | Query language | Local verification |
 |---|---|---|---|
-| `graph-neo4j` | Neo4j Java Driver | Cypher | Testcontainers `neo4j:5` |
-| `graph-memgraph` | Neo4j Java Driver compatible | Cypher | Testcontainers `memgraph/memgraph` |
-| `graph-age` | PostgreSQL JDBC + Exposed | Cypher-over-SQL | Testcontainers `apache/age:PG16_latest` |
-| `graph-tinkerpop` | TinkerGraph | Gremlin | In-memory JVM graph |
-| `graph-falkordb` | jfalkordb 0.7.0, Jedis-based | openCypher subset | Testcontainers `falkordb/falkordb:v4.18.1` |
+| `bluetape4k-graph-neo4j` | Neo4j Java Driver | Cypher | Testcontainers `neo4j:5` |
+| `bluetape4k-graph-memgraph` | Neo4j Java Driver compatible | Cypher | Testcontainers `memgraph/memgraph` |
+| `bluetape4k-graph-age` | PostgreSQL JDBC + Exposed | Cypher-over-SQL | Testcontainers `apache/age:PG16_latest` |
+| `bluetape4k-graph-tinkerpop` | TinkerGraph | Gremlin | In-memory JVM graph |
+| `bluetape4k-graph-falkordb` | jfalkordb 0.7.0, Jedis-based | openCypher subset | Testcontainers `falkordb/falkordb:v4.18.1` |
 
 Amazon Neptune implementation is blocked by issue #113 until local or reliable
 integration testability is proven. Do not build Neptune support against mocks

--- a/README.ko.md
+++ b/README.ko.md
@@ -279,8 +279,8 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-neo4j")   // 버전 생략 가능
-    implementation("io.github.bluetape4k.graph:graph-age")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")   // 버전 생략 가능
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-age")
 }
 ```
 
@@ -288,8 +288,8 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-core:0.2.0")
-    implementation("io.github.bluetape4k.graph:graph-neo4j:0.2.0")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:0.2.0")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:0.2.0")
     // graph-age | graph-memgraph | graph-tinkerpop | graph-ktor
 }
 ```

--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-neo4j")   // version can be omitted
-    implementation("io.github.bluetape4k.graph:graph-age")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")   // version can be omitted
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-age")
 }
 ```
 
@@ -288,8 +288,8 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-core:0.2.0")
-    implementation("io.github.bluetape4k.graph:graph-neo4j:0.2.0")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:0.2.0")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:0.2.0")
     // graph-age | graph-memgraph | graph-tinkerpop | graph-ktor
 }
 ```

--- a/benchmark/graph-age-benchmark/build.gradle.kts
+++ b/benchmark/graph-age-benchmark/build.gradle.kts
@@ -24,8 +24,8 @@ benchmark {
 }
 
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-age"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-age"))
 
     implementation(libs.kotlinx.benchmark.runtime)
     implementation(libs.bluetape4k.core)

--- a/benchmark/graph-benchmark/build.gradle.kts
+++ b/benchmark/graph-benchmark/build.gradle.kts
@@ -22,8 +22,8 @@ benchmark {
 }
 
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
 
     implementation(libs.kotlinx.benchmark.runtime)
     implementation(libs.bluetape4k.core)

--- a/benchmark/graph-io-benchmark/build.gradle.kts
+++ b/benchmark/graph-io-benchmark/build.gradle.kts
@@ -22,13 +22,13 @@ benchmark {
 }
 
 dependencies {
-    implementation(project(":graph-io-core"))
-    implementation(project(":graph-io-csv"))
-    implementation(project(":graph-io-jackson2"))
-    implementation(project(":graph-io-jackson3"))
-    implementation(project(":graph-io-graphml"))
-    implementation(project(":graph-okio"))
-    implementation(project(":graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-io-core"))
+    implementation(project(":bluetape4k-graph-io-csv"))
+    implementation(project(":bluetape4k-graph-io-jackson2"))
+    implementation(project(":bluetape4k-graph-io-jackson3"))
+    implementation(project(":bluetape4k-graph-io-graphml"))
+    implementation(project(":bluetape4k-graph-okio"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.bluetape4k.virtualthread.api)
     implementation(libs.bluetape4k.virtualthread.jdk21)

--- a/benchmark/graph-neo4j-benchmark/build.gradle.kts
+++ b/benchmark/graph-neo4j-benchmark/build.gradle.kts
@@ -24,8 +24,8 @@ benchmark {
 }
 
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-neo4j"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-neo4j"))
 
     implementation(libs.kotlinx.benchmark.runtime)
     implementation(libs.bluetape4k.core)

--- a/bom/README.ko.md
+++ b/bom/README.ko.md
@@ -81,8 +81,8 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-neo4j")
-    implementation("io.github.bluetape4k.graph:graph-spring-boot")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-spring-boot")
 }
 ```
 
@@ -91,7 +91,7 @@ dependencies {
 ```kotlin
 dependencies {
     implementation(platform("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>"))
-    implementation("io.github.bluetape4k.graph:graph-neo4j")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
 }
 ```
 

--- a/bom/README.md
+++ b/bom/README.md
@@ -82,8 +82,8 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-neo4j")
-    implementation("io.github.bluetape4k.graph:graph-spring-boot")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-spring-boot")
 }
 ```
 
@@ -92,7 +92,7 @@ dependencies {
 ```kotlin
 dependencies {
     implementation(platform("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>"))
-    implementation("io.github.bluetape4k.graph:graph-neo4j")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j")
 }
 ```
 

--- a/examples/code-graph-examples/build.gradle.kts
+++ b/examples/code-graph-examples/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-age"))
-    implementation(project(":graph-neo4j"))
-    implementation(project(":graph-memgraph"))
-    implementation(project(":graph-tinkerpop"))
-    implementation(project(":graph-falkordb"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-age"))
+    implementation(project(":bluetape4k-graph-neo4j"))
+    implementation(project(":bluetape4k-graph-memgraph"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)
@@ -18,6 +18,6 @@ dependencies {
     testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
     testImplementation(libs.hikaricp)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 }

--- a/examples/fraud-detection-examples/build.gradle.kts
+++ b/examples/fraud-detection-examples/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-age"))
-    implementation(project(":graph-neo4j"))
-    implementation(project(":graph-memgraph"))
-    implementation(project(":graph-tinkerpop"))
-    implementation(project(":graph-falkordb"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-age"))
+    implementation(project(":bluetape4k-graph-neo4j"))
+    implementation(project(":bluetape4k-graph-memgraph"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)
@@ -18,6 +18,6 @@ dependencies {
     testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
     testImplementation(libs.hikaricp)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 }

--- a/examples/knowledge-graph-examples/build.gradle.kts
+++ b/examples/knowledge-graph-examples/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-age"))
-    implementation(project(":graph-neo4j"))
-    implementation(project(":graph-memgraph"))
-    implementation(project(":graph-tinkerpop"))
-    implementation(project(":graph-falkordb"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-age"))
+    implementation(project(":bluetape4k-graph-neo4j"))
+    implementation(project(":bluetape4k-graph-memgraph"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)
@@ -18,6 +18,6 @@ dependencies {
     testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
     testImplementation(libs.hikaricp)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 }

--- a/examples/ktor-graph-examples/build.gradle.kts
+++ b/examples/ktor-graph-examples/build.gradle.kts
@@ -17,9 +17,9 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation(project(":graph-ktor"))
-    implementation(project(":graph-tinkerpop"))
-    implementation(project(":graph-falkordb"))
+    implementation(project(":bluetape4k-graph-ktor"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.bluetape4k.logging)
@@ -33,5 +33,5 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 }

--- a/examples/linkedin-graph-examples/build.gradle.kts
+++ b/examples/linkedin-graph-examples/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-age"))
-    implementation(project(":graph-neo4j"))
-    implementation(project(":graph-memgraph"))
-    implementation(project(":graph-tinkerpop"))
-    implementation(project(":graph-falkordb"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-age"))
+    implementation(project(":bluetape4k-graph-neo4j"))
+    implementation(project(":bluetape4k-graph-memgraph"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)
@@ -18,6 +18,6 @@ dependencies {
     testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
     testImplementation(libs.hikaricp)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 }

--- a/examples/recommendation-examples/build.gradle.kts
+++ b/examples/recommendation-examples/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    implementation(project(":graph-core"))
-    implementation(project(":graph-age"))
-    implementation(project(":graph-neo4j"))
-    implementation(project(":graph-memgraph"))
-    implementation(project(":graph-tinkerpop"))
-    implementation(project(":graph-falkordb"))
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-age"))
+    implementation(project(":bluetape4k-graph-neo4j"))
+    implementation(project(":bluetape4k-graph-memgraph"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-falkordb"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)
@@ -18,6 +18,6 @@ dependencies {
     testRuntimeOnly(libs.postgresql.driver)           // bluetape4k-testcontainers는 compileOnly로 선언
     testImplementation(libs.hikaricp)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 }

--- a/graph-io/core/build.gradle.kts
+++ b/graph-io/core/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
     api(libs.bluetape4k.core)
     api(libs.bluetape4k.io)
     api(libs.kotlinx.coroutines.core.lib)
@@ -9,5 +9,5 @@ dependencies {
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
 }

--- a/graph-io/csv/build.gradle.kts
+++ b/graph-io/csv/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-io-core"))
+    api(project(":bluetape4k-graph-io-core"))
     api(libs.bluetape4k.csv)
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.bluetape4k.virtualthread.api)
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
 }

--- a/graph-io/graphml/build.gradle.kts
+++ b/graph-io/graphml/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    api(project(":graph-io-core"))
+    api(project(":bluetape4k-graph-io-core"))
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.bluetape4k.virtualthread.api)
     implementation(libs.bluetape4k.virtualthread.jdk21)
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
 }

--- a/graph-io/jackson2/build.gradle.kts
+++ b/graph-io/jackson2/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-io-core"))
+    api(project(":bluetape4k-graph-io-core"))
     api(libs.bluetape4k.jackson2)
     api(libs.jackson.module.kotlin)
     api(libs.jackson.module.blackbird)
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
 }

--- a/graph-io/jackson3/build.gradle.kts
+++ b/graph-io/jackson3/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-io-core"))
+    api(project(":bluetape4k-graph-io-core"))
     api(libs.bluetape4k.jackson3)
     api(libs.jackson3.module.kotlin)
     api(libs.jackson3.module.blackbird)
@@ -10,6 +10,6 @@ dependencies {
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-tinkerpop"))
-    testImplementation(project(":graph-io-jackson2"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-io-jackson2"))
 }

--- a/graph-io/okio/README.ko.md
+++ b/graph-io/okio/README.ko.md
@@ -326,7 +326,7 @@ class MyGraphIoTest {
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-okio:VERSION")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-okio:VERSION")
 
     // 선택적 압축 라이브러리 (필요한 것만 추가)
     implementation("org.lz4:lz4-java:1.8.0")

--- a/graph-io/okio/README.md
+++ b/graph-io/okio/README.md
@@ -344,7 +344,7 @@ class MyGraphIoTest {
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-okio:VERSION")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-okio:VERSION")
 
     // Optional compression libraries — add only what you need
     implementation("org.lz4:lz4-java:1.8.0")

--- a/graph-io/okio/build.gradle.kts
+++ b/graph-io/okio/build.gradle.kts
@@ -1,13 +1,13 @@
 dependencies {
-    api(project(":graph-io-core"))
+    api(project(":bluetape4k-graph-io-core"))
     api(libs.bluetape4k.okio)
     api(libs.bluetape4k.tink)
 
     // 기존 graph-io 모듈 — 포맷별 임포터/익스포터 위임
-    implementation(project(":graph-io-csv"))
-    implementation(project(":graph-io-jackson2"))
-    implementation(project(":graph-io-jackson3"))
-    implementation(project(":graph-io-graphml"))
+    implementation(project(":bluetape4k-graph-io-csv"))
+    implementation(project(":bluetape4k-graph-io-jackson2"))
+    implementation(project(":bluetape4k-graph-io-jackson3"))
+    implementation(project(":bluetape4k-graph-io-graphml"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.bluetape4k.virtualthread.api)
@@ -22,7 +22,7 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test.lib)
     testImplementation(libs.okio.fakefilesystem)
-    testImplementation(project(":graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
 
     // 통합 테스트에서 압축 알고리즘 실제 사용
     testImplementation(libs.snappy.java)

--- a/graph/graph-age/build.gradle.kts
+++ b/graph/graph-age/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
 
     api(libs.exposed.core)
     api(libs.exposed.dao)

--- a/graph/graph-core/README.md
+++ b/graph/graph-core/README.md
@@ -273,13 +273,13 @@ val path = graphOps.shortestPath(
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-core:0.0.1")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:0.0.1")
 
     // pick one backend
-    implementation("io.github.bluetape4k.graph:graph-neo4j:0.0.1")
-    // implementation("io.github.bluetape4k.graph:graph-age:0.0.1")
-    // implementation("io.github.bluetape4k.graph:graph-memgraph:0.0.1")
-    // implementation("io.github.bluetape4k.graph:graph-tinkerpop:0.0.1")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:0.0.1")
+    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:0.0.1")
+    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:0.0.1")
+    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:0.0.1")
 }
 ```
 

--- a/graph/graph-core/build.gradle.kts
+++ b/graph/graph-core/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.kotlinx.coroutines.test.lib)
-    testImplementation(project(":graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
 }

--- a/graph/graph-falkordb/build.gradle.kts
+++ b/graph/graph-falkordb/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
 
     api(libs.jfalkordb)
     api(libs.bluetape4k.coroutines)

--- a/graph/graph-memgraph/build.gradle.kts
+++ b/graph/graph-memgraph/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
-    api(project(":graph-core"))
-    api(project(":graph-neo4j"))
+    api(project(":bluetape4k-graph-core"))
+    api(project(":bluetape4k-graph-neo4j"))
 
     api(libs.neo4j.java.driver)
     runtimeOnly(libs.neo4j.bolt.connection.netty)

--- a/graph/graph-neo4j/build.gradle.kts
+++ b/graph/graph-neo4j/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
     api(libs.neo4j.java.driver)
     runtimeOnly(libs.neo4j.bolt.connection.netty)
     runtimeOnly(libs.neo4j.bolt.connection.pooled)

--- a/graph/graph-tinkerpop/build.gradle.kts
+++ b/graph/graph-tinkerpop/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
 
     api(libs.tinkerpop.gremlin.core)
     api(libs.tinkergraph.gremlin)

--- a/ktor/graph-ktor/README.ko.md
+++ b/ktor/graph-ktor/README.ko.md
@@ -33,8 +33,8 @@ flowchart LR
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-ktor")
-    implementation("io.github.bluetape4k.graph:graph-tinkerpop") // 또는 graph-neo4j, graph-age, ...
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-ktor")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop") // 또는 graph-neo4j, graph-age, ...
     implementation("io.ktor:ktor-server-core")
 }
 ```

--- a/ktor/graph-ktor/README.md
+++ b/ktor/graph-ktor/README.md
@@ -32,8 +32,8 @@ Use `graph-ktor` with the backend module your application actually runs.
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-ktor")
-    implementation("io.github.bluetape4k.graph:graph-tinkerpop") // or graph-neo4j, graph-age, ...
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-ktor")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop") // or graph-neo4j, graph-age, ...
     implementation("io.ktor:ktor-server-core")
 }
 ```

--- a/ktor/graph-ktor/build.gradle.kts
+++ b/ktor/graph-ktor/build.gradle.kts
@@ -9,7 +9,7 @@ dependencyManagement {
 }
 
 dependencies {
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
 
     api(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)
@@ -18,11 +18,11 @@ dependencies {
     compileOnly(libs.ktor.server.core)
 
     // Backend helpers are compile-only; applications choose the concrete runtime backend.
-    compileOnly(project(":graph-tinkerpop"))
-    compileOnly(project(":graph-neo4j"))
-    compileOnly(project(":graph-memgraph"))
-    compileOnly(project(":graph-age"))
-    compileOnly(project(":graph-falkordb"))
+    compileOnly(project(":bluetape4k-graph-tinkerpop"))
+    compileOnly(project(":bluetape4k-graph-neo4j"))
+    compileOnly(project(":bluetape4k-graph-memgraph"))
+    compileOnly(project(":bluetape4k-graph-age"))
+    compileOnly(project(":bluetape4k-graph-falkordb"))
 
     // Logging
     implementation(libs.bluetape4k.logging)
@@ -32,12 +32,12 @@ dependencies {
     testImplementation(libs.ktor.server.cio)
     testImplementation(libs.ktor.server.test.host)
 
-    testImplementation(project(":graph-tinkerpop"))
-    testImplementation(project(":graph-neo4j"))
-    testImplementation(project(":graph-memgraph"))
-    testImplementation(project(":graph-age"))
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-neo4j"))
+    testImplementation(project(":bluetape4k-graph-memgraph"))
+    testImplementation(project(":bluetape4k-graph-age"))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
 
     testImplementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.testcontainers.core)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,14 +17,14 @@ rootProject.name = "$baseProjectName-graph"
 include("bluetape4k-graph-bom")
 project(":bluetape4k-graph-bom").projectDir = file("bom")
 
-includeModules("graph", false, false)
-includeModules("graph-io", false, true, excludeModuleNames = setOf("okio"))
-include("graph-okio")
-project(":graph-okio").projectDir = file("graph-io/okio")
+includeModules("graph", true, false)
+includeModules("graph-io", true, true, excludeModuleNames = setOf("okio"))
+include("bluetape4k-graph-okio")
+project(":bluetape4k-graph-okio").projectDir = file("graph-io/okio")
 includeModules("benchmark", false, false)
 includeModules("examples", false, false)
-includeModules("ktor", false, false)
-includeModules("spring-boot", false, false)
+includeModules("ktor", true, false)
+includeModules("spring-boot", true, false)
 
 fun includeModules(
     baseDir: String,

--- a/spring-boot/graph-spring-boot/README.ko.md
+++ b/spring-boot/graph-spring-boot/README.ko.md
@@ -24,10 +24,10 @@
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-spring-boot:<version>")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-spring-boot:<version>")
 
     // 런타임에 사용할 백엔드 하나만 추가
-    runtimeOnly("io.github.bluetape4k.graph:graph-neo4j:<version>")   // 또는 graph-memgraph / graph-age / graph-tinkerpop
+    runtimeOnly("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:<version>")   // 또는 graph-memgraph / graph-age / graph-tinkerpop
 }
 ```
 

--- a/spring-boot/graph-spring-boot/README.md
+++ b/spring-boot/graph-spring-boot/README.md
@@ -24,10 +24,10 @@ for the selected backend via a single property.
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("io.github.bluetape4k.graph:graph-spring-boot:<version>")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-spring-boot:<version>")
 
     // Add ONE backend at runtime
-    runtimeOnly("io.github.bluetape4k.graph:graph-neo4j:<version>")   // or graph-memgraph / graph-age / graph-tinkerpop
+    runtimeOnly("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:<version>")   // or graph-memgraph / graph-age / graph-tinkerpop
 }
 ```
 

--- a/spring-boot/graph-spring-boot/build.gradle.kts
+++ b/spring-boot/graph-spring-boot/build.gradle.kts
@@ -10,13 +10,13 @@ dependencies {
     implementation(platform(libs.spring.boot4.dependencies))
 
     // graph-core는 api로 전이 노출 — GraphOperations 등 공개 API 타입이 전이 노출 필요
-    api(project(":graph-core"))
+    api(project(":bluetape4k-graph-core"))
     // 백엔드 구현 모듈(graph-neo4j 등)만 compileOnly — 사용자가 원하는 백엔드만 runtime에 추가.
-    compileOnly(project(":graph-neo4j"))
-    compileOnly(project(":graph-memgraph"))
-    compileOnly(project(":graph-age"))
-    compileOnly(project(":graph-tinkerpop"))
-    compileOnly(project(":graph-falkordb"))
+    compileOnly(project(":bluetape4k-graph-neo4j"))
+    compileOnly(project(":bluetape4k-graph-memgraph"))
+    compileOnly(project(":bluetape4k-graph-age"))
+    compileOnly(project(":bluetape4k-graph-tinkerpop"))
+    compileOnly(project(":bluetape4k-graph-falkordb"))
 
     // Spring Boot 4.x (위 BOM override 적용됨)
     api("org.springframework.boot:spring-boot-autoconfigure")
@@ -31,12 +31,12 @@ dependencies {
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${libs.versions.spring.boot4.get()}")
 
     // Test
-    testImplementation(project(":graph-tinkerpop"))
-    testImplementation(project(":graph-neo4j"))
-    testImplementation(project(":graph-memgraph"))
-    testImplementation(project(":graph-age"))
-    testImplementation(project(":graph-falkordb"))
-    testImplementation(testFixtures(project(":graph-falkordb")))
+    testImplementation(project(":bluetape4k-graph-tinkerpop"))
+    testImplementation(project(":bluetape4k-graph-neo4j"))
+    testImplementation(project(":bluetape4k-graph-memgraph"))
+    testImplementation(project(":bluetape4k-graph-age"))
+    testImplementation(project(":bluetape4k-graph-falkordb"))
+    testImplementation(testFixtures(project(":bluetape4k-graph-falkordb")))
     testImplementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.testcontainers.neo4j)
     testImplementation(libs.testcontainers.postgresql)


### PR DESCRIPTION
## Summary

Rename all publishable module artifact IDs to follow the `bluetape4k-<repo>-<module>` naming convention.

**Strategy**: change `withProjectName=true` in `includeModules()` calls — no directory renames needed.

## Rename Mapping

| Before | After |
|---|---|
| `graph-core` | `bluetape4k-graph-core` |
| `graph-age` | `bluetape4k-graph-age` |
| `graph-falkordb` | `bluetape4k-graph-falkordb` |
| `graph-memgraph` | `bluetape4k-graph-memgraph` |
| `graph-neo4j` | `bluetape4k-graph-neo4j` |
| `graph-tinkerpop` | `bluetape4k-graph-tinkerpop` |
| `graph-io-core` | `bluetape4k-graph-io-core` |
| `graph-io-csv` | `bluetape4k-graph-io-csv` |
| `graph-io-graphml` | `bluetape4k-graph-io-graphml` |
| `graph-io-jackson2` | `bluetape4k-graph-io-jackson2` |
| `graph-io-jackson3` | `bluetape4k-graph-io-jackson3` |
| `graph-okio` | `bluetape4k-graph-okio` |
| `graph-spring-boot` | `bluetape4k-graph-spring-boot` |
| `graph-ktor` | `bluetape4k-graph-ktor` |

Benchmarks and examples keep their original names (not published).

## Files Changed

- `settings.gradle.kts`: `withProjectName=false` → `withProjectName=true` for library modules; `graph-okio` → `bluetape4k-graph-okio`
- Module `build.gradle.kts` files: internal `project()` refs
- `bom/build.gradle.kts`: auto-discovers new names (no manual change)
- `.github/workflows/ci.yml`, `nightly.yml`: Gradle task references
- `README.md`, `README.ko.md`: artifact IDs in usage examples
- `CLAUDE.md`, `AGENTS.md`: module name references