### PR TITLE
chore: upgrade JetBrains Exposed to 1.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ spring-boot4 = "4.0.6"  # https://mvnrepository.com/artifact/org.springframework
 neo4j-java-driver = "6.1.0"  # https://mvnrepository.com/artifact/org.neo4j.driver/neo4j-java-driver
 neo4j-bolt-connection = "11.0.2"  # https://mvnrepository.com/artifact/org.neo4j.bolt/neo4j-bolt-connection-bom
 
-exposed = "1.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-core
+exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-core
 
 okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio-fakefilesystem
 okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom


### PR DESCRIPTION
Aligns JetBrains Exposed version to 1.3.0 across the bluetape4k ecosystem.

## Why
`bluetape4k-exposed` and `bluetape4k-leader` already use `exposed = 1.3.0`.
`bluetape4k-dependencies` is the version source-of-truth and requires all repos to stay in sync.

## Changes
- `gradle/libs.versions.toml`: `exposed 1.2.0` → `1.3.0`