### PR TITLE
chore: parameterize snapshot publishing

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -38,7 +38,7 @@ jobs:
           cache-read-only: true
       - name: Publish SNAPSHOT
         run: |
-          ./gradlew publishAggregationToCentralSnapshots \
+          ./gradlew publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT \
             --no-daemon --no-configuration-cache --no-build-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/docs/lessons/2026-05-17-snapshot-version-parameterization.md
+++ b/docs/lessons/2026-05-17-snapshot-version-parameterization.md
@@ -1,0 +1,15 @@
+# Snapshot Version Parameterization
+
+Context: Central Portal releases should not require editing `gradle.properties`
+only to remove `-SNAPSHOT`.
+
+Decision: Keep `snapshotVersion=` empty by default and let
+`publish-snapshot.yml` pass `-PsnapshotVersion=-SNAPSHOT`.
+
+Outcome: `develop` stays release-ready, while snapshot publishing remains
+explicit in the workflow command.
+
+Verification: `actionlint .github/workflows/publish-snapshot.yml`.
+
+Future guard: Do not reintroduce `snapshotVersion=-SNAPSHOT` as the default in
+`gradle.properties`.


### PR DESCRIPTION
## Summary
- keep snapshotVersion empty by default so the working tree stays release-ready
- pass -PsnapshotVersion=-SNAPSHOT from publish-snapshot.yml only
- add a lesson entry to preserve the release workflow decision

## Verification
- actionlint .github/workflows/publish-snapshot.yml

## Notes
- This PR does not publish artifacts, create tags, or trigger a release.