### PR TITLE
fix: use released bluetape4k BOM for graph

### DIFF
--- a/docs/lessons/2026-05-17-central-release-pom-metadata.md
+++ b/docs/lessons/2026-05-17-central-release-pom-metadata.md
@@ -1,0 +1,27 @@
+# Central Release POM Metadata
+
+## Context
+
+The 0.3.0 Central Portal release failed validation because graph POMs still
+referenced `io.github.bluetape4k:*:1.8.0-SNAPSHOT`.
+
+## Decision
+
+Use the released `io.github.bluetape4k:bluetape4k-bom:1.8.0` version for graph
+release dependencies.
+
+## Outcome
+
+Generated publication POMs now contain `1.8.0` bluetape4k dependency metadata
+and no `SNAPSHOT` references.
+
+## Verification
+
+- `./gradlew generatePomFileForBluetapeGraphPublication --no-daemon --no-configuration-cache --no-build-cache`
+- Searched generated `pom-default.xml` files for `SNAPSHOT`.
+
+## Future Guidance
+
+Release branches must not reference bluetape4k `-SNAPSHOT` coordinates in
+catalog versions, direct dependency versions, or generated POM dependency
+management.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.8.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.8.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- Replace the remaining graph catalog bluetape4k version from 1.8.0-SNAPSHOT to 1.8.0.
- Add a release lesson for Central Portal SNAPSHOT checks.

## Verification
- ./gradlew generatePomFileForBluetapeGraphPublication --no-daemon --no-configuration-cache --no-build-cache
- find . -path './.worktrees' -prune -o -path '*/publications/*/pom-default.xml' -print | xargs rg -n 'SNAPSHOT'  # no matches
- Generated POMs reference io.github.bluetape4k:bluetape4k-bom:1.8.0.

## Release impact
- Fixes Central Portal validation failure for 0.3.0 caused by SNAPSHOT bluetape4k dependencies.

## DoD
- [x] Release POM metadata generated locally
- [x] No generated POM SNAPSHOT references
- [x] Lesson committed