### PR TITLE
Open 0.3.1 snapshot line

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -70,5 +70,5 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # project version
 #
 projectGroup=io.github.bluetape4k.graph
-baseVersion=0.3.0
-snapshotVersion=
+baseVersion=0.3.1
+snapshotVersion=-SNAPSHOT


### PR DESCRIPTION
## Summary

- Set `baseVersion=0.3.1` and `snapshotVersion=-SNAPSHOT`.
- Align develop with the next patch snapshot after the `0.3.0` release.

## Validation

- `./gradlew properties -q --no-configuration-cache --console=plain` reports `version: 0.3.1-SNAPSHOT`.
- `git diff --check`

## Not Tested

- Full build; version-only maintenance change.