### PR TITLE
build: align CI quality and dependency governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
               - 'settings.gradle.kts'
               - '.github/workflows/ci.yml'
 
-  # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
+  # ── 3. 전체 빌드 + Detekt 품질 게이트 ─────────────────────────────────────
   build:
-    name: Build (compile only)
+    name: Build & Detekt
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [validate-wrapper, changes]
@@ -140,6 +140,19 @@ jobs:
         run: ./gradlew build -x test --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Detekt static analysis
+        run: ./gradlew detekt --parallel
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+      - name: Upload detekt report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: detekt-report
+          path: '**/build/reports/detekt/*.xml'
+          retention-days: 7
 
   # ── 4. Core + TinkerGraph 테스트 (Docker 불필요) ──────────────────────────
   test-core:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: detekt-report
-          path: 'build/reports/detekt/*.xml'
+          path: '**/build/reports/detekt/*.xml'
           retention-days: 14
 
   # ── 2. Core + TinkerGraph (in-memory) ────────────────────────────────────

--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-18 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 17 issues.
+Open count: 17 issues; 15 remain after #18/#19 close through this work.
 
 ## Refresh Notes
 
@@ -14,6 +14,9 @@ Verified with `gh` on 2026-05-18 KST.
   - [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) - `bug: AGE, Memgraph, and TinkerGraph suspendTransaction still bridge through runBlocking`
 - PR #159 (`chore: refresh WIP snapshot - 2026-05-18`) is already merged, so this file reflects the current post-merge GitHub state.
 - Pre-existing local change `gradlew.bat` was not touched.
+- Issues #18 and #19 are handled by the CI quality-gate and dependency-governance refresh:
+  - CI now blocks on Detekt in the PR build job while Kover remains report-only.
+  - Leaf Dependabot stays scoped to GitHub Actions; Gradle/Maven library updates remain centralized in `bluetape4k-dependencies`.
 
 ## Current Direction
 
@@ -34,8 +37,6 @@ contracts and backend readiness before widening examples or benchmark lanes:
 | P1 | [#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158) Neo4jGraphSuspendOperations.suspendTransaction() runBlocking inside withContext(IO) | M | Remove `runBlocking`; use async Neo4j driver or coroutine-safe bridge to prevent IO thread starvation. |
 | P1 | [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) AGE/Memgraph/TinkerGraph suspendTransaction runBlocking bridge | M | Align the remaining suspend transaction implementations with #158. |
 | P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30. |
-| P2 | [#18](https://github.com/bluetape4k/bluetape4k-graph/issues/18) CI quality gates | M | Deferred from 0.3.0. |
-| P2 | [#19](https://github.com/bluetape4k/bluetape4k-graph/issues/19) Dependabot / Renovate automation | S | Deferred from 0.3.0. |
 | P2 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P2 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Useful after backend readiness is clear. |
 | P3 | [#126](https://github.com/bluetape4k/bluetape4k-graph/issues/126) add Spring Boot FalkorDB auto-config to nightly CI coverage | S | CI/documentation lane. |
@@ -76,5 +77,5 @@ contracts and backend readiness before widening examples or benchmark lanes:
 | Cancellation correctness | 1 | Start with `#156`, then `#157`. |
 | Suspend transaction safety | 1 | `#158` and `#160`; fix strategy should be consistent across backends. |
 | Research / backend readiness | 1 | `#113` before `#30`. |
-| CI / automation | 1 | `#18` or `#19`, one at a time. |
+| CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
 | Examples / benchmarks | 1 | `#111` before benchmarks; keep benchmark work after CI is stable. |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,9 @@
+import dev.detekt.gradle.DetektCreateBaselineTask
 import io.bluetape4k.gradle.applyBluetape4kPomMetadata
 import io.bluetape4k.gradle.centralSnapshotsRepository
 import io.bluetape4k.gradle.configurePublishingSigning
 import io.bluetape4k.gradle.resolveCentralPublishingConfig
 import io.bluetape4k.gradle.resolvePublishingSigningConfig
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import nmcp.NmcpAggregationExtension
 import nmcp.NmcpExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -87,6 +86,22 @@ fun Project.isNonPublishedModule(): Boolean {
             name.endsWith("-benchmark")
 }
 
+val detektBaselineFile = layout.projectDirectory.file("config/detekt/baseline.xml")
+
+val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) {
+    description = "Regenerates the shared Detekt baseline for existing findings."
+    ignoreFailures.set(true)
+    parallel.set(true)
+    buildUponDefaultConfig.set(true)
+    setSource(files(rootDir))
+    baseline.set(detektBaselineFile)
+    include("**/*.kt")
+    include("**/*.kts")
+    exclude("**/build/**")
+    exclude("**/.gradle/**")
+    exclude("**/resources/**")
+}
+
 subprojects {
     if (!isNonPublishedModule()) {
         apply(plugin = "com.gradleup.nmcp")
@@ -133,9 +148,21 @@ subprojects {
         plugin("org.jetbrains.dokka")
         plugin("com.adarshr.test-logger")
 
+        // Detekt — CI quality gate for publishable Kotlin modules.
+        if (!isNonPublishedModule()) {
+            plugin("dev.detekt")
+        }
+
         // Kover — Kotlin 코드 커버리지 (bom/benchmark/examples 는 커버리지 대상에서 제외)
         if (!isNonPublishedModule() && name != "bluetape4k-graph-bom") {
             plugin("org.jetbrains.kotlinx.kover")
+        }
+    }
+
+    plugins.withId("dev.detekt") {
+        extensions.configure<dev.detekt.gradle.extensions.DetektExtension>("detekt") {
+            baseline.set(detektBaselineFile)
+            buildUponDefaultConfig.set(true)
         }
     }
 
@@ -251,17 +278,6 @@ subprojects {
         testlogger {
             theme = com.adarshr.gradle.testlogger.theme.ThemeType.MOCHA_PARALLEL
             showFullStackTraces = true
-        }
-
-        val reportMerge by registering(ReportMergeTask::class) {
-            val file = rootProject.layout.buildDirectory.asFile.get().resolve("reports/detekt/merge.xml")
-            output.set(file)
-        }
-        withType<Detekt>().configureEach detekt@{
-            finalizedBy(reportMerge)
-            reportMerge.configure {
-                input.from(this@detekt.xmlReportFile)
-            }
         }
 
         dokka {

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,0 +1,321 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$slotResult != null &amp;&amp; lastPathFromIdValue == fromVal &amp;&amp; lastPathToIdValue == toVal &amp;&amp; lastAllPathsOptions === options</ID>
+    <ID>ComplexCondition:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$slotResult != null &amp;&amp; lastPathFromIdValue == fromVal &amp;&amp; lastPathToIdValue == toVal &amp;&amp; lastShortestPathOptions === options</ID>
+    <ID>ComplexCondition:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$slotResult != null &amp;&amp; lastPathFromIdValue == fromVal &amp;&amp; lastPathToIdValue == toVal &amp;&amp; lastAllPathsOptions === options</ID>
+    <ID>ComplexCondition:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$slotResult != null &amp;&amp; lastPathFromIdValue == fromVal &amp;&amp; lastPathToIdValue == toVal &amp;&amp; lastShortestPathOptions === options</ID>
+    <ID>CyclomaticComplexMethod:AStarRunner.kt:AStarRunner$fun run: GraphPath?</ID>
+    <ID>CyclomaticComplexMethod:AgeTypeParser.kt:AgeTypeParser$private fun parseAgtypeElements: List&lt;String></ID>
+    <ID>CyclomaticComplexMethod:AgeTypeParser.kt:AgeTypeParser$private fun parseValue: Pair&lt;Any?, Int></ID>
+    <ID>CyclomaticComplexMethod:CsvGraphBulkImporter.kt:CsvGraphBulkImporter$fun importGraph: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:CycleDetector.kt:CycleDetector$private fun dfsIterative</ID>
+    <ID>CyclomaticComplexMethod:DijkstraRunner.kt:DijkstraRunner$fun run: GraphPath?</ID>
+    <ID>CyclomaticComplexMethod:GraphMlBulkImporter.kt:GraphMlBulkImporter$fun importGraph: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$override fun importGraph: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$override fun importGraph: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:StaxGraphMlWriter.kt:StaxGraphMlWriter$fun write</ID>
+    <ID>CyclomaticComplexMethod:SuspendCsvGraphBulkImporter.kt:SuspendCsvGraphBulkImporter$suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:SuspendGraphMlBulkImporter.kt:SuspendGraphMlBulkImporter$suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$override suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$override suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>CyclomaticComplexMethod:TinkerGraphOperations.kt:TinkerGraphOperations$override fun neighbors: List&lt;GraphVertex></ID>
+    <ID>EmptyKotlinFile:FalkorDBSessionSupport.kt:io.bluetape4k.graph.falkordb.internal.FalkorDBSessionSupport.kt</ID>
+    <ID>FunctionOnlyReturningConstant:AgeSql.kt:AgeSql$fun createExtension: String</ID>
+    <ID>FunctionOnlyReturningConstant:AgeSql.kt:AgeSql$fun loadAge: String</ID>
+    <ID>FunctionOnlyReturningConstant:AgeSql.kt:AgeSql$fun setSearchPath: String</ID>
+    <ID>InvalidPackageDeclaration:PublishingSigningSupport.kt:package io.bluetape4k.gradle</ID>
+    <ID>LargeClass:FalkorDBGraphOperations.kt:FalkorDBGraphOperations : GraphOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>LongMethod:CsvGraphBulkExporter.kt:CsvGraphBulkExporter$fun exportGraph: GraphExportReport</ID>
+    <ID>LongMethod:CsvGraphBulkImporter.kt:CsvGraphBulkImporter$fun importGraph: GraphImportReport</ID>
+    <ID>LongMethod:GraphMlBulkImporter.kt:GraphMlBulkImporter$fun importGraph: GraphImportReport</ID>
+    <ID>LongMethod:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$override fun importGraph: GraphImportReport</ID>
+    <ID>LongMethod:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$override fun importGraph: GraphImportReport</ID>
+    <ID>LongMethod:StaxGraphMlWriter.kt:StaxGraphMlWriter$fun write</ID>
+    <ID>LongMethod:SuspendCsvGraphBulkExporter.kt:SuspendCsvGraphBulkExporter$suspend fun exportGraphSuspending: GraphExportReport</ID>
+    <ID>LongMethod:SuspendCsvGraphBulkImporter.kt:SuspendCsvGraphBulkImporter$suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>LongMethod:SuspendGraphMlBulkImporter.kt:SuspendGraphMlBulkImporter$suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>LongMethod:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$override suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>LongMethod:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$override suspend fun importGraphSuspending: GraphImportReport</ID>
+    <ID>LoopWithTooManyJumpStatements:AStarRunner.kt:AStarRunner$for</ID>
+    <ID>LoopWithTooManyJumpStatements:AStarRunner.kt:AStarRunner$while</ID>
+    <ID>LoopWithTooManyJumpStatements:BfsDfsRunner.kt:BfsDfsRunner$while</ID>
+    <ID>LoopWithTooManyJumpStatements:CsvGraphBulkImporter.kt:CsvGraphBulkImporter$for</ID>
+    <ID>LoopWithTooManyJumpStatements:CycleDetector.kt:CycleDetector$while</ID>
+    <ID>LoopWithTooManyJumpStatements:DijkstraRunner.kt:DijkstraRunner$for</ID>
+    <ID>LoopWithTooManyJumpStatements:DijkstraRunner.kt:DijkstraRunner$while</ID>
+    <ID>LoopWithTooManyJumpStatements:GraphMlBulkImporter.kt:GraphMlBulkImporter$for</ID>
+    <ID>LoopWithTooManyJumpStatements:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$for</ID>
+    <ID>LoopWithTooManyJumpStatements:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$for</ID>
+    <ID>LoopWithTooManyJumpStatements:StaxGraphMlReader.kt:StaxGraphMlReader$while</ID>
+    <ID>LoopWithTooManyJumpStatements:SuspendGraphMlBulkImporter.kt:SuspendGraphMlBulkImporter$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$for</ID>
+    <ID>MagicNumber:AgeBenchmarkState.kt:AgeBenchmarkState$2019L</ID>
+    <ID>MagicNumber:AgeBenchmarkState.kt:AgeBenchmarkState$2020L</ID>
+    <ID>MagicNumber:AgeBenchmarkState.kt:AgeBenchmarkState$2021L</ID>
+    <ID>MagicNumber:AgeBenchmarkState.kt:AgeBenchmarkState$2022L</ID>
+    <ID>MagicNumber:AgeBenchmarkState.kt:AgeBenchmarkState$4</ID>
+    <ID>MagicNumber:AgeTypeParser.kt:AgeTypeParser$4</ID>
+    <ID>MagicNumber:AgeTypeParser.kt:AgeTypeParser$5</ID>
+    <ID>MagicNumber:AgeVertexBenchmark.kt:AgeVertexBenchmark$10_000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$100_000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$10_000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$1_000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$2000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$200_000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$20_000</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$25</ID>
+    <ID>MagicNumber:BulkGraphIoBenchmarkState.kt:BulkGraphIoBenchmarkState$2_000</ID>
+    <ID>MagicNumber:CachingAgeGraphOperations.kt:CachingAgeGraphOperations$5</ID>
+    <ID>MagicNumber:CachingMemgraphGraphOperations.kt:CachingMemgraphGraphOperations$5</ID>
+    <ID>MagicNumber:CachingNeo4jGraphOperations.kt:CachingNeo4jGraphOperations$5</ID>
+    <ID>MagicNumber:FalkorDBServer.kt:FalkorDBServer$60</ID>
+    <ID>MagicNumber:GraphBenchmarkState.kt:GraphBenchmarkState$2019L</ID>
+    <ID>MagicNumber:GraphBenchmarkState.kt:GraphBenchmarkState$2020L</ID>
+    <ID>MagicNumber:GraphBenchmarkState.kt:GraphBenchmarkState$2021L</ID>
+    <ID>MagicNumber:GraphBenchmarkState.kt:GraphBenchmarkState$2022L</ID>
+    <ID>MagicNumber:KnowledgeGraphService.kt:KnowledgeGraphService$100</ID>
+    <ID>MagicNumber:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$100</ID>
+    <ID>MagicNumber:KtorGraphAppMain.kt:DemoCityGraph$160.0</ID>
+    <ID>MagicNumber:KtorGraphAppMain.kt:DemoCityGraph$220.0</ID>
+    <ID>MagicNumber:KtorGraphAppMain.kt:KtorGraphAppMain$65535</ID>
+    <ID>MagicNumber:Neo4jBenchmarkState.kt:Neo4jBenchmarkState$2019L</ID>
+    <ID>MagicNumber:Neo4jBenchmarkState.kt:Neo4jBenchmarkState$2020L</ID>
+    <ID>MagicNumber:Neo4jBenchmarkState.kt:Neo4jBenchmarkState$2021L</ID>
+    <ID>MagicNumber:Neo4jBenchmarkState.kt:Neo4jBenchmarkState$2022L</ID>
+    <ID>MagicNumber:Neo4jVertexBenchmark.kt:Neo4jVertexBenchmark$10_000</ID>
+    <ID>MagicNumber:VertexOperationsBenchmark.kt:VertexOperationsBenchmark$10_000</ID>
+    <ID>MatchingDeclarationName:BatchInsertSmokeSupport.kt:BatchInsertSmokeResult</ID>
+    <ID>MaxLineLength:AbstractFraudDetectionSuspendTest.kt:AbstractFraudDetectionSuspendTest$component.size >= 3 &amp;&amp; component.vertices.map { it.properties["accountId"] }.containsAll(listOf("acct-a", "acct-b", "acct-c"))</ID>
+    <ID>MaxLineLength:AbstractFraudDetectionTest.kt:AbstractFraudDetectionTest$component.size >= 3 &amp;&amp; component.vertices.map { it.properties["accountId"] }.containsAll(listOf("acct-a", "acct-b", "acct-c"))</ID>
+    <ID>MaxLineLength:AgeGraphOperations.kt:AgeGraphOperations$created.add(parseBatchIndex(rs.getString("idx")) to AgeTypeParser.parseEdge(rs.getString("e")))</ID>
+    <ID>MaxLineLength:AgeGraphOperations.kt:AgeGraphOperations$created.add(parseBatchIndex(rs.getString("idx")) to AgeTypeParser.parseVertex(rs.getString("v")))</ID>
+    <ID>MaxLineLength:AgeGraphOperations.kt:AgeGraphOperations$exec</ID>
+    <ID>MaxLineLength:AgeGraphOperations.kt:AgeGraphOperations$val stmt = AgeSql.createEdge(graphName, from, to, label, properties.matchProperties + properties.setProperties)</ID>
+    <ID>MaxLineLength:AgeTypeParser.kt:AgeTypeParser$*</ID>
+    <ID>MaxLineLength:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$if</ID>
+    <ID>MaxLineLength:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$lastPathFromIdValue = fromVal</ID>
+    <ID>MaxLineLength:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$override</ID>
+    <ID>MaxLineLength:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$if</ID>
+    <ID>MaxLineLength:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$lastPathFromIdValue = fromVal</ID>
+    <ID>MaxLineLength:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$override</ID>
+    <ID>MaxLineLength:BulkGraphIoBenchmark.kt:BulkGraphIoBenchmark$SuspendCsvGraphBulkExporter().exportGraphSuspending(sink, TinkerGraphSuspendOperations(s.ops as TinkerGraphOperations), exportOpts)</ID>
+    <ID>MaxLineLength:CachingAgeGraphOperationsTest.kt:CachingAgeGraphOperationsTest$every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))</ID>
+    <ID>MaxLineLength:CachingAgeGraphOperationsTest.kt:CachingAgeGraphOperationsTest$every { delegate.updateVertex("Person", aliceId, any()) } returns alice.copy(properties = mapOf("name" to "Alice Updated"))</ID>
+    <ID>MaxLineLength:CachingMemgraphGraphOperationsTest.kt:CachingMemgraphGraphOperationsTest$every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))</ID>
+    <ID>MaxLineLength:CachingMemgraphGraphOperationsTest.kt:CachingMemgraphGraphOperationsTest$every { delegate.updateVertex("Person", aliceId, any()) } returns alice.copy(properties = mapOf("name" to "Alice Updated"))</ID>
+    <ID>MaxLineLength:CachingNeo4jGraphOperationsTest.kt:CachingNeo4jGraphOperationsTest$every { delegate.createVertex("Person", props) } returns alice andThen alice.copy(id = GraphElementId.of("alice-2"))</ID>
+    <ID>MaxLineLength:CachingNeo4jGraphOperationsTest.kt:CachingNeo4jGraphOperationsTest$every { delegate.updateVertex("Person", aliceId, any()) } returns alice.copy(properties = mapOf("name" to "Alice Updated"))</ID>
+    <ID>MaxLineLength:CodeGraphService.kt:CodeGraphService$ops.neighbors(functionId, NeighborOptions(edgeLabel = "CALLS", direction = Direction.OUTGOING, maxDepth = maxDepth))</ID>
+    <ID>MaxLineLength:CodeGraphService.kt:CodeGraphService$ops.neighbors(moduleId, NeighborOptions(edgeLabel = "DEPENDS_ON", direction = Direction.INCOMING, maxDepth = depth))</ID>
+    <ID>MaxLineLength:CodeGraphService.kt:CodeGraphService$ops.neighbors(moduleId, NeighborOptions(edgeLabel = "DEPENDS_ON", direction = Direction.OUTGOING, maxDepth = maxDepth))</ID>
+    <ID>MaxLineLength:CodeGraphSuspendService.kt:CodeGraphSuspendService$ops.neighbors(functionId, NeighborOptions(edgeLabel = "CALLS", direction = Direction.OUTGOING, maxDepth = maxDepth))</ID>
+    <ID>MaxLineLength:CodeGraphSuspendService.kt:CodeGraphSuspendService$ops.neighbors(moduleId, NeighborOptions(edgeLabel = "DEPENDS_ON", direction = Direction.INCOMING, maxDepth = depth))</ID>
+    <ID>MaxLineLength:CodeGraphSuspendService.kt:CodeGraphSuspendService$ops.neighbors(moduleId, NeighborOptions(edgeLabel = "DEPENDS_ON", direction = Direction.OUTGOING, maxDepth = maxDepth))</ID>
+    <ID>MaxLineLength:CsvGraphBulkExporter.kt:CsvGraphBulkExporter$log.debug { "CSV export completed: verticesWritten=$vWritten, edgesWritten=$eWritten, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:CsvGraphBulkImporter.kt:CsvGraphBulkImporter$log.debug { "CSV import completed: vertices=$verticesCreated/$verticesRead, edges=$edgesCreated/$edgesRead, skipped=$skippedVertices/$skippedEdges, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:CsvGraphBulkImporter.kt:CsvGraphBulkImporter$log.debug { "Starting CSV import: defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }</ID>
+    <ID>MaxLineLength:CsvGraphBulkImporter.kt:CsvGraphBulkImporter$log.warn { "CSV import failed during vertex pass: vertices=$verticesCreated/$verticesRead, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:CycleDetectorTest.kt:CycleDetectorTest$invoking { CycleDetector.findCycles(emptyMap(), maxDepth = 0, maxCycles = 1) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:CycleDetectorTest.kt:CycleDetectorTest$invoking { CycleDetector.findCycles(emptyMap(), maxDepth = 1, maxCycles = 0) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:FalkorDBGraphOperations.kt:FalkorDBGraphOperations$"WITH collect({index: row.index, properties: row.properties, source: source, target: target}) AS matched, expected "</ID>
+    <ID>MaxLineLength:FalkorDBGraphOperations.kt:FalkorDBGraphOperations$"WITH row.index AS index, row.properties AS properties, row.source AS source, row.target AS target "</ID>
+    <ID>MaxLineLength:FalkorDBGraphSchemaManager.kt:FalkorDBGraphSchemaManager$if</ID>
+    <ID>MaxLineLength:GraphFalkorDBAutoConfiguration.kt:GraphFalkorDBAutoConfiguration.HealthConfig$fun</ID>
+    <ID>MaxLineLength:GraphIdentifiers.kt:"$paramName must be a valid identifier (letters, digits, underscore; must start with letter or underscore): $this"</ID>
+    <ID>MaxLineLength:GraphIoOkioPaths.kt:GraphIoOkioPaths$try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after DAEAD init failure" } }</ID>
+    <ID>MaxLineLength:GraphIoOkioPaths.kt:GraphIoOkioPaths$try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip+DAEAD init failure" } }</ID>
+    <ID>MaxLineLength:GraphIoOkioPaths.kt:GraphIoOkioPaths$try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close source after DAEAD init failure" } }</ID>
+    <ID>MaxLineLength:GraphIoOkioPaths.kt:GraphIoOkioPaths$try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close source after DAEAD+gzip init failure" } }</ID>
+    <ID>MaxLineLength:GraphIoOkioPaths.kt:GraphIoOkioPaths$try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close source after gzip init failure" } }</ID>
+    <ID>MaxLineLength:GraphIoRecordTest.kt:GraphIoRecordTest$invoking { GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2") } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoRecordTest.kt:GraphIoRecordTest$invoking { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2") } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoRecordTest.kt:GraphIoRecordTest$invoking { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ") } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphIoReportTest.kt:GraphIoReportTest$invoking { GraphIoFailure(phase = GraphIoPhase.READ_VERTEX, message = " ") } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:GraphMergeOperationsTest.kt:GraphMergeOperationsTest$val edge = GraphEdge(GraphElementId.of("e1"), "KNOWS", GraphElementId.of("v1"), GraphElementId.of("v2"), emptyMap())</ID>
+    <ID>MaxLineLength:GraphMlBulkExporter.kt:GraphMlBulkExporter$)</ID>
+    <ID>MaxLineLength:GraphMlBulkImporter.kt:GraphMlBulkImporter$.</ID>
+    <ID>MaxLineLength:Jackson2EnvelopeCodec.kt:Jackson2EnvelopeCodec$NdJsonEnvelope(NdJsonEnvelope.TYPE_EDGE, e.externalId, e.label, e.fromExternalId, e.toExternalId, e.properties)</ID>
+    <ID>MaxLineLength:Jackson2NdJsonBulkExporter.kt:Jackson2NdJsonBulkExporter$log.debug { "NDJSON_JACKSON2 export completed: verticesWritten=$vWritten, edgesWritten=$eWritten, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:Jackson2NdJsonBulkExporter.kt:Jackson2NdJsonBulkExporter$log.debug { "Starting NDJSON_JACKSON2 export: vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }</ID>
+    <ID>MaxLineLength:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$log.debug { "NDJSON_JACKSON2 import completed: vertices=$vc/$vr, edges=$ec/$er, skipped=$sv/$se, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$log.debug { "Starting NDJSON_JACKSON2 import: defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }</ID>
+    <ID>MaxLineLength:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$return</ID>
+    <ID>MaxLineLength:Jackson2NdJsonBulkImporter.kt:Jackson2NdJsonBulkImporter$return GraphImportReport(status, GraphIoFormat.NDJSON_JACKSON2, vr, vc, er, ec, sv, se, watch.elapsed(), failures)</ID>
+    <ID>MaxLineLength:Jackson3EnvelopeCodec.kt:Jackson3EnvelopeCodec$NdJsonEnvelope(NdJsonEnvelope.TYPE_EDGE, e.externalId, e.label, e.fromExternalId, e.toExternalId, e.properties)</ID>
+    <ID>MaxLineLength:Jackson3NdJsonBulkExporter.kt:Jackson3NdJsonBulkExporter$log.debug { "NDJSON_JACKSON3 export completed: verticesWritten=$vWritten, edgesWritten=$eWritten, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:Jackson3NdJsonBulkExporter.kt:Jackson3NdJsonBulkExporter$log.debug { "Starting NDJSON_JACKSON3 export: vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }</ID>
+    <ID>MaxLineLength:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$log.debug { "NDJSON_JACKSON3 import completed: vertices=$vc/$vr, edges=$ec/$er, skipped=$sv/$se, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$log.debug { "Starting NDJSON_JACKSON3 import: defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }</ID>
+    <ID>MaxLineLength:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$return</ID>
+    <ID>MaxLineLength:Jackson3NdJsonBulkImporter.kt:Jackson3NdJsonBulkImporter$return GraphImportReport(status, GraphIoFormat.NDJSON_JACKSON3, vr, vc, er, ec, sv, se, watch.elapsed(), failures)</ID>
+    <ID>MaxLineLength:JdbcTransactionExtensions.kt:message = "No-op: AGE load and search_path are handled by HikariCP connectionInitSql. Remove calls to this function."</ID>
+    <ID>MaxLineLength:KnowledgeGraphService.kt:KnowledgeGraphService$mapOf(ConceptLabel.conceptId.name to conceptId, ConceptLabel.name.name to name, ConceptLabel.domain.name to domain)</ID>
+    <ID>MaxLineLength:KnowledgeGraphService.kt:KnowledgeGraphService$mapOf(DocumentLabel.documentId.name to documentId, DocumentLabel.title.name to title, DocumentLabel.source.name to source)</ID>
+    <ID>MaxLineLength:KnowledgeGraphService.kt:KnowledgeGraphService$mapOf(EntityLabel.entityId.name to entityId, EntityLabel.name.name to name, EntityLabel.entityType.name to entityType)</ID>
+    <ID>MaxLineLength:KnowledgeGraphService.kt:KnowledgeGraphService$ops.neighbors(documentId, NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1))</ID>
+    <ID>MaxLineLength:KnowledgeGraphService.kt:KnowledgeGraphService$ops.neighbors(entityId, NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth))</ID>
+    <ID>MaxLineLength:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$mapOf(ConceptLabel.conceptId.name to conceptId, ConceptLabel.name.name to name, ConceptLabel.domain.name to domain)</ID>
+    <ID>MaxLineLength:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$mapOf(DocumentLabel.documentId.name to documentId, DocumentLabel.title.name to title, DocumentLabel.source.name to source)</ID>
+    <ID>MaxLineLength:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$mapOf(EntityLabel.entityId.name to entityId, EntityLabel.name.name to name, EntityLabel.entityType.name to entityType)</ID>
+    <ID>MaxLineLength:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$ops.neighbors(documentId, NeighborOptions(edgeLabel = MentionsLabel.label, direction = Direction.OUTGOING, maxDepth = 1))</ID>
+    <ID>MaxLineLength:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$ops.neighbors(entityId, NeighborOptions(edgeLabel = RelatedToLabel.label, direction = Direction.OUTGOING, maxDepth = depth))</ID>
+    <ID>MaxLineLength:KnowledgeGraphSuspendService.kt:KnowledgeGraphSuspendService$suspend</ID>
+    <ID>MaxLineLength:MemgraphGraphOperations.kt:MemgraphGraphOperations$"WITH collect({index: row.index, properties: row.properties, source: source, target: target}) AS matched, expected "</ID>
+    <ID>MaxLineLength:MemgraphGraphOperations.kt:MemgraphGraphOperations$"WITH row.index AS index, row.properties AS properties, row.source AS source, row.target AS target "</ID>
+    <ID>MaxLineLength:MemgraphGraphSchemaManager.kt:MemgraphGraphSchemaManager$if</ID>
+    <ID>MaxLineLength:MemgraphGraphSchemaManager.kt:MemgraphGraphSchemaManager$name = if (property.isNotBlank()) GraphSchemaNames.uniqueConstraintName(label, property) else "bt4k_constraint_$label"</ID>
+    <ID>MaxLineLength:MemgraphGraphSuspendOperations.kt:MemgraphGraphSuspendOperations$return withContext(Dispatchers.IO) { ShortestPathFallback.aStar(syncDelegate, fromId, toId, options, heuristic) }</ID>
+    <ID>MaxLineLength:Neo4jGraphOperations.kt:Neo4jGraphOperations$"WITH collect({index: row.index, properties: row.properties, source: source, target: target}) AS matched, expected "</ID>
+    <ID>MaxLineLength:Neo4jGraphOperations.kt:Neo4jGraphOperations$"WITH row.index AS index, row.properties AS properties, row.source AS source, row.target AS target "</ID>
+    <ID>MaxLineLength:Neo4jGraphSuspendOperations.kt:Neo4jGraphSuspendOperations$return withContext(Dispatchers.IO) { ShortestPathFallback.aStar(syncDelegate, fromId, toId, options, heuristic) }</ID>
+    <ID>MaxLineLength:OkioGraphBulkExporter.kt:OkioGraphBulkExporter$graphmlExporter.exportGraph(GraphExportSink.OutputStreamSink(os, closeOutput = false), operations, options)</ID>
+    <ID>MaxLineLength:OkioGraphBulkExporter.kt:OkioGraphBulkExporter$jackson2Exporter.exportGraph(GraphExportSink.OutputStreamSink(os, closeOutput = false), operations, options)</ID>
+    <ID>MaxLineLength:OkioGraphBulkExporter.kt:OkioGraphBulkExporter$jackson3Exporter.exportGraph(GraphExportSink.OutputStreamSink(os, closeOutput = false), operations, options)</ID>
+    <ID>MaxLineLength:OkioGraphBulkImporter.kt:OkioGraphBulkImporter$graphmlImporter.importGraph(GraphImportSource.InputStreamSource(is_, closeInput = false), operations, options)</ID>
+    <ID>MaxLineLength:OkioGraphBulkImporter.kt:OkioGraphBulkImporter$jackson2Importer.importGraph(GraphImportSource.InputStreamSource(is_, closeInput = false), operations, options)</ID>
+    <ID>MaxLineLength:OkioGraphBulkImporter.kt:OkioGraphBulkImporter$jackson3Importer.importGraph(GraphImportSource.InputStreamSource(is_, closeInput = false), operations, options)</ID>
+    <ID>MaxLineLength:OkioGraphIoBenchmark.kt:OkioGraphIoBenchmark$Jackson3NdJsonBulkImporter().importGraphGzip(pathSource(s.tempDir, "g3ok.ndjson.gz"), TinkerGraphOperations(), importOpts)</ID>
+    <ID>MaxLineLength:OkioGraphIoBenchmark.kt:OkioGraphIoBenchmark$okioImporter.importGraph(pathSource(s.tempDir, "g3ok.ndjson"), GraphIoFormat.NDJSON_JACKSON3, TinkerGraphOperations(), importOpts)</ID>
+    <ID>MaxLineLength:OkioGraphIoBenchmark.kt:OkioGraphIoBenchmark$okioImporter.importGraph(pathSource(s.tempDir, "gok.graphml"), GraphIoFormat.GRAPHML, TinkerGraphOperations(), importOpts)</ID>
+    <ID>MaxLineLength:OkioGraphIoBenchmark.kt:OkioGraphIoBenchmark$vtAdapter.exportGraphAsync(pathSink(s.tempDir, "g3vt.ndjson"), GraphIoFormat.NDJSON_JACKSON3, s.ops, exportOpts).get()</ID>
+    <ID>MaxLineLength:OkioGraphIoBenchmark.kt:OkioGraphIoBenchmark$vtAdapter.importGraphAsync(pathSource(s.tempDir, "g3vt.ndjson"), GraphIoFormat.NDJSON_JACKSON3, TinkerGraphOperations(), importOpts).get()</ID>
+    <ID>MaxLineLength:RecommendationService.kt:RecommendationService$mapOf(ProductLabel.productId.name to productId, ProductLabel.name.name to name, ProductLabel.category.name to category)</ID>
+    <ID>MaxLineLength:RecommendationService.kt:RecommendationService$mapOf(UserLabel.userId.name to userId, UserLabel.displayName.name to displayName, UserLabel.segment.name to segment)</ID>
+    <ID>MaxLineLength:RecommendationSuspendService.kt:RecommendationSuspendService$mapOf(ProductLabel.productId.name to productId, ProductLabel.name.name to name, ProductLabel.category.name to category)</ID>
+    <ID>MaxLineLength:RecommendationSuspendService.kt:RecommendationSuspendService$mapOf(UserLabel.userId.name to userId, UserLabel.displayName.name to displayName, UserLabel.segment.name to segment)</ID>
+    <ID>MaxLineLength:RecommendationSuspendService.kt:RecommendationSuspendService$suspend</ID>
+    <ID>MaxLineLength:ShortestPathFallbackTest.kt:FakeGraphOperations$override fun aStarPath: GraphPath?</ID>
+    <ID>MaxLineLength:ShortestPathFallbackTest.kt:FakeGraphOperations$override fun allPaths: List&lt;GraphPath></ID>
+    <ID>MaxLineLength:ShortestPathFallbackTest.kt:FakeGraphOperations$override fun createEdge: GraphEdge</ID>
+    <ID>MaxLineLength:ShortestPathFallbackTest.kt:FakeGraphOperations$override fun shortestPath: GraphPath?</ID>
+    <ID>MaxLineLength:ShortestPathFallbackTest.kt:FakeGraphOperations$override fun updateVertex: GraphVertex?</ID>
+    <ID>MaxLineLength:SuspendAdapterTest.kt:SuspendAdapterTest$adapter.exportGraphAwait(OkioGraphExportSink.PathSink(path, fakeFs), GraphIoFormat.NDJSON_JACKSON2, src, exportOptions)</ID>
+    <ID>MaxLineLength:SuspendCsvGraphBulkExporter.kt:SuspendCsvGraphBulkExporter$log.debug { "CSV export (suspend) completed: verticesWritten=$vWritten, edgesWritten=$eWritten, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendCsvGraphBulkExporter.kt:SuspendCsvGraphBulkExporter$log.debug { "Starting CSV export (suspend): vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }</ID>
+    <ID>MaxLineLength:SuspendCsvGraphBulkImporter.kt:SuspendCsvGraphBulkImporter$log.debug { "CSV import (suspend) completed: vertices=$verticesCreated/$verticesRead, edges=$edgesCreated/$edgesRead, skipped=$skippedVertices/$skippedEdges, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendCsvGraphBulkImporter.kt:SuspendCsvGraphBulkImporter$log.debug { "Starting CSV import (suspend): defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }</ID>
+    <ID>MaxLineLength:SuspendCsvGraphBulkImporter.kt:SuspendCsvGraphBulkImporter$log.warn { "CSV import (suspend) failed during vertex pass: vertices=$verticesCreated/$verticesRead, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson2NdJsonBulkExporter.kt:SuspendJackson2NdJsonBulkExporter$log.debug { "NDJSON_JACKSON2 export (suspend) completed: verticesWritten=$vWritten, edgesWritten=$eWritten, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson2NdJsonBulkExporter.kt:SuspendJackson2NdJsonBulkExporter$log.debug { "Starting NDJSON_JACKSON2 export (suspend): vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }</ID>
+    <ID>MaxLineLength:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$log.debug { "NDJSON_JACKSON2 import (suspend) completed: vertices=$vc/$vr, edges=$ec/$er, skipped=$sv/$se, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$log.debug { "Starting NDJSON_JACKSON2 import (suspend): defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }</ID>
+    <ID>MaxLineLength:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$log.warn { "NDJSON_JACKSON2 import (suspend) failed: vertices=$vc/$vr, edges=$ec/$er, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson2NdJsonBulkImporter.kt:SuspendJackson2NdJsonBulkImporter$return</ID>
+    <ID>MaxLineLength:SuspendJackson3NdJsonBulkExporter.kt:SuspendJackson3NdJsonBulkExporter$log.debug { "NDJSON_JACKSON3 export (suspend) completed: verticesWritten=$vWritten, edgesWritten=$eWritten, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson3NdJsonBulkExporter.kt:SuspendJackson3NdJsonBulkExporter$log.debug { "Starting NDJSON_JACKSON3 export (suspend): vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }</ID>
+    <ID>MaxLineLength:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$log.debug { "NDJSON_JACKSON3 import (suspend) completed: vertices=$vc/$vr, edges=$ec/$er, skipped=$sv/$se, status=$status, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$log.debug { "Starting NDJSON_JACKSON3 import (suspend): defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }</ID>
+    <ID>MaxLineLength:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$log.warn { "NDJSON_JACKSON3 import (suspend) failed: vertices=$vc/$vr, edges=$ec/$er, elapsed=${watch.elapsed()}" }</ID>
+    <ID>MaxLineLength:SuspendJackson3NdJsonBulkImporter.kt:SuspendJackson3NdJsonBulkImporter$return</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$?:</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$Direction.BOTH -> if (options.edgeLabel != null) AnonymousTraversal.both(options.edgeLabel) else AnonymousTraversal.both()</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$Direction.BOTH -> if (options.edgeLabel != null) g.V(idValue).both(options.edgeLabel) else g.V(idValue).both()</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$Direction.INCOMING -> if (options.edgeLabel != null) AnonymousTraversal.`in`(options.edgeLabel) else AnonymousTraversal.`in`()</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$Direction.INCOMING -> if (options.edgeLabel != null) g.V(idValue).`in`(options.edgeLabel) else g.V(idValue).`in`()</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$Direction.OUTGOING -> if (options.edgeLabel != null) AnonymousTraversal.out(options.edgeLabel) else AnonymousTraversal.out()</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$Direction.OUTGOING -> if (options.edgeLabel != null) g.V(idValue).out(options.edgeLabel) else g.V(idValue).out()</ID>
+    <ID>MaxLineLength:TinkerGraphOperations.kt:TinkerGraphOperations$val</ID>
+    <ID>MaxLineLength:WeightExtractorTest.kt:WeightExtractorTest$invoking { MissingWeightPolicy.UseDefault(Double.POSITIVE_INFINITY) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:WeightExtractorTest.kt:WeightExtractorTest$invoking { extractor.extract(edge("w" to Double.POSITIVE_INFINITY)) } shouldThrow IllegalArgumentException::class</ID>
+    <ID>MaxLineLength:build.gradle.kts:annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${libs.versions.spring.boot4.get()}")</ID>
+    <ID>ReturnCount:AStarRunner.kt:AStarRunner$fun run: GraphPath?</ID>
+    <ID>ReturnCount:AStarRunnerTest.kt:AStarRunnerTest$private fun euclidean: Double</ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$override fun allPaths: List&lt;GraphPath></ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$override fun findVerticesByLabel: List&lt;GraphVertex></ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$override fun neighbors: List&lt;GraphVertex></ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations$override fun shortestPath: GraphPath?</ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$override fun allPaths: List&lt;GraphPath></ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$override fun findVerticesByLabel: List&lt;GraphVertex></ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$override fun neighbors: List&lt;GraphVertex></ID>
+    <ID>ReturnCount:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations$override fun shortestPath: GraphPath?</ID>
+    <ID>ReturnCount:KtorGraphAppMain.kt:DemoCityGraph$suspend fun shortestPath: io.bluetape4k.graph.model.GraphPath?</ID>
+    <ID>ReturnCount:PageRankCalculator.kt:PageRankCalculator$fun compute: Map&lt;GraphElementId, Double></ID>
+    <ID>ReturnCount:PathReconstructor.kt:internal fun reconstructPath: GraphPath?</ID>
+    <ID>ReturnCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun allPaths: List&lt;GraphPath></ID>
+    <ID>ReturnCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun deleteEdge: Boolean</ID>
+    <ID>ReturnCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun deleteVertex: Boolean</ID>
+    <ID>ReturnCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun neighbors: List&lt;GraphVertex></ID>
+    <ID>ReturnCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun shortestPath: GraphPath?</ID>
+    <ID>ReturnCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun updateVertex: GraphVertex?</ID>
+    <ID>SerialVersionUIDInSerializableClass:GraphTraversalOptions.kt:GraphTraversalOptions : Serializable</ID>
+    <ID>SwallowedException:MemgraphGraphOperations.kt:MemgraphGraphOperations$e: org.neo4j.driver.exceptions.DatabaseException</ID>
+    <ID>SwallowedException:MemgraphGraphSuspendOperations.kt:MemgraphGraphSuspendOperations$e: org.neo4j.driver.exceptions.DatabaseException</ID>
+    <ID>SwallowedException:Neo4jGraphSuspendOperations.kt:Neo4jGraphSuspendOperations$e: Exception</ID>
+    <ID>ThrowingExceptionFromFinally:MemgraphGraphOperations.kt:MemgraphGraphOperations$throw closeFailure</ID>
+    <ID>ThrowingExceptionFromFinally:Neo4jGraphOperations.kt:Neo4jGraphOperations$throw closeFailure</ID>
+    <ID>ThrowsCount:AgeGraphOperations.kt:AgeGraphOperations$override fun createEdge: GraphEdge</ID>
+    <ID>ThrowsCount:AgeGraphOperations.kt:AgeGraphOperations$override fun createEdges: List&lt;GraphEdge></ID>
+    <ID>ThrowsCount:AgeGraphOperations.kt:AgeGraphOperations$override fun mergeEdge: GraphEdge</ID>
+    <ID>ThrowsCount:AgeGraphOperations.kt:AgeGraphOperations$override fun mergeVertex: GraphVertex</ID>
+    <ID>ThrowsCount:AgeGraphSuspendOperations.kt:AgeGraphSuspendOperations$override suspend fun createEdge: GraphEdge</ID>
+    <ID>ThrowsCount:TinkerGraphOperations.kt:TinkerGraphOperations$override fun createEdges: List&lt;GraphEdge></ID>
+    <ID>TooGenericExceptionCaught:AgeGraphOperations.kt:AgeGraphOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AgeGraphSuspendOperations.kt:AgeGraphSuspendOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FalkorDBGraphOperations.kt:FalkorDBGraphOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FalkorDBGraphSuspendOperations.kt:FalkorDBGraphSuspendOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GraphAgeAutoConfiguration.kt:GraphAgeAutoConfiguration.HealthConfig$ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:GraphFalkorDBAutoConfiguration.kt:GraphFalkorDBAutoConfiguration.HealthConfig$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GraphIoOkioPaths.kt:GraphIoOkioPaths$ce: Throwable</ID>
+    <ID>TooGenericExceptionCaught:GraphIoOkioPaths.kt:GraphIoOkioPaths$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:GraphIoOkioPaths.kt:GraphIoOkioPaths.AtomicMoveSink$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GraphMemgraphAutoConfiguration.kt:GraphMemgraphAutoConfiguration.HealthConfig$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GraphNeo4jAutoConfiguration.kt:GraphNeo4jAutoConfiguration.HealthConfig$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MemgraphGraphOperations.kt:MemgraphGraphOperations$closeFailure: Throwable</ID>
+    <ID>TooGenericExceptionCaught:MemgraphGraphOperations.kt:MemgraphGraphOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MemgraphGraphOperations.kt:MemgraphGraphOperations$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:MemgraphGraphOperations.kt:MemgraphGraphOperations$rollbackFailure: Throwable</ID>
+    <ID>TooGenericExceptionCaught:MemgraphGraphSuspendOperations.kt:MemgraphGraphSuspendOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Neo4jGraphOperations.kt:Neo4jGraphOperations$closeFailure: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Neo4jGraphOperations.kt:Neo4jGraphOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Neo4jGraphOperations.kt:Neo4jGraphOperations$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Neo4jGraphOperations.kt:Neo4jGraphOperations$rollbackFailure: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Neo4jGraphSuspendOperations.kt:Neo4jGraphSuspendOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:TinkerGraphOperations.kt:TinkerGraphOperations$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:TinkerGraphOperations.kt:TinkerGraphOperations$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:TinkerGraphOperations.kt:TinkerGraphOperations$restoreFailure: Throwable</ID>
+    <ID>TooManyFunctions:AgeGraphOperations.kt:AgeGraphOperations : GraphOperationsGraphTransactionalOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:AgeGraphSuspendOperations.kt:AgeGraphSuspendOperations : GraphSuspendOperationsGraphSuspendTransactionalOperationsGraphSuspendSchemaManagementOperationsGraphSuspendMergeOperations</ID>
+    <ID>TooManyFunctions:AgeSql.kt:AgeSql</ID>
+    <ID>TooManyFunctions:AgeVertexBenchmark.kt:AgeVertexBenchmark : AgeBenchmarkState</ID>
+    <ID>TooManyFunctions:BenchmarkSingleThreadedCachingAgeGraphOperations.kt:BenchmarkSingleThreadedCachingAgeGraphOperations : GraphOperations</ID>
+    <ID>TooManyFunctions:BenchmarkSingleThreadedCachingNeo4jGraphOperations.kt:BenchmarkSingleThreadedCachingNeo4jGraphOperations : GraphOperations</ID>
+    <ID>TooManyFunctions:BulkGraphIoBenchmark.kt:BulkGraphIoBenchmark</ID>
+    <ID>TooManyFunctions:CachingAgeGraphOperations.kt:CachingAgeGraphOperations : GraphOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:CachingMemgraphGraphOperations.kt:CachingMemgraphGraphOperations : GraphOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:CachingNeo4jGraphOperations.kt:CachingNeo4jGraphOperations : GraphOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:CodeGraphService.kt:CodeGraphService</ID>
+    <ID>TooManyFunctions:CodeGraphSuspendService.kt:CodeGraphSuspendService</ID>
+    <ID>TooManyFunctions:CsvOkioExtensions.kt:io.bluetape4k.graph.io.okio.extension.CsvOkioExtensions.kt</ID>
+    <ID>TooManyFunctions:FalkorDBGraphOperations.kt:FalkorDBGraphOperations : GraphOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:FalkorDBGraphSuspendOperations.kt:FalkorDBGraphSuspendOperations : GraphSuspendOperationsGraphSuspendSchemaManagementOperationsGraphSuspendMergeOperations</ID>
+    <ID>TooManyFunctions:GraphIoOkioPaths.kt:GraphIoOkioPaths : KLogging</ID>
+    <ID>TooManyFunctions:GraphSuspendTransactionScope.kt:BlockingGraphSuspendTransactionScope : GraphSuspendTransactionScope</ID>
+    <ID>TooManyFunctions:JacksonOkioExtensions.kt:io.bluetape4k.graph.io.okio.extension.JacksonOkioExtensions.kt</ID>
+    <ID>TooManyFunctions:LinkedInGraphService.kt:LinkedInGraphService</ID>
+    <ID>TooManyFunctions:LinkedInGraphSuspendService.kt:LinkedInGraphSuspendService</ID>
+    <ID>TooManyFunctions:MemgraphGraphOperations.kt:MemgraphGraphOperations : GraphOperationsGraphTransactionalOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:MemgraphGraphOperations.kt:MemgraphGraphTransactionScope : GraphTransactionScope</ID>
+    <ID>TooManyFunctions:MemgraphGraphSuspendOperations.kt:MemgraphGraphSuspendOperations : GraphSuspendOperationsGraphSuspendTransactionalOperationsGraphSuspendSchemaManagementOperationsGraphSuspendMergeOperations</ID>
+    <ID>TooManyFunctions:Neo4jGraphOperations.kt:Neo4jGraphOperations : GraphOperationsGraphTransactionalOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:Neo4jGraphOperations.kt:Neo4jGraphTransactionScope : GraphTransactionScope</ID>
+    <ID>TooManyFunctions:Neo4jGraphSuspendOperations.kt:Neo4jGraphSuspendOperations : GraphSuspendOperationsGraphSuspendTransactionalOperationsGraphSuspendSchemaManagementOperationsGraphSuspendMergeOperations</ID>
+    <ID>TooManyFunctions:OkioGraphIoBenchmark.kt:OkioGraphIoBenchmark</ID>
+    <ID>TooManyFunctions:TinkerGraphOperations.kt:TinkerGraphOperations : GraphOperationsGraphAlgorithmRepositoryGraphTransactionalOperationsGraphSchemaManagementOperationsGraphMergeOperations</ID>
+    <ID>TooManyFunctions:TinkerGraphSuspendOperations.kt:TinkerGraphSuspendOperations : GraphSuspendOperationsGraphSuspendTransactionalOperationsGraphSuspendSchemaManagementOperationsGraphSuspendMergeOperations</ID>
+    <ID>TooManyFunctions:VertexOperationsBenchmark.kt:VertexOperationsBenchmark : GraphBenchmarkState</ID>
+    <ID>UtilityClassWithPublicConstructor:GraphAutoConfiguration.kt:GraphAutoConfiguration</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/docs/governance/ci-quality-gates.md
+++ b/docs/governance/ci-quality-gates.md
@@ -1,0 +1,39 @@
+# CI Quality Gates
+
+## Current Status
+
+`bluetape4k-graph` uses CI quality gates that match the current repository
+policy instead of the older all-in-one gate proposed in issue #18.
+
+## Policy
+
+- CI blocks pull requests on secret scanning, Gradle wrapper validation,
+  compile-only build, Detekt static analysis, and targeted test jobs.
+- Detekt reports are uploaded from each module under
+  `**/build/reports/detekt/*.xml`.
+- Existing findings are tracked in `config/detekt/baseline.xml`; CI should fail
+  only for new findings outside that baseline.
+- Kover reports are generated and uploaded as report-only trend evidence.
+- Nightly keeps wider Detekt and coverage visibility for full/smoke scopes.
+- Dependency security posture is handled through CodeQL, GitHub dependency
+  graph alerts, Dependabot for GitHub Actions, and central library version
+  governance in `bluetape4k-dependencies`.
+
+## Exclusions
+
+- Do not add a fixed Kover percentage gate unless a later focused issue
+  reintroduces module-level thresholds.
+- Do not add `ktlint` as a one-off CI gate unless the repository adopts ktlint
+  as a maintained Gradle plugin and style contract.
+- Do not add OWASP Dependency Check to release publishing by default. Its NVD
+  dependency and false-positive profile make it a poor release-blocking gate for
+  this repository without a separate vulnerability triage policy.
+
+## Verification Contract
+
+- Workflow YAML must pass `actionlint`.
+- `./gradlew detekt` must pass locally for CI quality-gate changes.
+- Regenerate the baseline only with `./gradlew detektProjectBaseline` after
+  reviewing whether existing findings should instead be fixed.
+- Kover report generation remains `continue-on-error: true` so coverage data is
+  visible without failing builds solely on a fixed threshold.

--- a/docs/governance/dependency-update-policy.md
+++ b/docs/governance/dependency-update-policy.md
@@ -1,0 +1,29 @@
+# Dependency Update Policy
+
+## Current Status
+
+`bluetape4k-graph` is a leaf repository in the bluetape4k dependency graph.
+Gradle and Maven library versions are governed centrally through
+`bluetape4k-dependencies`.
+
+## Policy
+
+- Change shared library versions in `bluetape4k-dependencies` first.
+- Materialize central updates into this repository with the shared sync scripts.
+- Keep this repository's Dependabot configuration limited to GitHub Actions.
+- Do not enable Renovate in this repository unless the organization changes the
+  central dependency-governance model.
+
+## Dependabot Scope
+
+`.github/dependabot.yml` intentionally tracks only GitHub Actions updates on
+the `develop` branch. Gradle package updates are omitted so leaf repositories do
+not drift away from the central BOM and version catalog.
+
+## Verification Contract
+
+- Parse `.github/dependabot.yml` after edits.
+- For central version sync work, run the relevant `sync-shared-versions.py` and
+  `sync-dependabot-ignores.py` checks from the central dependency repository.
+- Record any intentional exception in a focused issue before changing the
+  per-repository Dependabot scope.

--- a/docs/lessons/2026-05-18-issue-18-19-ci-dependency-governance.md
+++ b/docs/lessons/2026-05-18-issue-18-19-ci-dependency-governance.md
@@ -1,0 +1,34 @@
+# Issue 18/19 CI and Dependency Governance
+
+## Context
+
+Issues #18 and #19 still described the pre-governance setup: ktlint, fixed
+Kover thresholds, OWASP dependency-check, and per-repository Gradle Dependabot
+updates.
+
+## Decision
+
+Keep the current governance model: CI blocks on Detekt and tests, Kover stays
+report-only, and Gradle/Maven library updates flow through
+`bluetape4k-dependencies`. Leaf Dependabot remains scoped to GitHub Actions.
+
+## Outcome
+
+CI now runs Detekt in the pull-request build job, governance docs describe the
+current quality and dependency policies, and WIP status no longer advertises
+#18/#19 as open automation work.
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml`
+- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
+- `./gradlew detektProjectBaseline --no-daemon`
+- `./gradlew detekt --no-daemon`
+- `./gradlew build -x test --no-daemon`
+- `git diff --check`
+
+## Future Guidance
+
+Do not re-add ktlint, fixed Kover thresholds, OWASP dependency-check, or leaf
+Gradle Dependabot updates just because old issue text mentions them. Open a new
+focused governance issue first.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ datafaker = "2.5.4"  # https://mvnrepository.com/artifact/net.datafaker/datafake
 random-beans = "3.9.0"  # https://mvnrepository.com/artifact/io.github.benas/random-beans
 
 # Plugin versions
-detekt = "1.23.8"  # https://mvnrepository.com/artifact/io.gitlab.arturbosch.detekt/detekt-gradle-plugin
+detekt = "2.0.0-alpha.3"  # https://plugins.gradle.org/plugin/dev.detekt
 dependency-management = "1.1.7"  # https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
 dokka = "2.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
 kover = "0.9.8"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kover-gradle-plugin
@@ -70,7 +70,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinx-atomicfu" }
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark" }
 
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 dependency-management = { id = "io.spring.dependency-management", version.ref = "dependency-management" }
 spring-boot = { id = "org.springframework.boot" }
 spring-boot4 = { id = "org.springframework.boot", version.ref = "spring-boot4" }


### PR DESCRIPTION
## Summary

- Closes #18 by wiring Detekt as the PR quality gate with module report artifacts and a shared baseline.
- Closes #19 by keeping leaf Dependabot scoped to GitHub Actions and documenting central Gradle/Maven dependency governance.
- Updates WIP/governance/lesson docs so old ktlint, fixed Kover threshold, OWASP dependency-check, and leaf Gradle Dependabot requirements are no longer treated as current scope.

## Verification

- actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'
- ./gradlew detekt --no-daemon
- ./gradlew build -x test --no-daemon
- git diff --check

## Notes

Kover remains report-only under the current coverage policy. Full integration tests with containers were not run locally.