### PR TITLE
test: cover Spring Boot FalkorDB nightly auto-config

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -128,9 +128,9 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 3. Spring Boot (TinkerGraph, in-memory) ───────────────────
+  # ── 3. Spring Boot (TinkerGraph + full-scope FalkorDB) ─────────
   test-spring-starters:
-    name: Test / Spring Boot (TinkerGraph)
+    name: Test / Spring Boot
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build
@@ -160,6 +160,38 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           SPRING_PROFILES_ACTIVE: tinkergraph
 
+      - name: Restore Testcontainers image cache
+        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
+      - name: Test Spring Boot FalkorDB auto-configuration
+        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :bluetape4k-graph-spring-boot:test \
+              --tests "*.FalkorDBSpringBootIntegrationTest" \
+              --rerun-tasks \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          BLUETAPE4K_GRAPH_SPRING_FALKORDB_INTEGRATION: "true"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
+
       - name: Generate Kover XML report
         if: always()
         run: |
@@ -184,79 +216,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 4. Spring Boot FalkorDB auto-configuration (Testcontainers) ──────────
-  test-spring-falkordb:
-    name: Test / Spring Boot FalkorDB (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: build
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-
-      - uses: gradle/actions/setup-gradle@v6
-        with:
-          gradle-version: wrapper
-          cache-read-only: true
-
-      - name: Restore Testcontainers image cache
-        uses: ./.github/actions/testcontainers-image-cache
-        with:
-          mode: restore
-          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
-          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
-
-      - name: Test Spring Boot FalkorDB auto-configuration
-        run: |
-          for attempt in 1 2 3; do
-            ./gradlew \
-              :bluetape4k-graph-spring-boot:test \
-              --tests "*.FalkorDBSpringBootIntegrationTest" \
-              --rerun-tasks \
-              --no-daemon --continue && break
-            echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
-          done
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
-          BLUETAPE4K_GRAPH_SPRING_FALKORDB_INTEGRATION: "true"
-          TESTCONTAINERS_RYUK_DISABLED: "true"
-          DOCKER_HOST: "unix:///var/run/docker.sock"
-
-      - name: Save Testcontainers image cache
-        if: always()
-        uses: ./.github/actions/testcontainers-image-cache
-        with:
-          mode: save
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-graph-spring-boot:koverXmlReport --no-daemon
-        continue-on-error: true
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-results-spring-falkordb
-          path: '**/build/test-results/test/*.xml'
-          retention-days: 14
-
-      - name: Upload coverage report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-spring-falkordb
-          path: '**/build/reports/kover/'
-          retention-days: 14
-
-  # ── 5. Ktor Graph (Testcontainers) ───────────────────────────────────────
+  # ── 4. Ktor Graph (Testcontainers) ───────────────────────────────────────
   test-graph-ktor:
     name: Test / Ktor Graph (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -323,7 +283,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 6. Neo4j (Testcontainers) ─────────────────────────────────────────────
+  # ── 5. Neo4j (Testcontainers) ─────────────────────────────────────────────
   test-graph-neo4j:
     name: Test / Neo4j (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -390,7 +350,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 7. Memgraph (Testcontainers) ──────────────────────────────────────────
+  # ── 6. Memgraph (Testcontainers) ──────────────────────────────────────────
   test-graph-memgraph:
     name: Test / Memgraph (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -457,7 +417,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 8. Apache AGE (Testcontainers) ────────────────────────────────────────
+  # ── 7. Apache AGE (Testcontainers) ────────────────────────────────────────
   test-graph-age:
     name: Test / Apache AGE (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -524,7 +484,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 9. FalkorDB (Testcontainers) ──────────────────────────────────────────
+  # ── 8. FalkorDB (Testcontainers) ──────────────────────────────────────────
   test-graph-falkordb:
     name: Test / FalkorDB (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -591,7 +551,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 10. 커버리지 집계 ─────────────────────────────────────────────────────
+  # ── 9. 커버리지 집계 ──────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
 
@@ -600,7 +560,6 @@ jobs:
     needs:
       - test-core
       - test-spring-starters
-      - test-spring-falkordb
       - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph
@@ -644,7 +603,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 30
 
-  # ── 11. 결과 집계 ─────────────────────────────────────────────────────────
+  # ── 10. 결과 집계 ─────────────────────────────────────────────────────────
   nightly-status:
     name: Nightly Status
     runs-on: ubuntu-latest
@@ -653,7 +612,6 @@ jobs:
       - build
       - test-core
       - test-spring-starters
-      - test-spring-falkordb
       - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -184,7 +184,79 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 4. Ktor Graph (Testcontainers) ───────────────────────────────────────
+  # ── 4. Spring Boot FalkorDB auto-configuration (Testcontainers) ──────────
+  test-spring-falkordb:
+    name: Test / Spring Boot FalkorDB (Testcontainers)
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
+      - name: Test Spring Boot FalkorDB auto-configuration
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew \
+              :bluetape4k-graph-spring-boot:test \
+              --tests "*.FalkorDBSpringBootIntegrationTest" \
+              --rerun-tasks \
+              --no-daemon --continue && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          BLUETAPE4K_GRAPH_SPRING_FALKORDB_INTEGRATION: "true"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
+
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :bluetape4k-graph-spring-boot:koverXmlReport --no-daemon
+        continue-on-error: true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-spring-falkordb
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-spring-falkordb
+          path: '**/build/reports/kover/'
+          retention-days: 14
+
+  # ── 5. Ktor Graph (Testcontainers) ───────────────────────────────────────
   test-graph-ktor:
     name: Test / Ktor Graph (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -251,7 +323,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 5. Neo4j (Testcontainers) ─────────────────────────────────────────────
+  # ── 6. Neo4j (Testcontainers) ─────────────────────────────────────────────
   test-graph-neo4j:
     name: Test / Neo4j (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -318,7 +390,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 6. Memgraph (Testcontainers) ──────────────────────────────────────────
+  # ── 7. Memgraph (Testcontainers) ──────────────────────────────────────────
   test-graph-memgraph:
     name: Test / Memgraph (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -385,7 +457,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 7. Apache AGE (Testcontainers) ────────────────────────────────────────
+  # ── 8. Apache AGE (Testcontainers) ────────────────────────────────────────
   test-graph-age:
     name: Test / Apache AGE (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -452,7 +524,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 8. FalkorDB (Testcontainers) ──────────────────────────────────────────
+  # ── 9. FalkorDB (Testcontainers) ──────────────────────────────────────────
   test-graph-falkordb:
     name: Test / FalkorDB (Testcontainers)
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
@@ -519,7 +591,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
-  # ── 9. 커버리지 집계 ──────────────────────────────────────────────────────
+  # ── 10. 커버리지 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
 
@@ -528,6 +600,7 @@ jobs:
     needs:
       - test-core
       - test-spring-starters
+      - test-spring-falkordb
       - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph
@@ -571,7 +644,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 30
 
-  # ── 10. 결과 집계 ─────────────────────────────────────────────────────────
+  # ── 11. 결과 집계 ─────────────────────────────────────────────────────────
   nightly-status:
     name: Nightly Status
     runs-on: ubuntu-latest
@@ -580,6 +653,7 @@ jobs:
       - build
       - test-core
       - test-spring-starters
+      - test-spring-falkordb
       - test-graph-ktor
       - test-graph-neo4j
       - test-graph-memgraph

--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-18 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 17 issues; 15 remain after #18/#19 close through this work.
+Open count: 15 issues; 14 remain after #126 closes through this work.
 
 ## Refresh Notes
 
@@ -17,6 +17,8 @@ Verified with `gh` on 2026-05-18 KST.
 - Issues #18 and #19 are handled by the CI quality-gate and dependency-governance refresh:
   - CI now blocks on Detekt in the PR build job while Kover remains report-only.
   - Leaf Dependabot stays scoped to GitHub Actions; Gradle/Maven library updates remain centralized in `bluetape4k-dependencies`.
+- Issue #126 is handled by adding a full-nightly Spring Boot FalkorDB Testcontainers job and a gated
+  `@SpringBootTest` that verifies the auto-configuration path against a live FalkorDB container.
 
 ## Current Direction
 
@@ -39,7 +41,6 @@ contracts and backend readiness before widening examples or benchmark lanes:
 | P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30. |
 | P2 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P2 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Useful after backend readiness is clear. |
-| P3 | [#126](https://github.com/bluetape4k/bluetape4k-graph/issues/126) add Spring Boot FalkorDB auto-config to nightly CI coverage | S | CI/documentation lane. |
 | P3 | [#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127) replace deprecated/internal Ktor APIs in graph-ktor | S | Build maintenance when Ktor flags concrete drift. |
 | P3 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation lane. |
 | P3 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |

--- a/WIP.md
+++ b/WIP.md
@@ -17,7 +17,7 @@ Verified with `gh` on 2026-05-18 KST.
 - Issues #18 and #19 are handled by the CI quality-gate and dependency-governance refresh:
   - CI now blocks on Detekt in the PR build job while Kover remains report-only.
   - Leaf Dependabot stays scoped to GitHub Actions; Gradle/Maven library updates remain centralized in `bluetape4k-dependencies`.
-- Issue #126 is handled by adding a full-nightly Spring Boot FalkorDB Testcontainers job and a gated
+- Issue #126 is handled by adding a full-nightly Spring Boot FalkorDB Testcontainers step and a gated
   `@SpringBootTest` that verifies the auto-configuration path against a live FalkorDB container.
 
 ## Current Direction

--- a/docs/lessons/2026-05-18-issue-126-spring-falkordb-nightly.md
+++ b/docs/lessons/2026-05-18-issue-126-spring-falkordb-nightly.md
@@ -1,0 +1,46 @@
+# Issue 126 Spring Boot FalkorDB Nightly Coverage
+
+## Context
+
+Issue #126 asked whether `graph-spring-boot` covered the FalkorDB
+auto-configuration path in nightly CI with a live FalkorDB Testcontainer.
+
+## Decision
+
+Keep the normal Spring Boot test job focused on the existing TinkerGraph smoke
+path, and add a dedicated `scope=full` nightly job for the FalkorDB Spring Boot
+auto-configuration path. Gate the new live-container `@SpringBootTest` behind an
+environment variable so routine module tests compile it but do not start Docker.
+
+## Outcome
+
+Nightly now has `Test / Spring Boot FalkorDB (Testcontainers)`, which runs
+`FalkorDBSpringBootIntegrationTest` against `FalkorDBServer.Launcher.falkordb`.
+The workflow forces that filtered test to execute with `--rerun-tasks` so a
+cached skipped result from routine Spring Boot tests cannot satisfy the
+full-nightly gate. The test verifies the Boot context registers graph
+operations, suspend and virtual-thread operations, and the FalkorDB health
+indicator against a live container. `falkordbHealthIndicator` now uses a
+bean-name missing-bean condition so other Actuator health indicators do not
+block the backend-specific health indicator.
+
+## Verification
+
+- `BLUETAPE4K_GRAPH_SPRING_FALKORDB_INTEGRATION=true ./gradlew :bluetape4k-graph-spring-boot:test --tests "*.FalkorDBSpringBootIntegrationTest" --rerun-tasks --no-daemon --continue`
+- `./gradlew :bluetape4k-graph-spring-boot:test --no-daemon --continue`
+- `./gradlew detekt --no-daemon`
+- `actionlint .github/workflows/nightly-tests.yml`
+- `git diff --check`
+
+IDE diagnostics could not run because the graph worktree is not open in the
+IntelliJ MCP project list; Gradle compile/test and Detekt were used as fallback.
+
+## Future Guidance
+
+For expensive Spring Boot + Testcontainers coverage, prefer a gated test plus a
+dedicated full-nightly job. Add `--rerun-tasks` to the dedicated job when the
+same test class is normally compiled but skipped, because Gradle build cache can
+otherwise reuse a skipped test result. This keeps smoke tests cheap while still
+proving the real auto-configuration path before release.
+For backend-specific health indicators, use name-based `@ConditionalOnMissingBean`
+guards instead of a broad `HealthIndicator` type guard.

--- a/docs/lessons/2026-05-18-issue-126-spring-falkordb-nightly.md
+++ b/docs/lessons/2026-05-18-issue-126-spring-falkordb-nightly.md
@@ -8,21 +8,22 @@ auto-configuration path in nightly CI with a live FalkorDB Testcontainer.
 ## Decision
 
 Keep the normal Spring Boot test job focused on the existing TinkerGraph smoke
-path, and add a dedicated `scope=full` nightly job for the FalkorDB Spring Boot
-auto-configuration path. Gate the new live-container `@SpringBootTest` behind an
-environment variable so routine module tests compile it but do not start Docker.
+path for smoke scope, and add a `scope=full` step in the same job for the
+FalkorDB Spring Boot auto-configuration path. Gate the new live-container
+`@SpringBootTest` behind an environment variable so routine module tests compile
+it but do not start Docker.
 
 ## Outcome
 
-Nightly now has `Test / Spring Boot FalkorDB (Testcontainers)`, which runs
-`FalkorDBSpringBootIntegrationTest` against `FalkorDBServer.Launcher.falkordb`.
-The workflow forces that filtered test to execute with `--rerun-tasks` so a
-cached skipped result from routine Spring Boot tests cannot satisfy the
-full-nightly gate. The test verifies the Boot context registers graph
-operations, suspend and virtual-thread operations, and the FalkorDB health
-indicator against a live container. `falkordbHealthIndicator` now uses a
-bean-name missing-bean condition so other Actuator health indicators do not
-block the backend-specific health indicator.
+Nightly now runs `FalkorDBSpringBootIntegrationTest` inside the `Test / Spring
+Boot` job during full scope, after the normal TinkerGraph Spring Boot test
+warms the module dependencies. The workflow forces that filtered test to execute
+with `--rerun-tasks` so a cached skipped result from routine Spring Boot tests
+cannot satisfy the full-nightly gate. The test verifies the Boot context
+registers graph operations, suspend and virtual-thread operations, and the
+FalkorDB health indicator against a live container. `falkordbHealthIndicator`
+now uses a bean-name missing-bean condition so other Actuator health indicators
+do not block the backend-specific health indicator.
 
 ## Verification
 
@@ -38,8 +39,9 @@ IntelliJ MCP project list; Gradle compile/test and Detekt were used as fallback.
 ## Future Guidance
 
 For expensive Spring Boot + Testcontainers coverage, prefer a gated test plus a
-dedicated full-nightly job. Add `--rerun-tasks` to the dedicated job when the
-same test class is normally compiled but skipped, because Gradle build cache can
+full-nightly step in the existing Spring Boot job when it can reuse the same
+module dependency resolution. Add `--rerun-tasks` to the gated step when the same
+test class is normally compiled but skipped, because Gradle build cache can
 otherwise reuse a skipped test result. This keeps smoke tests cheap while still
 proving the real auto-configuration path before release.
 For backend-specific health indicators, use name-based `@ConditionalOnMissingBean`

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -118,7 +118,7 @@ class GraphFalkorDBAutoConfiguration {
          * `__health__` 그래프에 `RETURN 1` 쿼리를 실행하여 연결 상태를 확인한다.
          */
         @Bean
-        @ConditionalOnMissingBean
+        @ConditionalOnMissingBean(name = ["falkordbHealthIndicator"])
         fun falkordbHealthIndicator(driver: com.falkordb.Driver): org.springframework.boot.health.contributor.HealthIndicator =
             org.springframework.boot.health.contributor.HealthIndicator {
                 try {

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/FalkorDBSpringBootIntegrationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/FalkorDBSpringBootIntegrationTest.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.graph.spring.boot.autoconfigure
+
+import com.falkordb.Driver
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.util.UUID
+
+@SpringBootTest(
+    classes = [FalkorDBSpringBootIntegrationTest.TestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+)
+@EnabledIfEnvironmentVariable(named = "BLUETAPE4K_GRAPH_SPRING_FALKORDB_INTEGRATION", matches = "true")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FalkorDBSpringBootIntegrationTest {
+
+    companion object {
+        private val server = FalkorDBServer.Launcher.falkordb
+        private val graphName = "spring_boot_${UUID.randomUUID().toString().replace("-", "").take(12)}"
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun graphProperties(registry: DynamicPropertyRegistry) {
+            registry.add("bluetape4k.graph.backend") { "falkordb" }
+            registry.add("bluetape4k.graph.falkordb.host") { server.host }
+            registry.add("bluetape4k.graph.falkordb.port") { server.port }
+            registry.add("bluetape4k.graph.falkordb.graph-name") { graphName }
+        }
+    }
+
+    @Autowired
+    private lateinit var driver: Driver
+
+    @Autowired
+    private lateinit var graphOperations: GraphOperations
+
+    @Autowired
+    private lateinit var graphSuspendOperations: GraphSuspendOperations
+
+    @Autowired
+    private lateinit var graphVirtualThreadOperations: GraphVirtualThreadOperations
+
+    @Autowired
+    @Qualifier("falkordbHealthIndicator")
+    private lateinit var healthIndicator: HealthIndicator
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { driver.graph(graphName).use { it.deleteGraph() } }
+    }
+
+    @Test
+    fun `Spring Boot context wires FalkorDB auto-configuration against live container`() {
+        graphOperations.shouldNotBeNull()
+        graphSuspendOperations.shouldNotBeNull()
+        graphVirtualThreadOperations.shouldNotBeNull()
+
+        val vertex = graphOperations.createVertex("Issue126", mapOf("source" to "spring-boot"))
+
+        vertex.label shouldBeEqualTo "Issue126"
+        vertex.properties["source"] shouldBeEqualTo "spring-boot"
+        healthIndicator.health().shouldNotBeNull().status.code shouldBeEqualTo "UP"
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(
+        excludeName = [
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+        ]
+    )
+    @Import(GraphAutoConfiguration::class)
+    class TestApp
+}


### PR DESCRIPTION
## Summary

- Closes #126 by adding full-nightly FalkorDB coverage inside the existing `Test / Spring Boot` Nightly job.
- Adds `FalkorDBSpringBootIntegrationTest`, a gated `@SpringBootTest` that verifies the FalkorDB auto-configuration path against a live FalkorDB Testcontainer.
- Fixes `falkordbHealthIndicator` to use a bean-name missing-bean condition so other Actuator health indicators do not suppress the backend health indicator.
- Updates WIP and captures the lesson for gated Testcontainers nightly coverage.

## Verification

- `BLUETAPE4K_GRAPH_SPRING_FALKORDB_INTEGRATION=true ./gradlew :bluetape4k-graph-spring-boot:test --tests '*.FalkorDBSpringBootIntegrationTest' --rerun-tasks --no-daemon --continue`
- `./gradlew :bluetape4k-graph-spring-boot:test --no-daemon --continue`
- `./gradlew build -x test --no-daemon`
- `./gradlew detekt --no-daemon`
- `actionlint .github/workflows/nightly-tests.yml`
- `git diff --check`

## Review Notes

- Claude advisor found the broad `@ConditionalOnMissingBean` health-indicator risk; fixed with `name = ["falkordbHealthIndicator"]`.
- Codex review found the Gradle test-cache risk for a gated filtered test; fixed with `--rerun-tasks` in the full-nightly step.
- The first manual full Nightly run failed in the separate Spring FalkorDB job while downloading Maven Central artifacts with HTTP 403. After checking `bluetape4k-aws` and `bluetape4k-workshop` Nightly patterns, the FalkorDB Spring Boot coverage was moved into the existing Spring Boot job to reuse module dependency resolution and avoid an extra parallel Spring Boot runner.
- IntelliJ diagnostics could not run because this graph worktree is not open in the IntelliJ MCP project list; Gradle compile/test and Detekt were used as fallback.

## Nightly Evidence

- Manual `Nightly` with `scope=full` on `test/issue-126-spring-falkordb-nightly`: https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26037952480
- Result: success. `Test / Spring Boot` passed, including `Test Spring Boot FalkorDB auto-configuration`.
