### PR TITLE
fix: remove remaining suspend transaction blocking bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Neo4j suspend transactions no longer bridge through `runBlocking`**: `Neo4jGraphSuspendOperations.suspendTransaction()` now uses Neo4j reactive transactions, preserves rollback/cleanup semantics, and materializes returned transaction `Flow` values before commit ([#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158)).
+- **AGE, Memgraph, and TinkerGraph suspend transactions no longer bridge through `runBlocking`**: AGE now uses Exposed suspended transactions with a native suspend transaction scope, Memgraph uses reactive Bolt transactions, and TinkerGraph uses a suspend-aware rollback snapshot path. Cancellation rollback and returned transaction `Flow` materialization are covered by targeted tests ([#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160)).
 
 ---
 

--- a/WIP.md
+++ b/WIP.md
@@ -21,6 +21,8 @@ Verified with `gh` on 2026-05-18 KST.
   `@SpringBootTest` that verifies the auto-configuration path against a live FalkorDB container.
 - Issue #158 is handled by moving Neo4j suspend transactions to the reactive transaction API, keeping
   rollback/cleanup semantics, and materializing returned transaction `Flow` values before commit.
+- Issue #160 is handled by removing the remaining AGE, Memgraph, and TinkerGraph `runBlocking`
+  transaction bridges and adding cancellation rollback plus returned `Flow` materialization tests.
 
 ## Current Direction
 
@@ -28,7 +30,7 @@ Verified with `gh` on 2026-05-18 KST.
 contracts and backend readiness before widening examples or benchmark lanes:
 
 1. Fix cancellation and `runCatching{}` issues in FalkorDB/Memgraph (#156/#157).
-2. Continue removing `runBlocking` bridges from suspend transaction implementations; #158 is fixed, #160 remains for AGE/Memgraph/TinkerGraph.
+2. Continue cancellation correctness work now that suspend transaction `runBlocking` bridges are removed by #158 and #160.
 3. Complete Neptune testability research (#113) before starting the backend epic (#30).
 4. Resume examples, CI automation, and benchmarks only after correctness baselines are stable.
 
@@ -39,7 +41,7 @@ contracts and backend readiness before widening examples or benchmark lanes:
 | P1 | [#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156) FalkorDBGraphSuspendOperations.graphExists() swallows CancellationException | S | Replace `runCatching{}` so suspend function propagates cancellation correctly. |
 | P1 | [#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157) FalkorDB/MemgraphGraphSchemaManager overly broad runCatching{} | S | Narrow to expected exceptions; fix correctness baseline for graph-falkordb and graph-memgraph. |
 | P1 | [#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158) Neo4jGraphSuspendOperations.suspendTransaction() runBlocking inside withContext(IO) | M | Remove `runBlocking`; use async Neo4j driver or coroutine-safe bridge to prevent IO thread starvation. |
-| P1 | [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) AGE/Memgraph/TinkerGraph suspendTransaction runBlocking bridge | M | Align the remaining suspend transaction implementations with #158. |
+| P1 | [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) AGE/Memgraph/TinkerGraph suspendTransaction runBlocking bridge | M | Handled by this work; remove from active queue after merge. |
 | P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30. |
 | P2 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P2 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Useful after backend readiness is clear. |
@@ -60,8 +62,8 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 #158 Neo4j suspendTransaction runBlocking bridge
 #160 AGE / Memgraph / TinkerGraph suspendTransaction runBlocking bridge
-  -> remove suspend-to-blocking transaction bridges consistently
-  -> verify cancellation does not pin IO workers indefinitely
+  -> suspend-to-blocking transaction bridges removed consistently
+  -> cancellation rollback and returned Flow materialization covered by tests
 
 #113 Neptune local testability research
   -> #30 Neptune backend
@@ -78,7 +80,7 @@ contracts and backend readiness before widening examples or benchmark lanes:
 | Lane | Limit | Current next |
 |---|---:|---|
 | Cancellation correctness | 1 | Start with `#156`, then `#157`. |
-| Suspend transaction safety | 1 | Apply the #158 reactive/suspend-aware strategy to `#160` where each backend supports it. |
+| Suspend transaction safety | 1 | #160 in PR; remove this lane after merge unless a new transaction-safety issue appears. |
 | Research / backend readiness | 1 | `#113` before `#30`. |
 | CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
 | Examples / benchmarks | 1 | `#111` before benchmarks; keep benchmark work after CI is stable. |

--- a/docs/lessons/2026-05-19-issue-160-suspend-transactions.md
+++ b/docs/lessons/2026-05-19-issue-160-suspend-transactions.md
@@ -1,0 +1,31 @@
+# Issue 160 Suspend Transaction Cleanup
+
+## Context
+
+AGE, Memgraph, and TinkerGraph suspend transaction implementations still executed user suspend blocks through a blocking coroutine bridge inside a synchronous transaction callback.
+
+## Decision
+
+- Use backend-native suspend/reactive transaction boundaries where available.
+- Materialize any returned transaction `Flow` before commit/transaction exit.
+- For TinkerGraph, keep the in-memory rollback-snapshot semantics and guard the suspend and synchronous transaction paths with one shared semaphore gate.
+
+## Outcome
+
+- AGE `suspendTransaction` now runs inside `newSuspendedTransaction(Dispatchers.IO)` with a dedicated current-transaction suspend scope.
+- Memgraph now mirrors the Neo4j reactive transaction pattern with reactive commit/rollback/cleanup.
+- TinkerGraph no longer invokes a blocking coroutine bridge, restores snapshots on failure or cancellation, and serializes synchronous and suspend transactions around rollback snapshots.
+
+## Verification
+
+- `./gradlew :bluetape4k-graph-tinkerpop:compileKotlin :bluetape4k-graph-tinkerpop:compileTestKotlin :bluetape4k-graph-tinkerpop:test --tests "io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperationsTest" :bluetape4k-graph-tinkerpop:detekt --console=plain --no-daemon`
+- `./gradlew :bluetape4k-graph-tinkerpop:test :bluetape4k-graph-age:test :bluetape4k-graph-memgraph:test --console=plain --no-daemon`
+- `./gradlew :bluetape4k-graph-age:detekt :bluetape4k-graph-memgraph:detekt :bluetape4k-graph-tinkerpop:detekt --console=plain --no-daemon`
+- `rg -n "runBlocking" graph/graph-age graph/graph-memgraph graph/graph-tinkerpop -g '*.kt'` returned no matches.
+- `git diff --check`
+- `codex review --uncommitted` reported no actionable correctness issues after fixing a TinkerGraph gate-acquisition cancellation race found in the first pass.
+- Claude CLI advisor was attempted twice but produced no output before timeout; record this as a review-tool availability gap, not a code finding.
+
+## Future Guidance
+
+When a transaction block can return `Flow`, collect it before committing or leaving the transaction. Lazy collection after transaction cleanup can turn a correct rollback/commit implementation into a closed-resource bug.

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperations.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperations.kt
@@ -25,7 +25,6 @@ import io.bluetape4k.graph.repository.GraphSuspendMergeOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphSuspendTransactionScope
 import io.bluetape4k.graph.repository.GraphSuspendTransactionalOperations
-import io.bluetape4k.graph.repository.asSuspendTransactionScope
 import io.bluetape4k.graph.schema.GraphSuspendSchemaManagementOperations
 import io.bluetape4k.graph.schema.GraphSuspendSchemaManager
 import io.bluetape4k.graph.schema.asSuspendSchemaManager
@@ -34,11 +33,13 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 
 /**
  * Apache AGE + PostgreSQL 기반 [GraphSuspendOperations] 구현체 (코루틴 방식).
@@ -55,7 +56,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTrans
  * // HikariCP DataSource 생성 (connectionInitSql로 AGE 로드)
  * val ops = AgeGraphSuspendOperations("social")
  *
- * runBlocking {
+ * suspend fun writeGraph() {
  *     ops.createGraph("social")
  *
  *     val alice = ops.createVertex("Person", mapOf("name" to "Alice", "age" to 30))
@@ -89,12 +90,18 @@ class AgeGraphSuspendOperations(
         AgeGraphSchemaManager().asSuspendSchemaManager()
 
     override suspend fun <T> suspendTransaction(block: suspend GraphSuspendTransactionScope.() -> T): T =
-        withContext(Dispatchers.IO) {
-            AgeGraphOperations(graphName).transaction {
-                val scope = asSuspendTransactionScope()
-                runBlocking { scope.block() }
-            }
+        newSuspendedTransaction(Dispatchers.IO) {
+            val result = AgeGraphSuspendTransactionScope(graphName).block()
+            materializeTransactionResult(result)
         }
+
+    private suspend fun <T> materializeTransactionResult(result: T): T {
+        if (result !is Flow<*>) return result
+
+        val values = result.toList()
+        @Suppress("UNCHECKED_CAST")
+        return values.asFlow() as T
+    }
 
     override suspend fun mergeVertex(
         label: String,
@@ -494,5 +501,176 @@ class AgeGraphSuspendOperations(
     override fun pageRank(options: PageRankOptions): Flow<PageRankScore> = flow {
         val list = withContext(Dispatchers.IO) { syncDelegate.pageRank(options) }
         list.forEach { emit(it) }
+    }
+}
+
+@Suppress("TooManyFunctions")
+private class AgeGraphSuspendTransactionScope(
+    private val graphName: String,
+): GraphSuspendTransactionScope {
+
+    private fun GraphElementId.toAgeLong(): Long =
+        value.toLongOrNull()
+            ?: throw GraphQueryException("AGE requires numeric ID, got: $value")
+
+    override suspend fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex {
+        label.requireNotBlank("label")
+
+        var vertex: GraphVertex? = null
+        TransactionManager.current().exec(AgeSql.createVertex(graphName, label, properties)) { rs ->
+            if (rs.next()) {
+                vertex = AgeTypeParser.parseVertex(rs.getString("v"))
+            }
+        }
+        return vertex ?: throw GraphQueryException("Failed to create vertex with label=$label")
+    }
+
+    override suspend fun findVertexById(label: String, id: GraphElementId): GraphVertex? {
+        label.requireNotBlank("label")
+        val longId = id.toAgeLong()
+
+        var vertex: GraphVertex? = null
+        TransactionManager.current().exec(AgeSql.matchVertexById(graphName, label, longId)) { rs ->
+            if (rs.next()) {
+                vertex = AgeTypeParser.parseVertex(rs.getString("v"))
+            }
+        }
+        return vertex
+    }
+
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? {
+        val longId = id.toAgeLong()
+
+        var vertex: GraphVertex? = null
+        TransactionManager.current().exec(AgeSql.matchVertexById(graphName, longId)) { rs ->
+            if (rs.next()) {
+                vertex = AgeTypeParser.parseVertex(rs.getString("v"))
+            }
+        }
+        return vertex
+    }
+
+    override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
+        label.requireNotBlank("label")
+        return flow {
+            val vertices = mutableListOf<GraphVertex>()
+            TransactionManager.current().exec(AgeSql.matchVertices(graphName, label, filter)) { rs ->
+                while (rs.next()) {
+                    vertices.add(AgeTypeParser.parseVertex(rs.getString("v")))
+                }
+            }
+            vertices.forEach { emit(it) }
+        }
+    }
+
+    override suspend fun updateVertex(
+        label: String,
+        id: GraphElementId,
+        properties: Map<String, Any?>,
+    ): GraphVertex? {
+        label.requireNotBlank("label")
+        val longId = id.toAgeLong()
+
+        var vertex: GraphVertex? = null
+        TransactionManager.current().exec(AgeSql.updateVertex(graphName, label, longId, properties)) { rs ->
+            if (rs.next()) {
+                vertex = AgeTypeParser.parseVertex(rs.getString("v"))
+            }
+        }
+        return vertex
+    }
+
+    override suspend fun deleteVertex(label: String, id: GraphElementId): Boolean {
+        label.requireNotBlank("label")
+        val longId = id.toAgeLong()
+
+        var deleted = false
+        TransactionManager.current().exec(AgeSql.deleteVertex(graphName, label, longId)) { rs ->
+            deleted = rs.next()
+        }
+        return deleted
+    }
+
+    override suspend fun countVertices(label: String): Long {
+        label.requireNotBlank("label")
+
+        var count = 0L
+        TransactionManager.current().exec(AgeSql.countVertices(graphName, label)) { rs ->
+            if (rs.next()) {
+                count = rs.getString("count").trim().toLongOrNull() ?: 0L
+            }
+        }
+        return count
+    }
+
+    override suspend fun createEdge(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        label: String,
+        properties: Map<String, Any?>,
+    ): GraphEdge {
+        label.requireNotBlank("label")
+        val from = fromId.toAgeLong()
+        val to = toId.toAgeLong()
+
+        var edge: GraphEdge? = null
+        TransactionManager.current().exec(AgeSql.createEdge(graphName, from, to, label, properties)) { rs ->
+            if (rs.next()) {
+                edge = AgeTypeParser.parseEdge(rs.getString("e"))
+            }
+        }
+        return edge ?: throw GraphQueryException("Failed to create edge: $label ($fromId -> $toId)")
+    }
+
+    override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> {
+        label.requireNotBlank("label")
+        return flow {
+            val edges = mutableListOf<GraphEdge>()
+            TransactionManager.current().exec(AgeSql.matchEdgesByLabel(graphName, label, filter)) { rs ->
+                while (rs.next()) {
+                    edges.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                }
+            }
+            edges.forEach { emit(it) }
+        }
+    }
+
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val longId = startId.toAgeLong()
+
+        return flow {
+            val edges = mutableListOf<GraphEdge>()
+            TransactionManager.current().exec(AgeSql.matchEdgesByStartId(graphName, longId, edgeLabel)) { rs ->
+                while (rs.next()) {
+                    edges.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                }
+            }
+            edges.forEach { emit(it) }
+        }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val longId = endId.toAgeLong()
+
+        return flow {
+            val edges = mutableListOf<GraphEdge>()
+            TransactionManager.current().exec(AgeSql.matchEdgesByEndId(graphName, longId, edgeLabel)) { rs ->
+                while (rs.next()) {
+                    edges.add(AgeTypeParser.parseEdge(rs.getString("e")))
+                }
+            }
+            edges.forEach { emit(it) }
+        }
+    }
+
+    override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean {
+        label.requireNotBlank("label")
+        val longId = id.toAgeLong()
+
+        var deleted = false
+        TransactionManager.current().exec(AgeSql.deleteEdge(graphName, label, longId)) { rs ->
+            deleted = rs.next()
+        }
+        return deleted
     }
 }

--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperationsTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperationsTest.kt
@@ -12,7 +12,10 @@ import io.bluetape4k.graph.repository.suspendTransaction
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -189,10 +192,40 @@ class AgeGraphSuspendOperationsTest {
         ops.findEdgesByLabel("KNOWS").toList().shouldBeEmpty()
     }
 
+    @Test
+    @Order(30)
+    fun `suspendTransaction은 취소 시 빠르게 반환하고 rollback한다`() = runSuspendIO {
+        val existing = ops.createVertex("Person", mapOf("name" to "Existing"))
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(500) {
+                ops.suspendTransaction {
+                    createVertex("Person", mapOf("name" to "Cancelled"))
+                    awaitCancellation()
+                }
+            }
+        }
+
+        ops.findVertexById("Person", existing.id)?.properties?.get("name") shouldBeEqualTo "Existing"
+        ops.countVertices("Person") shouldBeEqualTo 1L
+    }
+
+    @Test
+    @Order(31)
+    fun `suspendTransaction은 반환된 Flow를 commit 전에 materialize한다`() = runSuspendIO {
+        val people = ops.suspendTransaction {
+            createVertex("Person", mapOf("name" to "Alice"))
+            findVerticesByLabel("Person")
+        }
+
+        val names = people.toList().map { it.properties["name"] }
+        names.any { it == "Alice" }.shouldBeTrue()
+    }
+
     // ───────────────────────── 간선(Edge) CRUD ─────────────────────────
 
     @Test
-    @Order(30)
+    @Order(32)
     fun `두 정점 사이에 간선을 생성한다`() = runSuspendIO {
         val alice = ops.createVertex("Person", mapOf("name" to "Alice"))
         val bob = ops.createVertex("Person", mapOf("name" to "Bob"))
@@ -203,7 +236,7 @@ class AgeGraphSuspendOperationsTest {
     }
 
     @Test
-    @Order(31)
+    @Order(33)
     fun `label로 간선 목록을 조회한다`() = runSuspendIO {
         val alice = ops.createVertex("Person", mapOf("name" to "Alice"))
         val bob = ops.createVertex("Person", mapOf("name" to "Bob"))
@@ -216,7 +249,7 @@ class AgeGraphSuspendOperationsTest {
     }
 
     @Test
-    @Order(32)
+    @Order(34)
     fun `간선을 삭제한다`() = runSuspendIO {
         val alice = ops.createVertex("Person", mapOf("name" to "Alice"))
         val bob = ops.createVertex("Person", mapOf("name" to "Bob"))

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
@@ -24,7 +24,6 @@ import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphSuspendMergeOperations
 import io.bluetape4k.graph.repository.GraphSuspendTransactionScope
 import io.bluetape4k.graph.repository.GraphSuspendTransactionalOperations
-import io.bluetape4k.graph.repository.asSuspendTransactionScope
 import io.bluetape4k.graph.schema.GraphSuspendSchemaManager
 import io.bluetape4k.graph.schema.GraphSuspendSchemaManagementOperations
 import io.bluetape4k.graph.schema.asSuspendSchemaManager
@@ -36,20 +35,21 @@ import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.asFlow as asReactiveFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.neo4j.driver.Driver
 import org.neo4j.driver.Query
 import org.neo4j.driver.Record
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.reactivestreams.ReactiveSession
+import org.neo4j.driver.reactivestreams.ReactiveTransaction
 
 /**
  * Memgraph용 [GraphSuspendOperations] 구현체 (코루틴 방식).
@@ -60,13 +60,14 @@ import org.neo4j.driver.reactivestreams.ReactiveSession
  * Memgraph는 `elementId()` 대신 정수형 `id()`를 사용한다.
  * Cypher 쿼리에서 `id(n) = toInteger($id)` 형태로 노드를 조회한다.
  *
- * [ReactiveSession] + [Flow]를 사용한다.
+ * [ReactiveSession] + [Flow]를 사용한다. Transactional suspend blocks run on Memgraph
+ * reactive transactions, so they do not bridge through a blocking coroutine adapter.
  *
  * ```kotlin
  * val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
  * val ops = MemgraphGraphSuspendOperations(driver)
  *
- * runBlocking {
+ * suspend fun writeGraph() {
  *     val alice = ops.createVertex("Person", mapOf("name" to "Alice", "age" to 30))
  *     val bob   = ops.createVertex("Person", mapOf("name" to "Bob",   "age" to 25))
  *     ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024))
@@ -101,13 +102,91 @@ class MemgraphGraphSuspendOperations(
     override fun schemaManager(): GraphSuspendSchemaManager =
         MemgraphGraphSchemaManager(driver, database).asSuspendSchemaManager()
 
-    override suspend fun <T> suspendTransaction(block: suspend GraphSuspendTransactionScope.() -> T): T =
-        withContext(Dispatchers.IO) {
-            MemgraphGraphOperations(driver, database).transaction {
-                val scope = asSuspendTransactionScope()
-                runBlocking { scope.block() }
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun <T> suspendTransaction(block: suspend GraphSuspendTransactionScope.() -> T): T {
+        val s = session()
+        var failure: Throwable? = null
+        try {
+            val tx = beginTransaction(s) { failure = it }
+            try {
+                val result = MemgraphReactiveGraphSuspendTransactionScope(tx).block()
+                val materializedResult = materializeTransactionResult(result)
+                tx.commit<Void>().awaitFirstOrNull()
+                return materializedResult
+            } catch (e: Throwable) {
+                failure = e
+                try {
+                    withContext(NonCancellable) {
+                        tx.rollback<Void>().awaitFirstOrNull()
+                    }
+                } catch (rollbackFailure: Throwable) {
+                    e.addSuppressed(rollbackFailure)
+                }
+                throw e
+            } finally {
+                failure = closeTransaction(tx, failure)
+            }
+        } finally {
+            closeSession(s, failure)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun beginTransaction(
+        session: ReactiveSession,
+        onFailure: (Throwable) -> Unit,
+    ): ReactiveTransaction =
+        try {
+            session.beginTransaction().awaitSingle()
+        } catch (e: Throwable) {
+            onFailure(e)
+            throw e
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun closeTransaction(
+        tx: ReactiveTransaction,
+        failure: Throwable?,
+    ): Throwable? =
+        try {
+            withContext(NonCancellable) {
+                tx.close().awaitFirstOrNull()
+            }
+            failure
+        } catch (closeFailure: Throwable) {
+            if (failure != null) {
+                failure.addSuppressed(closeFailure)
+            } else {
+                log.warn(closeFailure) { "Failed to close Memgraph reactive transaction after successful commit." }
+            }
+            failure
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun closeSession(
+        session: ReactiveSession,
+        failure: Throwable?,
+    ) {
+        try {
+            withContext(NonCancellable) {
+                session.close<Void>().awaitFirstOrNull()
+            }
+        } catch (closeFailure: Throwable) {
+            if (failure != null) {
+                failure.addSuppressed(closeFailure)
+            } else {
+                log.warn(closeFailure) { "Failed to close Memgraph reactive session after successful transaction." }
             }
         }
+    }
+
+    private suspend fun <T> materializeTransactionResult(result: T): T {
+        if (result !is Flow<*>) return result
+
+        val values = result.toList()
+        @Suppress("UNCHECKED_CAST")
+        return values.asFlow() as T
+    }
 
     override suspend fun mergeVertex(
         label: String,
@@ -142,7 +221,7 @@ class MemgraphGraphSuspendOperations(
         val s = session()
         return try {
             val result = s.run(Query(cypher, params)).awaitSingle()
-            result.records().asFlow().toList().map(mapper)
+            result.records().asReactiveFlow().toList().map(mapper)
         } finally {
             withContext(NonCancellable) { s.close<Void>().awaitFirstOrNull() }
         }
@@ -157,15 +236,17 @@ class MemgraphGraphSuspendOperations(
         cypher: String,
         params: Map<String, Any?> = emptyMap(),
         mapper: (Record) -> T,
-    ): Flow<T> = channelFlow {
+    ): Flow<T> {
         cypher.requireNotBlank("cypher")
 
-        val s = session()
-        try {
-            val result = s.run(Query(cypher, params)).awaitSingle()
-            result.records().asFlow().map(mapper).collect { send(it) }
-        } finally {
-            withContext(NonCancellable) { s.close<Void>().awaitFirstOrNull() }
+        return flow {
+            val s = session()
+            try {
+                val result = s.run(Query(cypher, params)).awaitSingle()
+                emitAll(result.records().asReactiveFlow().map(mapper))
+            } finally {
+                withContext(NonCancellable) { s.close<Void>().awaitFirstOrNull() }
+            }
         }
     }
 
@@ -504,5 +585,181 @@ class MemgraphGraphSuspendOperations(
     override fun detectCycles(options: CycleOptions): Flow<GraphCycle> = flow {
         val list = withContext(Dispatchers.IO) { syncDelegate.detectCycles(options) }
         list.forEach { emit(it) }
+    }
+}
+
+@Suppress("TooManyFunctions")
+private class MemgraphReactiveGraphSuspendTransactionScope(
+    private val tx: ReactiveTransaction,
+): GraphSuspendTransactionScope {
+
+    private suspend fun <T> runQuery(
+        cypher: String,
+        params: Map<String, Any?> = emptyMap(),
+        mapper: (Record) -> T,
+    ): List<T> {
+        val result = tx.run(Query(cypher, params)).awaitSingle()
+        return result.records().asReactiveFlow().toList().map(mapper)
+    }
+
+    private fun <T> flowQuery(
+        cypher: String,
+        params: Map<String, Any?> = emptyMap(),
+        mapper: (Record) -> T,
+    ): Flow<T> = flow {
+        val result = tx.run(Query(cypher, params)).awaitSingle()
+        emitAll(result.records().asReactiveFlow().map(mapper))
+    }
+
+    override suspend fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+
+        val propsClause = if (properties.isEmpty()) "" else $$" $props"
+        val cypher = $$"CREATE (n:$$label$$propsClause) RETURN n"
+        val params = if (properties.isEmpty()) emptyMap() else mapOf("props" to properties)
+
+        return runQuery(cypher, params) {
+            MemgraphRecordMapper.recordToVertex(it)
+        }.firstOrNull() ?: throw GraphQueryException("Failed to create vertex: $label")
+    }
+
+    override suspend fun findVertexById(label: String, id: GraphElementId): GraphVertex? {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+
+        return runQuery(
+            $$"MATCH (n:$$label) WHERE id(n) = toInteger($id) RETURN n",
+            mapOf("id" to id.value),
+        ) {
+            MemgraphRecordMapper.recordToVertex(it)
+        }.firstOrNull()
+    }
+
+    override suspend fun findVertexById(id: GraphElementId): GraphVertex? =
+        runQuery(
+            "MATCH (n) WHERE id(n) = toInteger(\$id) RETURN n",
+            mapOf("id" to id.value),
+        ) {
+            MemgraphRecordMapper.recordToVertex(it)
+        }.firstOrNull()
+
+    override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+        val whereClause = if (filter.isEmpty()) "" else
+            " WHERE " + filter.keys.joinToString(" AND ") { key ->
+                val propertyKey = key.requireSafeIdentifier("property key")
+                "n.$propertyKey = \$$key"
+            }
+
+        return flowQuery(
+            $$"MATCH (n:$$label)$$whereClause RETURN n",
+            filter,
+        ) {
+            MemgraphRecordMapper.recordToVertex(it)
+        }
+    }
+
+    override suspend fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex? {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+        if (properties.isEmpty()) return findVertexById(label, id)
+        val setClause = properties.keys.joinToString(", ") { key ->
+            val propertyKey = key.requireSafeIdentifier("property key")
+            "n.$propertyKey = \$$key"
+        }
+        val params = properties + mapOf("id" to id.value)
+
+        return runQuery(
+            $$"MATCH (n:$$label) WHERE id(n) = toInteger($id) SET $$setClause RETURN n",
+            params,
+        ) {
+            MemgraphRecordMapper.recordToVertex(it)
+        }.firstOrNull()
+    }
+
+    override suspend fun deleteVertex(label: String, id: GraphElementId): Boolean {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+
+        val result = tx.run(
+            Query(
+                $$"MATCH (n:$$label) WHERE id(n) = toInteger($id) DETACH DELETE n",
+                mapOf("id" to id.value),
+            ),
+        ).awaitSingle()
+        return result.consume().awaitSingle().counters().nodesDeleted() > 0
+    }
+
+    override suspend fun countVertices(label: String): Long {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+        val result = tx.run(Query($$"MATCH (n:$$label) RETURN count(n) AS cnt")).awaitSingle()
+        return result.records().awaitFirstOrNull()?.get("cnt")?.asLong() ?: 0L
+    }
+
+    override suspend fun createEdge(
+        fromId: GraphElementId,
+        toId: GraphElementId,
+        label: String,
+        properties: Map<String, Any?>,
+    ): GraphEdge {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+
+        val propsClause = if (properties.isEmpty()) "" else $$" $props"
+        val params = mutableMapOf<String, Any?>("fromId" to fromId.value, "toId" to toId.value)
+        if (properties.isNotEmpty()) params["props"] = properties
+
+        return runQuery(
+            $$"MATCH (a), (b) WHERE id(a) = toInteger($fromId) AND id(b) = toInteger($toId) " +
+                    $$"CREATE (a)-[r:$$label$$propsClause]->(b) RETURN r",
+            params,
+        ) {
+            MemgraphRecordMapper.recordToEdge(it)
+        }.firstOrNull() ?: throw GraphQueryException("Failed to create edge: $label")
+    }
+
+    override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+        val whereClause = if (filter.isEmpty()) "" else
+            " WHERE " + filter.keys.joinToString(" AND ") { key ->
+                val propertyKey = key.requireSafeIdentifier("property key")
+                "r.$propertyKey = \$$key"
+            }
+
+        return flowQuery(
+            $$"MATCH ()-[r:$$label]->()$$whereClause RETURN r",
+            filter,
+        ) {
+            MemgraphRecordMapper.recordToEdge(it)
+        }
+    }
+
+    override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val labelPart = edgeLabel?.let { ":${it.requireSafeIdentifier("edgeLabel")}" } ?: ""
+        return flowQuery(
+            $$"MATCH (n)-[r$$labelPart]->(m) WHERE id(n) = toInteger($startId) RETURN r",
+            mapOf("startId" to startId.value),
+        ) {
+            MemgraphRecordMapper.recordToEdge(it)
+        }
+    }
+
+    override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> {
+        val labelPart = edgeLabel?.let { ":${it.requireSafeIdentifier("edgeLabel")}" } ?: ""
+        return flowQuery(
+            $$"MATCH (n)-[r$$labelPart]->(m) WHERE id(m) = toInteger($endId) RETURN r",
+            mapOf("endId" to endId.value),
+        ) {
+            MemgraphRecordMapper.recordToEdge(it)
+        }
+    }
+
+    override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean {
+        label.requireNotBlank("label").requireSafeIdentifier("label")
+        id.value.requireNotBlank("id.value")
+
+        val result = tx.run(
+            Query(
+                $$"MATCH ()-[r:$$label]->() WHERE id(r) = toInteger($id) DELETE r",
+                mapOf("id" to id.value),
+            ),
+        ).awaitSingle()
+        return result.consume().awaitSingle().counters().relationshipsDeleted() > 0
     }
 }

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperationsTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperationsTest.kt
@@ -10,7 +10,10 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
@@ -193,7 +196,37 @@ class MemgraphGraphSuspendOperationsTest {
     }
 
     @Test
-    @Order(29)
+    @Order(30)
+    fun `suspendTransaction은 취소 시 빠르게 반환하고 rollback한다`() = runSuspendIO {
+        val existing = ops.createVertex("Person", mapOf("name" to "Existing"))
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(500) {
+                ops.suspendTransaction {
+                    createVertex("Person", mapOf("name" to "Cancelled"))
+                    awaitCancellation()
+                }
+            }
+        }
+
+        ops.findVertexById("Person", existing.id)?.properties?.get("name") shouldBeEqualTo "Existing"
+        ops.countVertices("Person") shouldBeEqualTo 1L
+    }
+
+    @Test
+    @Order(31)
+    fun `suspendTransaction은 반환된 Flow를 commit 전에 materialize한다`() = runSuspendIO {
+        val people = ops.suspendTransaction {
+            createVertex("Person", mapOf("name" to "Alice"))
+            findVerticesByLabel("Person")
+        }
+
+        val names = people.toList().map { it.properties["name"] }
+        names shouldContain "Alice"
+    }
+
+    @Test
+    @Order(32)
     fun `unsafe Cypher identifiers are rejected before query execution`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             ops.findVerticesByLabel("Person", mapOf("name) RETURN n MATCH (m" to "Alice")).toList()
@@ -206,7 +239,7 @@ class MemgraphGraphSuspendOperationsTest {
     // ----- 간선(Edge) CRUD -----
 
     @Test
-    @Order(30)
+    @Order(33)
     fun `두 정점 사이에 간선을 생성한다`() = runSuspendIO {
         val alice = ops.createVertex("Person", mapOf("name" to "Alice"))
         val bob = ops.createVertex("Person", mapOf("name" to "Bob"))
@@ -221,7 +254,7 @@ class MemgraphGraphSuspendOperationsTest {
     }
 
     @Test
-    @Order(31)
+    @Order(34)
     fun `label로 간선 목록을 조회한다`() = runSuspendIO {
         val a = ops.createVertex("Person", mapOf("name" to "A"))
         val b = ops.createVertex("Person", mapOf("name" to "B"))

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -43,6 +43,7 @@ import org.apache.tinkerpop.gremlin.structure.Edge
 import org.apache.tinkerpop.gremlin.structure.T
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
+import java.util.concurrent.Semaphore
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__ as AnonymousTraversal
@@ -78,6 +79,7 @@ class TinkerGraphOperations :
     private val graph: TinkerGraph = TinkerGraph.open()
     private val g: GraphTraversalSource = graph.traversal()
     private val schemaManager = TinkerGraphSchemaManager()
+    private val transactionGate = Semaphore(1)
     private val writeLock = ReentrantLock()
 
     override fun close() {
@@ -107,19 +109,51 @@ class TinkerGraphOperations :
     // -- GraphTransactionalOperations --
 
     override fun <T> transaction(block: GraphTransactionScope.() -> T): T =
-        synchronized(graph) {
-            val snapshot = snapshot()
-            try {
-                block(TinkerGraphTransactionScope(this))
-            } catch (e: Throwable) {
+        withTransactionGate {
+            synchronized(graph) {
+                val snapshot = snapshot()
                 try {
-                    restore(snapshot)
-                } catch (restoreFailure: Throwable) {
-                    e.addSuppressed(restoreFailure)
+                    block(TinkerGraphTransactionScope(this))
+                } catch (e: Throwable) {
+                    try {
+                        restore(snapshot)
+                    } catch (restoreFailure: Throwable) {
+                        e.addSuppressed(restoreFailure)
+                    }
+                    throw e
                 }
-                throw e
             }
         }
+
+    internal fun tryAcquireTransactionGate(): Boolean =
+        transactionGate.tryAcquire()
+
+    internal fun releaseTransactionGate() {
+        transactionGate.release()
+    }
+
+    internal fun createTransactionSnapshot(): Any =
+        synchronized(graph) {
+            snapshot()
+        }
+
+    internal fun restoreTransactionSnapshot(snapshot: Any) {
+        synchronized(graph) {
+            restore(snapshot as TinkerGraphSnapshot)
+        }
+    }
+
+    internal fun transactionScope(): GraphTransactionScope =
+        TinkerGraphTransactionScope(this)
+
+    private fun <T> withTransactionGate(block: () -> T): T {
+        transactionGate.acquire()
+        try {
+            return block()
+        } finally {
+            transactionGate.release()
+        }
+    }
 
     // -- GraphVertexRepository --
 
@@ -222,27 +256,29 @@ class TinkerGraphOperations :
         matchProperties: Map<String, Any?>,
         setProperties: Map<String, Any?>,
     ): GraphVertex =
-        synchronized(graph) {
-            val properties = GraphMergeValidation.validateVertex(label, matchProperties, setProperties)
-            val traversal = g.V().hasLabel(label)
-            properties.matchProperties.forEach { (key, value) ->
-                traversal.has(key, value)
-            }
-            val optional = traversal.tryNext()
-            val vertex = if (optional.isPresent) {
-                optional.get()
-            } else {
-                val create = g.addV(label)
+        withTransactionGate {
+            synchronized(graph) {
+                val properties = GraphMergeValidation.validateVertex(label, matchProperties, setProperties)
+                val traversal = g.V().hasLabel(label)
                 properties.matchProperties.forEach { (key, value) ->
-                    create.property(key, value)
+                    traversal.has(key, value)
                 }
-                create.next()
-            }
+                val optional = traversal.tryNext()
+                val vertex = if (optional.isPresent) {
+                    optional.get()
+                } else {
+                    val create = g.addV(label)
+                    properties.matchProperties.forEach { (key, value) ->
+                        create.property(key, value)
+                    }
+                    create.next()
+                }
 
-            properties.setProperties.forEach { (key, value) ->
-                if (value != null) vertex.property(key, value)
+                properties.setProperties.forEach { (key, value) ->
+                    if (value != null) vertex.property(key, value)
+                }
+                GremlinRecordMapper.vertexToGraphVertex(vertex)
             }
-            GremlinRecordMapper.vertexToGraphVertex(vertex)
         }
 
     // -- GraphEdgeRepository --
@@ -352,34 +388,36 @@ class TinkerGraphOperations :
         matchProperties: Map<String, Any?>,
         setProperties: Map<String, Any?>,
     ): GraphEdge =
-        synchronized(graph) {
-            val properties = GraphMergeValidation.validateEdge(fromId, toId, label, matchProperties, setProperties)
-            val fromIdValue = fromId.value.toLongOrNull()
-                ?: throw GraphQueryException("Invalid fromId: ${fromId.value}")
-            val toIdValue = toId.value.toLongOrNull()
-                ?: throw GraphQueryException("Invalid toId: ${toId.value}")
+        withTransactionGate {
+            synchronized(graph) {
+                val properties = GraphMergeValidation.validateEdge(fromId, toId, label, matchProperties, setProperties)
+                val fromIdValue = fromId.value.toLongOrNull()
+                    ?: throw GraphQueryException("Invalid fromId: ${fromId.value}")
+                val toIdValue = toId.value.toLongOrNull()
+                    ?: throw GraphQueryException("Invalid toId: ${toId.value}")
 
-            val traversal = g.V(fromIdValue).outE(label)
-                .where(AnonymousTraversal.inV().hasId(toIdValue))
-            properties.matchProperties.forEach { (key, value) ->
-                traversal.has(key, value)
-            }
-
-            val optional = traversal.tryNext()
-            val edge: Edge = if (optional.isPresent) {
-                optional.get()
-            } else {
-                val create = g.V(fromIdValue).addE(label).to(AnonymousTraversal.V<Vertex>(toIdValue))
+                val traversal = g.V(fromIdValue).outE(label)
+                    .where(AnonymousTraversal.inV().hasId(toIdValue))
                 properties.matchProperties.forEach { (key, value) ->
-                    create.property(key, value)
+                    traversal.has(key, value)
                 }
-                create.next()
-            }
 
-            properties.setProperties.forEach { (key, value) ->
-                if (value != null) edge.property(key, value)
+                val optional = traversal.tryNext()
+                val edge: Edge = if (optional.isPresent) {
+                    optional.get()
+                } else {
+                    val create = g.V(fromIdValue).addE(label).to(AnonymousTraversal.V<Vertex>(toIdValue))
+                    properties.matchProperties.forEach { (key, value) ->
+                        create.property(key, value)
+                    }
+                    create.next()
+                }
+
+                properties.setProperties.forEach { (key, value) ->
+                    if (value != null) edge.property(key, value)
+                }
+                GremlinRecordMapper.edgeToGraphEdge(edge)
             }
-            GremlinRecordMapper.edgeToGraphEdge(edge)
         }
 
     // -- GraphTraversalRepository --

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperations.kt
@@ -29,9 +29,12 @@ import io.bluetape4k.graph.schema.asSuspendSchemaManager
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
 /**
@@ -43,7 +46,7 @@ import kotlinx.coroutines.withContext
  * ```kotlin
  * val ops = TinkerGraphSuspendOperations()
  *
- * runBlocking {
+ * suspend fun writeGraph() {
  *     val alice = ops.createVertex("Person", mapOf("name" to "Alice", "age" to 30L))
  *     val bob   = ops.createVertex("Person", mapOf("name" to "Bob",   "age" to 25L))
  *     ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2020L))
@@ -66,7 +69,9 @@ class TinkerGraphSuspendOperations(
    GraphSuspendSchemaManagementOperations,
    GraphSuspendMergeOperations {
 
-    companion object: KLoggingChannel()
+    companion object: KLoggingChannel() {
+        private const val TRANSACTION_GATE_RETRY_DELAY_MILLIS = 10L
+    }
 
     override fun close() {
         delegate.close()
@@ -75,13 +80,46 @@ class TinkerGraphSuspendOperations(
     override fun schemaManager(): GraphSuspendSchemaManager =
         delegate.schemaManager().asSuspendSchemaManager()
 
-    override suspend fun <T> suspendTransaction(block: suspend GraphSuspendTransactionScope.() -> T): T =
-        withContext(Dispatchers.IO) {
-            delegate.transaction {
-                val scope = asSuspendTransactionScope()
-                runBlocking { scope.block() }
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun <T> suspendTransaction(block: suspend GraphSuspendTransactionScope.() -> T): T {
+        acquireTransactionGate()
+        return try {
+            val snapshot = withContext(Dispatchers.IO) {
+                delegate.createTransactionSnapshot()
             }
+            try {
+                withContext(Dispatchers.IO) {
+                    val result = delegate.transactionScope().asSuspendTransactionScope().block()
+                    materializeTransactionResult(result)
+                }
+            } catch (e: Throwable) {
+                try {
+                    withContext(NonCancellable + Dispatchers.IO) {
+                        delegate.restoreTransactionSnapshot(snapshot)
+                    }
+                } catch (restoreFailure: Throwable) {
+                    e.addSuppressed(restoreFailure)
+                }
+                throw e
+            }
+        } finally {
+            delegate.releaseTransactionGate()
         }
+    }
+
+    private suspend fun acquireTransactionGate() {
+        while (!delegate.tryAcquireTransactionGate()) {
+            delay(TRANSACTION_GATE_RETRY_DELAY_MILLIS)
+        }
+    }
+
+    private suspend fun <T> materializeTransactionResult(result: T): T {
+        if (result !is Flow<*>) return result
+
+        val values = result.toList()
+        @Suppress("UNCHECKED_CAST")
+        return values.asFlow() as T
+    }
 
     override suspend fun mergeVertex(
         label: String,

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperationsTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperationsTest.kt
@@ -8,7 +8,15 @@ import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.repository.suspendTransaction
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
@@ -187,10 +195,81 @@ class TinkerGraphSuspendOperationsTest {
         ops.findEdgesByLabel("KNOWS").toList().shouldHaveSize(0)
     }
 
+    @Test
+    @Order(31)
+    fun `suspendTransaction은 취소 시 빠르게 반환하고 rollback한다`() = runSuspendIO {
+        val existing = ops.createVertex("Person", mapOf("name" to "Existing"))
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(500) {
+                ops.suspendTransaction {
+                    createVertex("Person", mapOf("name" to "Cancelled"))
+                    awaitCancellation()
+                }
+            }
+        }
+
+        ops.findVertexById("Person", existing.id)?.properties?.get("name") shouldBeEqualTo "Existing"
+        ops.countVertices("Person") shouldBeEqualTo 1L
+    }
+
+    @Test
+    @Order(32)
+    fun `suspendTransaction은 반환된 Flow를 commit 전에 materialize한다`() = runSuspendIO {
+        val people = ops.suspendTransaction {
+            createVertex("Person", mapOf("name" to "Alice"))
+            findVerticesByLabel("Person")
+        }
+
+        val names = people.toList().map { it.properties["name"] }
+        names shouldContain "Alice"
+    }
+
+    @Test
+    @Order(33)
+    fun `suspendTransaction은 동기 transaction과 rollback snapshot을 직렬화한다`() = runSuspendIO {
+        val delegate = TinkerGraphOperations()
+        val suspendOps = TinkerGraphSuspendOperations(delegate)
+        try {
+            coroutineScope {
+                val started = CompletableDeferred<Unit>()
+                val release = CompletableDeferred<Unit>()
+                val suspendTx = async(Dispatchers.IO) {
+                    assertFailsWith<IllegalStateException> {
+                        suspendOps.suspendTransaction {
+                            createVertex("Person", mapOf("name" to "Suspending"))
+                            started.complete(Unit)
+                            release.await()
+                            error("rollback")
+                        }
+                    }
+                }
+
+                started.await()
+                val syncTx = async(Dispatchers.IO) {
+                    delegate.transaction {
+                        createVertex("Person", mapOf("name" to "Sync"))
+                    }
+                }
+
+                delay(100)
+                release.complete(Unit)
+                suspendTx.await()
+                syncTx.await()
+            }
+
+            val names = delegate.findVerticesByLabel("Person").map { it.properties["name"] }
+            names shouldContain "Sync"
+            delegate.countVertices("Person") shouldBeEqualTo 1L
+        } finally {
+            suspendOps.close()
+        }
+    }
+
     // ----- 간선(Edge) CRUD -----
 
     @Test
-    @Order(30)
+    @Order(34)
     fun `두 정점 사이에 간선을 생성한다`() = runSuspendIO {
         val alice = ops.createVertex("Person", mapOf("name" to "Alice"))
         val bob = ops.createVertex("Person", mapOf("name" to "Bob"))
@@ -204,7 +283,7 @@ class TinkerGraphSuspendOperationsTest {
     }
 
     @Test
-    @Order(31)
+    @Order(35)
     fun `label로 간선 목록을 조회한다`() = runSuspendIO {
         val a = ops.createVertex("Person", mapOf("name" to "A"))
         val b = ops.createVertex("Person", mapOf("name" to "B"))
@@ -220,7 +299,7 @@ class TinkerGraphSuspendOperationsTest {
     }
 
     @Test
-    @Order(32)
+    @Order(36)
     fun `간선을 삭제한다`() = runSuspendIO {
         val a = ops.createVertex("Person", mapOf("name" to "A"))
         val b = ops.createVertex("Person", mapOf("name" to "B"))


### PR DESCRIPTION
## Summary

Fixes #160.

- Replaces AGE suspend transactions with Exposed `newSuspendedTransaction(Dispatchers.IO)` and a current-transaction suspend scope.
- Replaces Memgraph suspend transaction bridging with reactive Bolt transactions, commit/rollback cleanup, and returned `Flow` materialization before commit.
- Replaces TinkerGraph `runBlocking` bridging with a suspend-aware snapshot rollback path and a shared sync/suspend transaction gate.
- Adds cancellation rollback and returned transaction `Flow` materialization coverage for AGE, Memgraph, and TinkerGraph.
- Updates `CHANGELOG.md`, `WIP.md`, and the issue lesson.

## Validation

- `./gradlew :bluetape4k-graph-tinkerpop:compileKotlin :bluetape4k-graph-tinkerpop:compileTestKotlin :bluetape4k-graph-tinkerpop:test --tests "io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperationsTest" :bluetape4k-graph-tinkerpop:detekt --console=plain --no-daemon`
- `./gradlew :bluetape4k-graph-tinkerpop:test :bluetape4k-graph-age:test :bluetape4k-graph-memgraph:test --console=plain --no-daemon`
- `./gradlew :bluetape4k-graph-age:detekt :bluetape4k-graph-memgraph:detekt :bluetape4k-graph-tinkerpop:detekt --console=plain --no-daemon`
- `rg -n "runBlocking" graph/graph-age graph/graph-memgraph graph/graph-tinkerpop -g '*.kt'` returned no matches.
- `git diff --check`
- `codex review --uncommitted`: no actionable correctness issues after fixing the first-pass TinkerGraph gate acquisition finding.

## Review Notes

Claude CLI advisor was attempted twice but produced no output before timeout, so this PR records that as a review-tool availability gap. Codex review completed on the latest diff.

## Not Tested

- Full repository build.