### PR TITLE
fix: preserve FalkorDB graphExists cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FalkorDB suspend graph existence checks propagate coroutine cancellation**: `FalkorDBGraphSuspendOperations.graphExists()` now rethrows `CancellationException` instead of converting cancellation into `false`, while preserving the existing fallback for ordinary driver failures ([#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156)).
 - **Neo4j suspend transactions no longer bridge through `runBlocking`**: `Neo4jGraphSuspendOperations.suspendTransaction()` now uses Neo4j reactive transactions, preserves rollback/cleanup semantics, and materializes returned transaction `Flow` values before commit ([#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158)).
 - **AGE, Memgraph, and TinkerGraph suspend transactions no longer bridge through `runBlocking`**: AGE now uses Exposed suspended transactions with a native suspend transaction scope, Memgraph uses reactive Bolt transactions, and TinkerGraph uses a suspend-aware rollback snapshot path. Cancellation rollback and returned transaction `Flow` materialization are covered by targeted tests ([#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160)).
 

--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-18 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 15 issues; 14 remain after #126 closes through this work.
+Open count: 12 issues; 11 remain after #156 closes through this work.
 
 ## Refresh Notes
 
@@ -23,13 +23,15 @@ Verified with `gh` on 2026-05-18 KST.
   rollback/cleanup semantics, and materializing returned transaction `Flow` values before commit.
 - Issue #160 is handled by removing the remaining AGE, Memgraph, and TinkerGraph `runBlocking`
   transaction bridges and adding cancellation rollback plus returned `Flow` materialization tests.
+- Issue #156 is handled by rethrowing `CancellationException` from FalkorDB suspend `graphExists()`
+  while preserving the ordinary driver-failure fallback.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Fix cancellation and `runCatching{}` issues in FalkorDB/Memgraph (#156/#157).
+1. Fix the remaining broad `runCatching{}` issue in FalkorDB/Memgraph schema managers (#157).
 2. Continue cancellation correctness work now that suspend transaction `runBlocking` bridges are removed by #158 and #160.
 3. Complete Neptune testability research (#113) before starting the backend epic (#30).
 4. Resume examples, CI automation, and benchmarks only after correctness baselines are stable.
@@ -38,10 +40,10 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156) FalkorDBGraphSuspendOperations.graphExists() swallows CancellationException | S | Replace `runCatching{}` so suspend function propagates cancellation correctly. |
+| P1 | [#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156) FalkorDBGraphSuspendOperations.graphExists() swallows CancellationException | S | Handled by this work; remove from active queue after merge. |
 | P1 | [#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157) FalkorDB/MemgraphGraphSchemaManager overly broad runCatching{} | S | Narrow to expected exceptions; fix correctness baseline for graph-falkordb and graph-memgraph. |
 | P1 | [#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158) Neo4jGraphSuspendOperations.suspendTransaction() runBlocking inside withContext(IO) | M | Remove `runBlocking`; use async Neo4j driver or coroutine-safe bridge to prevent IO thread starvation. |
-| P1 | [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) AGE/Memgraph/TinkerGraph suspendTransaction runBlocking bridge | M | Handled by this work; remove from active queue after merge. |
+| P1 | [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) AGE/Memgraph/TinkerGraph suspendTransaction runBlocking bridge | M | Merged; remove from active queue on next WIP refresh. |
 | P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30. |
 | P2 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P2 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Useful after backend readiness is clear. |
@@ -57,6 +59,7 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 ```text
 #156 FalkorDBGraphSuspendOperations.graphExists() CancellationException fix
+  -> suspend graphExists now rethrows coroutine cancellation
 #157 FalkorDB/MemgraphGraphSchemaManager broad runCatching fix
   -> correctness baseline for graph-falkordb and graph-memgraph
 
@@ -79,8 +82,8 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Cancellation correctness | 1 | Start with `#156`, then `#157`. |
-| Suspend transaction safety | 1 | #160 in PR; remove this lane after merge unless a new transaction-safety issue appears. |
+| Cancellation correctness | 1 | #156 in PR; continue with `#157` after merge. |
+| Suspend transaction safety | 1 | #160 merged; keep this lane idle unless a new transaction-safety issue appears. |
 | Research / backend readiness | 1 | `#113` before `#30`. |
 | CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
 | Examples / benchmarks | 1 | `#111` before benchmarks; keep benchmark work after CI is stable. |

--- a/docs/lessons/2026-05-19-issue-156-falkordb-cancellation.md
+++ b/docs/lessons/2026-05-19-issue-156-falkordb-cancellation.md
@@ -1,0 +1,26 @@
+# Issue 156 FalkorDB Cancellation Propagation
+
+## Context
+
+`FalkorDBGraphSuspendOperations.graphExists()` used `runCatching {}` inside a suspend function and converted every failure into `false`.
+
+## Decision
+
+- Rethrow `CancellationException` before ordinary exception fallback.
+- Preserve the existing warn-and-return-false behavior for non-cancellation driver failures.
+- Keep MockK collaborators as class-level fields and reset them in `@BeforeEach` with `clearMocks(...)`.
+
+## Outcome
+
+`graphExists()` now preserves structured concurrency cancellation semantics, and the regression test fixes the behavior with a mocked driver that throws `CancellationException`.
+
+## Verification
+
+- `./gradlew :bluetape4k-graph-falkordb:compileKotlin :bluetape4k-graph-falkordb:compileTestKotlin :bluetape4k-graph-falkordb:test --tests "io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperationsTest" :bluetape4k-graph-falkordb:detekt --console=plain --no-daemon`
+- `./gradlew :bluetape4k-graph-falkordb:test :bluetape4k-graph-falkordb:detekt --console=plain --no-daemon`
+- `codex review --uncommitted` reported no correctness issues.
+- Claude CLI advisor review reported `NO P0/P1 FINDINGS`.
+
+## Future Guidance
+
+Do not use `runCatching {}` around suspend-facing code unless cancellation is rethrown before fallback handling.

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperations.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperations.kt
@@ -39,6 +39,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -189,11 +190,14 @@ class FalkorDBGraphSuspendOperations(
     override suspend fun graphExists(name: String): Boolean {
         name.requireNotBlank("name")
         return withContext(Dispatchers.IO) {
-            runCatching { driver.listGraphs().contains(name) }
-                .getOrElse {
-                    log.warn(it) { "graphExists($name) failed; treating as false" }
-                    false
-                }
+            try {
+                driver.listGraphs().contains(name)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "graphExists($name) failed; treating as false" }
+                false
+            }
         }
     }
 

--- a/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperationsTest.kt
+++ b/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperationsTest.kt
@@ -9,6 +9,10 @@ import io.bluetape4k.graph.repository.suspendTransaction
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.toList
@@ -33,6 +37,7 @@ class FalkorDBGraphSuspendOperationsTest : AbstractFalkorDBTest() {
     companion object : KLoggingChannel()
 
     private lateinit var ops: FalkorDBGraphSuspendOperations
+    private val cancelledDriver = mockk<com.falkordb.Driver>()
 
     @BeforeAll
     override fun setupAll() {
@@ -42,6 +47,7 @@ class FalkorDBGraphSuspendOperationsTest : AbstractFalkorDBTest() {
 
     @BeforeEach
     fun cleanup() = runSuspendIO {
+        clearMocks(cancelledDriver)
         ops.dropGraph(graphName)
     }
 
@@ -68,6 +74,18 @@ class FalkorDBGraphSuspendOperationsTest : AbstractFalkorDBTest() {
     fun `graphExists returns false for non-existent graph`() = runSuspendIO {
         val result = ops.graphExists("non_existent_graph_xyz_12345")
         result shouldBeEqualTo false
+    }
+
+    @Test
+    @Order(13)
+    fun `graphExists propagates coroutine cancellation`() = runSuspendIO {
+        every { cancelledDriver.listGraphs() } throws CancellationException("cancelled")
+
+        val cancelledOps = FalkorDBGraphSuspendOperations(cancelledDriver, graphName)
+
+        assertFailsWith<CancellationException> {
+            cancelledOps.graphExists(graphName)
+        }
     }
 
     // ----- 정점(Vertex) CRUD -----


### PR DESCRIPTION
## Summary

Fixes #156.

- Rethrows `CancellationException` from `FalkorDBGraphSuspendOperations.graphExists()` before ordinary driver-failure fallback handling.
- Preserves the existing warn-and-return-false behavior for non-cancellation exceptions.
- Adds a MockK regression test with the mock stored as a class field and reset in `@BeforeEach` with `clearMocks(...)`.
- Updates `CHANGELOG.md`, `WIP.md`, and the issue lesson.

## Validation

- `./gradlew :bluetape4k-graph-falkordb:compileKotlin :bluetape4k-graph-falkordb:compileTestKotlin :bluetape4k-graph-falkordb:test --tests "io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperationsTest" :bluetape4k-graph-falkordb:detekt --console=plain --no-daemon`
- `./gradlew :bluetape4k-graph-falkordb:test :bluetape4k-graph-falkordb:detekt --console=plain --no-daemon`
- `git diff --check`
- `codex review --uncommitted`: no correctness issues.
- Claude CLI advisor review: `NO P0/P1 FINDINGS`.

## Notes

The remaining `runCatching { driver.listGraphs().contains(name) }` match is in synchronous `FalkorDBGraphOperations.graphExists()`, not the suspend path covered by #156.

## Not Tested

- Full repository build.