### PR TITLE
fix: preserve schema manager cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FalkorDB and Memgraph schema manager DDL fallbacks preserve cancellation**: schema manager create/drop index helper paths now rethrow `CancellationException` before applying already-exists or missing-resource message fallbacks ([#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157)).
 - **FalkorDB suspend graph existence checks propagate coroutine cancellation**: `FalkorDBGraphSuspendOperations.graphExists()` now rethrows `CancellationException` instead of converting cancellation into `false`, while preserving the existing fallback for ordinary driver failures ([#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156)).
 - **Neo4j suspend transactions no longer bridge through `runBlocking`**: `Neo4jGraphSuspendOperations.suspendTransaction()` now uses Neo4j reactive transactions, preserves rollback/cleanup semantics, and materializes returned transaction `Flow` values before commit ([#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158)).
 - **AGE, Memgraph, and TinkerGraph suspend transactions no longer bridge through `runBlocking`**: AGE now uses Exposed suspended transactions with a native suspend transaction scope, Memgraph uses reactive Bolt transactions, and TinkerGraph uses a suspend-aware rollback snapshot path. Cancellation rollback and returned transaction `Flow` materialization are covered by targeted tests ([#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160)).

--- a/WIP.md
+++ b/WIP.md
@@ -1,12 +1,12 @@
 # WIP - bluetape4k-graph
 
-Snapshot: 2026-05-18 KST
+Snapshot: 2026-05-19 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 12 issues; 11 remain after #156 closes through this work.
+Open count: 11 issues; 10 remain after #157 closes through this work.
 
 ## Refresh Notes
 
-Verified with `gh` on 2026-05-18 KST.
+Verified with `gh` on 2026-05-19 KST.
 
 - qmd was queried first for prior graph lessons, specs, plans, and follow-ups.
 - Existing issues #156, #157, and #158 were unassigned; they are now assigned to `debop`.
@@ -25,32 +25,32 @@ Verified with `gh` on 2026-05-18 KST.
   transaction bridges and adding cancellation rollback plus returned `Flow` materialization tests.
 - Issue #156 is handled by rethrowing `CancellationException` from FalkorDB suspend `graphExists()`
   while preserving the ordinary driver-failure fallback.
+- Issue #157 is handled by replacing FalkorDB/Memgraph schema manager `runCatching {}` ignore
+  helpers with explicit `try/catch` branches that rethrow `CancellationException` before expected
+  already-exists or missing-resource fallbacks.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Fix the remaining broad `runCatching{}` issue in FalkorDB/Memgraph schema managers (#157).
-2. Continue cancellation correctness work now that suspend transaction `runBlocking` bridges are removed by #158 and #160.
-3. Complete Neptune testability research (#113) before starting the backend epic (#30).
-4. Resume examples, CI automation, and benchmarks only after correctness baselines are stable.
+1. Finish and merge the FalkorDB/Memgraph schema manager cancellation fix (#157).
+2. Resume milestone 0.3.1 feature/adoption work with graph-io backed sample dataset loaders (#111).
+3. Handle Ktor/FalkorDB hygiene items after feature work: #127, #135, #133, and #134.
+4. Keep Neptune testability research (#113) as the predecessor for the backlog backend epic (#30).
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156) FalkorDBGraphSuspendOperations.graphExists() swallows CancellationException | S | Handled by this work; remove from active queue after merge. |
-| P1 | [#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157) FalkorDB/MemgraphGraphSchemaManager overly broad runCatching{} | S | Narrow to expected exceptions; fix correctness baseline for graph-falkordb and graph-memgraph. |
-| P1 | [#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158) Neo4jGraphSuspendOperations.suspendTransaction() runBlocking inside withContext(IO) | M | Remove `runBlocking`; use async Neo4j driver or coroutine-safe bridge to prevent IO thread starvation. |
-| P1 | [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) AGE/Memgraph/TinkerGraph suspendTransaction runBlocking bridge | M | Merged; remove from active queue on next WIP refresh. |
-| P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30. |
-| P2 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
-| P2 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Useful after backend readiness is clear. |
-| P3 | [#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127) replace deprecated/internal Ktor APIs in graph-ktor | S | Build maintenance when Ktor flags concrete drift. |
-| P3 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation lane. |
+| P1 | [#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157) FalkorDB/MemgraphGraphSchemaManager overly broad runCatching{} | S | Handled by this work; remove from active queue after merge. |
+| P1 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Highest remaining 0.3.1 feature/adoption value after cancellation correctness. |
+| P2 | [#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127) replace deprecated/internal Ktor APIs in graph-ktor | S | Build maintenance when Ktor flags concrete drift. |
+| P2 | [#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135) close FalkorDB driver in Ktor test teardown | S | Test hygiene after feature work. |
+| P3 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation/adoption lane. |
 | P3 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
-| P3 | [#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135) close FalkorDB driver in Ktor test teardown | S | Test hygiene. |
+| P3 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
+| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P4 | [#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14) backend JMH benchmark | M | After CI gates settle. |
 | P4 | [#15](https://github.com/bluetape4k/bluetape4k-graph/issues/15) runtime comparison benchmark | M | After stable baselines. |
 | P4 | [#41](https://github.com/bluetape4k/bluetape4k-graph/issues/41) weighted path benchmark | S | After merged #40 baseline. |
@@ -82,8 +82,8 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Cancellation correctness | 1 | #156 in PR; continue with `#157` after merge. |
+| Cancellation correctness | 1 | #157 in PR; idle after merge unless a new cancellation bug appears. |
 | Suspend transaction safety | 1 | #160 merged; keep this lane idle unless a new transaction-safety issue appears. |
 | Research / backend readiness | 1 | `#113` before `#30`. |
 | CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
-| Examples / benchmarks | 1 | `#111` before benchmarks; keep benchmark work after CI is stable. |
+| Examples / benchmarks | 1 | `#111` is next milestone 0.3.1 work after #157 merges. |

--- a/docs/lessons/2026-05-19-issue-157-schema-manager-errors.md
+++ b/docs/lessons/2026-05-19-issue-157-schema-manager-errors.md
@@ -1,0 +1,28 @@
+# Issue 157 Schema Manager Error Handling
+
+## Context
+
+FalkorDB and Memgraph schema managers used `runCatching {}` in private DDL ignore helpers. That made cancellation and ordinary database errors flow through the same broad fallback path.
+
+## Decision
+
+- Replace the helper-level `runCatching {}` calls with explicit `try/catch`.
+- Rethrow `CancellationException` before already-exists or missing-resource message fallbacks.
+- Keep MockK driver collaborators as class-level fields and reset them in `@BeforeEach` with `clearMocks(...)`.
+- Suppress detekt `TooGenericExceptionCaught` only on the two helper functions per backend because the helpers intentionally inspect expected driver exception messages.
+
+## Outcome
+
+`createIndex()` and `dropIndex()` in both schema managers now preserve coroutine cancellation while keeping idempotent DDL behavior for expected already-exists and missing-resource responses.
+
+## Verification
+
+- `./gradlew :bluetape4k-graph-falkordb:compileKotlin :bluetape4k-graph-falkordb:compileTestKotlin :bluetape4k-graph-falkordb:test --tests "io.bluetape4k.graph.falkordb.FalkorDBGraphSchemaManagerTest" :bluetape4k-graph-falkordb:detekt :bluetape4k-graph-memgraph:compileKotlin :bluetape4k-graph-memgraph:compileTestKotlin :bluetape4k-graph-memgraph:test --tests "io.bluetape4k.graph.memgraph.MemgraphGraphSchemaManagerTest" :bluetape4k-graph-memgraph:detekt --console=plain --no-daemon`
+- `./gradlew :bluetape4k-graph-falkordb:test :bluetape4k-graph-memgraph:test :bluetape4k-graph-falkordb:detekt :bluetape4k-graph-memgraph:detekt --console=plain --no-daemon`
+- IntelliJ diagnostics could not run because the worktree was not an open IntelliJ project; Gradle compile/test/detekt was used as fallback evidence.
+- Codex review found the first regression messages too weak; tests were updated to use fallback-matching cancellation messages and the follow-up review reported no blocking correctness bugs.
+- Claude CLI review reported `NO P0/P1 FINDINGS`.
+
+## Future Guidance
+
+Do not use `runCatching {}` for cancellation-sensitive fallback helpers. Make cancellation a first branch, then handle expected driver failures explicitly.

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSchemaManager.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSchemaManager.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.graph.model.GraphIndex
 import io.bluetape4k.graph.model.GraphSchemaEntityType
 import io.bluetape4k.graph.schema.GraphSchemaManager
 import io.bluetape4k.graph.schema.GraphSchemaNames
+import kotlinx.coroutines.CancellationException
 
 /**
  * FalkorDB Cypher DDL 기반 스키마 관리자.
@@ -75,8 +76,13 @@ class FalkorDBGraphSchemaManager(
         )
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun ignoreAlreadyExists(block: () -> Unit) {
-        runCatching(block).getOrElse { e ->
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             val message = e.message.orEmpty()
             if (!message.contains("already", ignoreCase = true) && !message.contains("exists", ignoreCase = true)) {
                 throw e
@@ -84,8 +90,13 @@ class FalkorDBGraphSchemaManager(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun ignoreMissing(block: () -> Unit) {
-        runCatching(block).getOrElse { e ->
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             val message = e.message.orEmpty()
             if (!message.contains("not found", ignoreCase = true) && !message.contains("does not exist", ignoreCase = true)) {
                 throw e

--- a/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSchemaManagerTest.kt
+++ b/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSchemaManagerTest.kt
@@ -4,6 +4,10 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.graph.schema.schemaManager
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -12,9 +16,11 @@ import java.util.UUID
 class FalkorDBGraphSchemaManagerTest: AbstractFalkorDBTest() {
 
     private lateinit var ops: FalkorDBGraphOperations
+    private val cancellationDriver = mockk<com.falkordb.Driver>()
 
     @BeforeEach
     fun setUp() {
+        clearMocks(cancellationDriver)
         ops = FalkorDBGraphOperations(driver, graphName)
     }
 
@@ -43,6 +49,28 @@ class FalkorDBGraphSchemaManagerTest: AbstractFalkorDBTest() {
         }
 
         ex.message shouldContain "GRAPH.CONSTRAINT CREATE"
+    }
+
+    @Test
+    fun `createIndex propagates cancellation before already exists fallback`() {
+        every { cancellationDriver.graph(graphName) } throws CancellationException("already exists")
+
+        val manager = FalkorDBGraphSchemaManager(cancellationDriver, graphName)
+
+        assertFailsWith<CancellationException> {
+            manager.createIndex("Person", "email")
+        }
+    }
+
+    @Test
+    fun `dropIndex propagates cancellation before missing fallback`() {
+        every { cancellationDriver.graph(graphName) } throws CancellationException("does not exist")
+
+        val manager = FalkorDBGraphSchemaManager(cancellationDriver, graphName)
+
+        assertFailsWith<CancellationException> {
+            manager.dropIndex("Person", "email")
+        }
     }
 
     private fun uniqueLabel(): String =

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSchemaManager.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSchemaManager.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.graph.model.GraphIndex
 import io.bluetape4k.graph.model.GraphSchemaEntityType
 import io.bluetape4k.graph.schema.GraphSchemaManager
 import io.bluetape4k.graph.schema.GraphSchemaNames
+import kotlinx.coroutines.CancellationException
 import org.neo4j.driver.Driver
 import org.neo4j.driver.Record
 import org.neo4j.driver.Session
@@ -92,8 +93,13 @@ class MemgraphGraphSchemaManager(
         )
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun ignoreAlreadyExists(block: () -> Unit) {
-        runCatching(block).getOrElse { e ->
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             val message = e.message.orEmpty()
             if (!message.contains("already", ignoreCase = true) && !message.contains("exists", ignoreCase = true)) {
                 throw e
@@ -101,8 +107,13 @@ class MemgraphGraphSchemaManager(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun ignoreMissing(block: () -> Unit) {
-        runCatching(block).getOrElse { e ->
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             val message = e.message.orEmpty()
             if (!message.contains("not found", ignoreCase = true) && !message.contains("does not exist", ignoreCase = true)) {
                 throw e

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSchemaManagerTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSchemaManagerTest.kt
@@ -5,18 +5,25 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.graph.model.GraphConstraintType
 import io.bluetape4k.graph.schema.schemaManager
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
+import org.neo4j.driver.SessionConfig
 import java.util.UUID
 
 class MemgraphGraphSchemaManagerTest {
 
     private lateinit var driver: Driver
     private lateinit var ops: MemgraphGraphOperations
+    private val cancellationDriver = mockk<Driver>()
 
     @BeforeAll
     fun setup() {
@@ -27,6 +34,11 @@ class MemgraphGraphSchemaManagerTest {
     @AfterAll
     fun teardown() {
         driver.close()
+    }
+
+    @BeforeEach
+    fun clearMockDriver() {
+        clearMocks(cancellationDriver)
     }
 
     @Test
@@ -58,6 +70,28 @@ class MemgraphGraphSchemaManagerTest {
     fun `rejects unsafe identifiers before building DDL`() {
         assertFailsWith<IllegalArgumentException> {
             ops.schemaManager().createIndex("Person) MATCH (n", "email")
+        }
+    }
+
+    @Test
+    fun `createIndex propagates cancellation before already exists fallback`() {
+        every { cancellationDriver.session(any<SessionConfig>()) } throws CancellationException("already exists")
+
+        val manager = MemgraphGraphSchemaManager(cancellationDriver)
+
+        assertFailsWith<CancellationException> {
+            manager.createIndex("Person", "email")
+        }
+    }
+
+    @Test
+    fun `dropIndex propagates cancellation before missing fallback`() {
+        every { cancellationDriver.session(any<SessionConfig>()) } throws CancellationException("does not exist")
+
+        val manager = MemgraphGraphSchemaManager(cancellationDriver)
+
+        assertFailsWith<CancellationException> {
+            manager.dropIndex("Person", "email")
         }
     }
 


### PR DESCRIPTION
Fixes #157.

## Changes
- Replaced FalkorDB and Memgraph schema manager `runCatching {}` DDL ignore helpers with explicit `try/catch`.
- Rethrow `CancellationException` before already-exists and missing-resource fallback matching.
- Added fallback-matching cancellation regression tests for create/drop index paths in both backends.
- Updated `CHANGELOG.md`, `WIP.md`, and the issue lesson.

## Validation
- `./gradlew :bluetape4k-graph-falkordb:compileKotlin :bluetape4k-graph-falkordb:compileTestKotlin :bluetape4k-graph-falkordb:test --tests "io.bluetape4k.graph.falkordb.FalkorDBGraphSchemaManagerTest" :bluetape4k-graph-falkordb:detekt :bluetape4k-graph-memgraph:compileKotlin :bluetape4k-graph-memgraph:compileTestKotlin :bluetape4k-graph-memgraph:test --tests "io.bluetape4k.graph.memgraph.MemgraphGraphSchemaManagerTest" :bluetape4k-graph-memgraph:detekt --console=plain --no-daemon`
- `./gradlew :bluetape4k-graph-falkordb:test :bluetape4k-graph-memgraph:test :bluetape4k-graph-falkordb:detekt :bluetape4k-graph-memgraph:detekt --console=plain --no-daemon`
- `git diff --check`
- `codex review --uncommitted`: no blocking correctness bugs after regression-test strengthening
- Claude CLI review: `NO P0/P1 FINDINGS`

## Notes
- IntelliJ diagnostics were unavailable for this worktree (`project_not_found`), so Gradle compile/test/detekt was used as fallback evidence.
- Full repository build was not run.