### PR TITLE
Add graph-io sample loaders for domain examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **graph-io backed domain example sample loaders**: fraud detection, recommendation, and knowledge graph examples now include bundled CSV fixtures plus sync/suspend sample dataset loaders, with TinkerGraph smoke coverage and English/Korean README import flows ([#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111)).
+
 ### Fixed
 
 - **FalkorDB and Memgraph schema manager DDL fallbacks preserve cancellation**: schema manager create/drop index helper paths now rethrow `CancellationException` before applying already-exists or missing-resource message fallbacks ([#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157)).

--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-19 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 11 issues; 10 remain after #157 closes through this work.
+Open count: 10 issues; 9 remain after #111 closes through this work.
 
 ## Refresh Notes
 
@@ -28,24 +28,24 @@ Verified with `gh` on 2026-05-19 KST.
 - Issue #157 is handled by replacing FalkorDB/Memgraph schema manager `runCatching {}` ignore
   helpers with explicit `try/catch` branches that rethrow `CancellationException` before expected
   already-exists or missing-resource fallbacks.
+- Issue #111 is handled by adding graph-io CSV sample dataset loaders, bundled fixtures, sync/suspend
+  TinkerGraph smoke coverage, English/Korean README import flows, and release notes.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Finish and merge the FalkorDB/Memgraph schema manager cancellation fix (#157).
-2. Resume milestone 0.3.1 feature/adoption work with graph-io backed sample dataset loaders (#111).
-3. Handle Ktor/FalkorDB hygiene items after feature work: #127, #135, #133, and #134.
-4. Keep Neptune testability research (#113) as the predecessor for the backlog backend epic (#30).
+1. Finish and merge graph-io backed sample dataset loaders (#111).
+2. Handle Ktor/FalkorDB hygiene items after feature work: #127, #135, #133, and #134.
+3. Keep Neptune testability research (#113) as the predecessor for the backlog backend epic (#30).
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#157](https://github.com/bluetape4k/bluetape4k-graph/issues/157) FalkorDB/MemgraphGraphSchemaManager overly broad runCatching{} | S | Handled by this work; remove from active queue after merge. |
-| P1 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Highest remaining 0.3.1 feature/adoption value after cancellation correctness. |
-| P2 | [#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127) replace deprecated/internal Ktor APIs in graph-ktor | S | Build maintenance when Ktor flags concrete drift. |
+| P1 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Handled by this work; remove from active queue after merge. |
+| P2 | [#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127) replace deprecated/internal Ktor APIs in graph-ktor | S | Next 0.3.1 maintenance work after #111 merges. |
 | P2 | [#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135) close FalkorDB driver in Ktor test teardown | S | Test hygiene after feature work. |
 | P3 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation/adoption lane. |
 | P3 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
@@ -82,8 +82,8 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Cancellation correctness | 1 | #157 in PR; idle after merge unless a new cancellation bug appears. |
+| Cancellation correctness | 1 | #157 merged; idle unless a new cancellation bug appears. |
 | Suspend transaction safety | 1 | #160 merged; keep this lane idle unless a new transaction-safety issue appears. |
 | Research / backend readiness | 1 | `#113` before `#30`. |
 | CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
-| Examples / benchmarks | 1 | `#111` is next milestone 0.3.1 work after #157 merges. |
+| Examples / benchmarks | 1 | `#111` in PR; idle after merge unless another adoption issue is selected. |

--- a/docs/lessons/2026-05-19-issue-111-sample-dataset-loaders.md
+++ b/docs/lessons/2026-05-19-issue-111-sample-dataset-loaders.md
@@ -1,0 +1,30 @@
+# Issue #111 Sample Dataset Loaders
+
+## Context
+
+Issue #111 adds graph-io backed sample data loaders for the fraud detection, recommendation, and knowledge graph
+example modules.
+
+## Decision
+
+Keep the loaders module-local and resource-backed. TinkerGraph smoke tests are sufficient for the import path because
+the loaders call graph-io through the common `GraphOperations` contract, while existing backend matrix tests continue to
+cover traversal behavior.
+
+## Outcome
+
+Added sync and suspend CSV loader entry points, bundled domain fixtures, README import examples, and TinkerGraph smoke
+tests for each module.
+
+## Verification
+
+- `./gradlew :fraud-detection-examples:compileKotlin :fraud-detection-examples:compileTestKotlin :fraud-detection-examples:test --tests "io.bluetape4k.graph.examples.fraud.FraudDetectionSampleDatasetLoaderTest" :recommendation-examples:compileKotlin :recommendation-examples:compileTestKotlin :recommendation-examples:test --tests "io.bluetape4k.graph.examples.recommendation.RecommendationSampleDatasetLoaderTest" :knowledge-graph-examples:compileKotlin :knowledge-graph-examples:compileTestKotlin :knowledge-graph-examples:test --tests "io.bluetape4k.graph.examples.knowledge.KnowledgeGraphSampleDatasetLoaderTest" --console=plain --no-daemon` passed with 12 sample loader tests.
+- `./gradlew :fraud-detection-examples:test :knowledge-graph-examples:test :recommendation-examples:test --tests '*SampleDatasetLoaderTest'` passed during Codex review, including the existing fraud and knowledge backend matrices plus the new loader tests.
+- Example modules do not expose Detekt tasks; repository-wide `detektMain detektTest` still fails on pre-existing non-example issues.
+- Codex review found no actionable bugs after the class loader fallback fix.
+- Claude review was run and the P1 findings were fixed: KDoc contract sections, verification evidence, and stream cleanup on failure paths.
+
+## Future Guard
+
+When example modules add sample data, keep fixtures small, cover the graph-io import report counts, and assert at least
+one domain service query against the imported graph.

--- a/docs/superpowers/plans/2026-05-19-issue-111-sample-dataset-loaders-plan.md
+++ b/docs/superpowers/plans/2026-05-19-issue-111-sample-dataset-loaders-plan.md
@@ -1,0 +1,17 @@
+# Issue #111 Sample Dataset Loaders Plan
+
+## Steps
+
+1. Add graph-io CSV dependencies to the three domain example modules.
+2. Add one public sample dataset loader per module with sync and suspend import entry points.
+3. Add bundled CSV fixtures for fraud, recommendation, and knowledge graph datasets.
+4. Add TinkerGraph smoke tests that verify import reports and domain service queries.
+5. Update English and Korean READMEs with import flow and verification scope.
+6. Run targeted compile, tests, Detekt, Codex review, and Claude review before PR.
+
+## Done When
+
+- The three sample loaders import their default CSV fixtures successfully.
+- Tests prove the imported graphs work with each domain service.
+- Public docs and KDoc use current API names.
+- PR review artifacts include both Codex and Claude verdicts.

--- a/docs/superpowers/specs/2026-05-19-issue-111-sample-dataset-loaders-design.md
+++ b/docs/superpowers/specs/2026-05-19-issue-111-sample-dataset-loaders-design.md
@@ -1,0 +1,33 @@
+# Issue #111 Sample Dataset Loaders Design
+
+## Context
+
+The fraud detection, recommendation, and knowledge graph examples already demonstrate backend-independent domain
+services. Issue #111 adds graph-io backed sample import paths so learners can load realistic fixtures instead of
+building every graph imperatively in code.
+
+## Decision
+
+Add one small loader object per domain example module:
+
+- `FraudDetectionSampleDatasetLoader`
+- `RecommendationSampleDatasetLoader`
+- `KnowledgeGraphSampleDatasetLoader`
+
+Each loader imports bundled CSV resources through `CsvGraphBulkImporter` and `SuspendCsvGraphBulkImporter`, preserving
+the existing `GraphOperations` / `GraphSuspendOperations` split. The loaders stay in the example modules rather than a
+shared module because the resource paths and domain fixture semantics are module-specific.
+
+## Contract
+
+- Default resources live under `sample-data/{domain}/vertices.csv` and `sample-data/{domain}/edges.csv`.
+- CSV files use graph-io prefixed property columns such as `prop.accountId`.
+- Import reports must complete with the expected vertex and edge counts on TinkerGraph.
+- Domain services must be able to query the imported graph immediately after import.
+- README.md and README.ko.md must describe the import flow.
+
+## Verification Strategy
+
+Use TinkerGraph smoke tests for the loader path because the loaders exercise graph-io through the backend-independent
+`GraphOperations` contract. Container-backed backend traversal behavior remains covered by the existing domain test
+matrix, and issue #111 does not change backend-specific import behavior.

--- a/examples/fraud-detection-examples/README.ko.md
+++ b/examples/fraud-detection-examples/README.ko.md
@@ -117,6 +117,24 @@ val clusters = service.detectSuspiciousClusters(minSize = 3)
 val ranked = service.rankHighRiskAccounts(limit = 10)
 ```
 
+## 샘플 데이터셋 Import
+
+`FraudDetectionSampleDatasetLoader`는 번들된 graph-io CSV fixture를 임의의 `GraphOperations` 구현체로 import합니다.
+fixture에는 세 계좌와 순환 이체 체인이 포함되어 있어 위 분석 메서드를 바로 실행할 수 있습니다.
+
+```kotlin
+val service = FraudDetectionService(ops)
+service.initialize()
+
+val report = FraudDetectionSampleDatasetLoader.importCsv(ops)
+
+check(report.status == GraphIoStatus.COMPLETED)
+val cycles = service.detectCircularTransfers(maxDepth = 5)
+```
+
+이 import flow는 TinkerGraph smoke test로 검증합니다. loader가 backend 독립 `GraphOperations` 계약을 통해 graph-io를
+사용하기 때문입니다. 컨테이너 기반 backend 동작은 기존 도메인 test matrix가 계속 담당합니다.
+
 ## 테스트 읽는 법
 
 `AbstractFraudDetectionTest`와 `AbstractFraudDetectionSuspendTest`가 학습 시나리오입니다. 구체 backend test class는
@@ -140,10 +158,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":graph-core"))
-implementation(project(":graph-neo4j"))
-implementation(project(":graph-memgraph"))
-implementation(project(":graph-age"))
-implementation(project(":graph-falkordb"))
-implementation(project(":graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-core"))
+implementation(project(":bluetape4k-graph-neo4j"))
+implementation(project(":bluetape4k-graph-memgraph"))
+implementation(project(":bluetape4k-graph-age"))
+implementation(project(":bluetape4k-graph-falkordb"))
+implementation(project(":bluetape4k-graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-io-csv"))
 ```

--- a/examples/fraud-detection-examples/README.md
+++ b/examples/fraud-detection-examples/README.md
@@ -119,6 +119,25 @@ val clusters = service.detectSuspiciousClusters(minSize = 3)
 val ranked = service.rankHighRiskAccounts(limit = 10)
 ```
 
+## Sample Dataset Import
+
+`FraudDetectionSampleDatasetLoader` imports the bundled graph-io CSV fixture into any `GraphOperations`
+implementation. The fixture contains three accounts and a circular transfer chain, so it is immediately usable with the
+analysis methods above.
+
+```kotlin
+val service = FraudDetectionService(ops)
+service.initialize()
+
+val report = FraudDetectionSampleDatasetLoader.importCsv(ops)
+
+check(report.status == GraphIoStatus.COMPLETED)
+val cycles = service.detectCircularTransfers(maxDepth = 5)
+```
+
+The TinkerGraph smoke test covers this import flow because the loader exercises graph-io through the backend-independent
+`GraphOperations` contract. Container-backed backend behavior remains covered by the existing domain test matrix.
+
 ## How to Read the Tests
 
 Start with `AbstractFraudDetectionTest` and `AbstractFraudDetectionSuspendTest`. They contain the learning scenarios.
@@ -142,10 +161,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":graph-core"))
-implementation(project(":graph-neo4j"))
-implementation(project(":graph-memgraph"))
-implementation(project(":graph-age"))
-implementation(project(":graph-falkordb"))
-implementation(project(":graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-core"))
+implementation(project(":bluetape4k-graph-neo4j"))
+implementation(project(":bluetape4k-graph-memgraph"))
+implementation(project(":bluetape4k-graph-age"))
+implementation(project(":bluetape4k-graph-falkordb"))
+implementation(project(":bluetape4k-graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-io-csv"))
 ```

--- a/examples/fraud-detection-examples/build.gradle.kts
+++ b/examples/fraud-detection-examples/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation(project(":bluetape4k-graph-memgraph"))
     implementation(project(":bluetape4k-graph-tinkerpop"))
     implementation(project(":bluetape4k-graph-falkordb"))
+    implementation(project(":bluetape4k-graph-io-csv"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)

--- a/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/io/FraudDetectionSampleDatasetLoader.kt
+++ b/examples/fraud-detection-examples/src/main/kotlin/io/bluetape4k/graph/examples/fraud/io/FraudDetectionSampleDatasetLoader.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.graph.examples.fraud.io
+
+import io.bluetape4k.graph.io.csv.CsvGraphBulkImporter
+import io.bluetape4k.graph.io.csv.CsvGraphImportSource
+import io.bluetape4k.graph.io.csv.CsvGraphIoOptions
+import io.bluetape4k.graph.io.csv.SuspendCsvGraphBulkImporter
+import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.report.GraphImportReport
+import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import java.io.InputStream
+
+/**
+ * Imports the fraud detection sample CSV dataset with graph-io.
+ *
+ * The default resources model accounts as vertices and transfers as directed edges, then persists them through
+ * [GraphOperations] or [GraphSuspendOperations].
+ *
+ * ## Behavior / Contract
+ *
+ * - Default resources are resolved from the current thread context class loader first, then this loader's class loader.
+ * - Missing resource names are caller input errors and throw [IllegalArgumentException].
+ * - The loader owns and closes the resource input streams, including failure paths before graph-io consumes both files.
+ * - [GraphImportOptions] and [CsvGraphIoOptions] default to graph-io defaults unless callers override them.
+ * - The loader does not create or clear graphs; callers should initialize the target operations before import.
+ *
+ * ```kotlin
+ * val report = FraudDetectionSampleDatasetLoader.importCsv(ops)
+ * println("accounts=${report.verticesCreated}, transfers=${report.edgesCreated}")
+ * ```
+ */
+object FraudDetectionSampleDatasetLoader {
+
+    const val DEFAULT_VERTICES_RESOURCE: String = "sample-data/fraud/vertices.csv"
+    const val DEFAULT_EDGES_RESOURCE: String = "sample-data/fraud/edges.csv"
+
+    fun importCsv(
+        operations: GraphOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSource(verticesResource, edgesResource) { source ->
+            CsvGraphBulkImporter().importGraph(source, operations, options, csvOptions)
+        }
+
+    suspend fun importCsvSuspending(
+        operations: GraphSuspendOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSourceSuspending(verticesResource, edgesResource) { source ->
+            SuspendCsvGraphBulkImporter().importGraphSuspending(source, operations, options, csvOptions)
+        }
+
+    private fun <T> withImportSource(
+        verticesResource: String,
+        edgesResource: String,
+        block: (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private suspend fun <T> withImportSourceSuspending(
+        verticesResource: String,
+        edgesResource: String,
+        block: suspend (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private fun InputStream.toSource(): GraphImportSource =
+        GraphImportSource.InputStreamSource(
+            input = this,
+            closeInput = false,
+        )
+
+    private fun resourceStreamOrThrow(resourceName: String): InputStream =
+        requireNotNull(
+            listOfNotNull(
+                Thread.currentThread().contextClassLoader,
+                FraudDetectionSampleDatasetLoader::class.java.classLoader,
+            ).asSequence()
+                .mapNotNull { it.getResourceAsStream(resourceName) }
+                .firstOrNull()
+        ) {
+            "Sample dataset resource not found: $resourceName"
+        }
+}

--- a/examples/fraud-detection-examples/src/main/resources/sample-data/fraud/edges.csv
+++ b/examples/fraud-detection-examples/src/main/resources/sample-data/fraud/edges.csv
@@ -1,0 +1,4 @@
+id,label,from,to,prop.amount,prop.occurredAt
+tx-ab,TRANSFERRED_TO,acct-a,acct-b,150,2026-05-01T10:00:00Z
+tx-bc,TRANSFERRED_TO,acct-b,acct-c,90,2026-05-01T10:05:00Z
+tx-ca,TRANSFERRED_TO,acct-c,acct-a,70,2026-05-01T10:10:00Z

--- a/examples/fraud-detection-examples/src/main/resources/sample-data/fraud/vertices.csv
+++ b/examples/fraud-detection-examples/src/main/resources/sample-data/fraud/vertices.csv
@@ -1,0 +1,4 @@
+id,label,prop.accountId,prop.ownerName,prop.riskTier
+acct-a,Account,acct-a,Alice,watch
+acct-b,Account,acct-b,Bob,standard
+acct-c,Account,acct-c,Carol,standard

--- a/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionSampleDatasetLoaderTest.kt
+++ b/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionSampleDatasetLoaderTest.kt
@@ -1,0 +1,88 @@
+package io.bluetape4k.graph.examples.fraud
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.fraud.io.FraudDetectionSampleDatasetLoader
+import io.bluetape4k.graph.examples.fraud.schema.AccountLabel
+import io.bluetape4k.graph.examples.fraud.service.FraudDetectionService
+import io.bluetape4k.graph.examples.fraud.service.FraudDetectionSuspendService
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class FraudDetectionSampleDatasetLoaderTest {
+
+    @Test
+    fun `imports graph-io CSV sample dataset into TinkerGraph`() {
+        val ops = TinkerGraphOperations()
+        val service = FraudDetectionService(ops)
+        service.initialize()
+
+        val report = FraudDetectionSampleDatasetLoader.importCsv(ops)
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 3L
+        report.edgesCreated shouldBeEqualTo 3L
+        ops.findVerticesByLabel(AccountLabel.label).map { it.properties[AccountLabel.accountId.name] } shouldContain "acct-a"
+        service.detectCircularTransfers(maxDepth = 5).shouldNotBeEmpty()
+        service.detectSuspiciousClusters(minSize = 3).shouldNotBeEmpty()
+        service.rankHighRiskAccounts(limit = 3).shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `imports graph-io CSV sample dataset into suspend TinkerGraph`() = runTest {
+        val ops = TinkerGraphSuspendOperations()
+        val service = FraudDetectionSuspendService(ops)
+        service.initialize()
+
+        val report = FraudDetectionSampleDatasetLoader.importCsvSuspending(ops)
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 3L
+        report.edgesCreated shouldBeEqualTo 3L
+        service.detectCircularTransfers(maxDepth = 5).toList().shouldNotBeEmpty()
+        service.detectSuspiciousClusters(minSize = 3).toList().shouldNotBeEmpty()
+        service.rankHighRiskAccounts(limit = 3).toList().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `imports default resources when context class loader cannot see examples`() {
+        withContextClassLoader(object : ClassLoader(null) {}) {
+            val ops = TinkerGraphOperations()
+            FraudDetectionService(ops).initialize()
+
+            val report = FraudDetectionSampleDatasetLoader.importCsv(ops)
+
+            report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+            report.verticesCreated shouldBeEqualTo 3L
+            report.edgesCreated shouldBeEqualTo 3L
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when sample resource is missing`() {
+        assertFailsWith<IllegalArgumentException> {
+            FraudDetectionSampleDatasetLoader.importCsv(
+                TinkerGraphOperations(),
+                verticesResource = "sample-data/fraud/missing-vertices.csv",
+            )
+        }
+    }
+
+    private fun <T> withContextClassLoader(classLoader: ClassLoader, block: () -> T): T {
+        val thread = Thread.currentThread()
+        val previous = thread.contextClassLoader
+        thread.contextClassLoader = classLoader
+
+        return try {
+            block()
+        } finally {
+            thread.contextClassLoader = previous
+        }
+    }
+}

--- a/examples/knowledge-graph-examples/README.ko.md
+++ b/examples/knowledge-graph-examples/README.ko.md
@@ -128,6 +128,25 @@ val mentioned = service.findMentionedEntities(doc.id)
 val paths = service.inferRelationshipPaths(kotlin.id, coroutines.id)
 ```
 
+## 샘플 데이터셋 Import
+
+`KnowledgeGraphSampleDatasetLoader`는 번들된 graph-io CSV fixture를 임의의 `GraphOperations` 구현체로 import합니다.
+fixture에는 바로 조회할 수 있는 문서, 엔티티, 개념, mention, 관련 엔티티 edge, 분류 edge가 포함되어 있습니다.
+
+```kotlin
+val service = KnowledgeGraphService(ops)
+service.initialize()
+
+val report = KnowledgeGraphSampleDatasetLoader.importCsv(ops)
+val document = ops.findVerticesByLabel("Document", mapOf("documentId" to "doc-graph")).single()
+
+check(report.status == GraphIoStatus.COMPLETED)
+val mentioned = service.findMentionedEntities(document.id)
+```
+
+TinkerGraph smoke test는 컨테이너 비용 없이 graph-io import 계약을 검증합니다. 기존 backend 도메인 테스트는 Neo4j,
+Memgraph, Apache AGE, FalkorDB에서 traversal 동작을 계속 검증합니다.
+
 ## 테스트 읽는 법
 
 Abstract test는 작은 지식 그래프를 만들고, mention 조회, 관련 엔티티 탐색, 개념 분류, 제한된 관계 경로 추론을 한 흐름으로
@@ -151,10 +170,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":graph-core"))
-implementation(project(":graph-neo4j"))
-implementation(project(":graph-memgraph"))
-implementation(project(":graph-age"))
-implementation(project(":graph-falkordb"))
-implementation(project(":graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-core"))
+implementation(project(":bluetape4k-graph-neo4j"))
+implementation(project(":bluetape4k-graph-memgraph"))
+implementation(project(":bluetape4k-graph-age"))
+implementation(project(":bluetape4k-graph-falkordb"))
+implementation(project(":bluetape4k-graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-io-csv"))
 ```

--- a/examples/knowledge-graph-examples/README.md
+++ b/examples/knowledge-graph-examples/README.md
@@ -130,6 +130,26 @@ val mentioned = service.findMentionedEntities(doc.id)
 val paths = service.inferRelationshipPaths(kotlin.id, coroutines.id)
 ```
 
+## Sample Dataset Import
+
+`KnowledgeGraphSampleDatasetLoader` imports the bundled graph-io CSV fixture into any `GraphOperations`
+implementation. The fixture contains documents, entities, concepts, mentions, related-entity edges, and classifications
+that can be queried immediately.
+
+```kotlin
+val service = KnowledgeGraphService(ops)
+service.initialize()
+
+val report = KnowledgeGraphSampleDatasetLoader.importCsv(ops)
+val document = ops.findVerticesByLabel("Document", mapOf("documentId" to "doc-graph")).single()
+
+check(report.status == GraphIoStatus.COMPLETED)
+val mentioned = service.findMentionedEntities(document.id)
+```
+
+The TinkerGraph smoke test covers the graph-io import contract without adding container cost. Existing backend domain
+tests continue to prove traversal behavior on Neo4j, Memgraph, Apache AGE, and FalkorDB.
+
 ## How to Read the Tests
 
 The abstract tests show the complete story: load a small knowledge graph, query mentioned entities, traverse related
@@ -153,10 +173,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":graph-core"))
-implementation(project(":graph-neo4j"))
-implementation(project(":graph-memgraph"))
-implementation(project(":graph-age"))
-implementation(project(":graph-falkordb"))
-implementation(project(":graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-core"))
+implementation(project(":bluetape4k-graph-neo4j"))
+implementation(project(":bluetape4k-graph-memgraph"))
+implementation(project(":bluetape4k-graph-age"))
+implementation(project(":bluetape4k-graph-falkordb"))
+implementation(project(":bluetape4k-graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-io-csv"))
 ```

--- a/examples/knowledge-graph-examples/build.gradle.kts
+++ b/examples/knowledge-graph-examples/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation(project(":bluetape4k-graph-memgraph"))
     implementation(project(":bluetape4k-graph-tinkerpop"))
     implementation(project(":bluetape4k-graph-falkordb"))
+    implementation(project(":bluetape4k-graph-io-csv"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)

--- a/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/io/KnowledgeGraphSampleDatasetLoader.kt
+++ b/examples/knowledge-graph-examples/src/main/kotlin/io/bluetape4k/graph/examples/knowledge/io/KnowledgeGraphSampleDatasetLoader.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.graph.examples.knowledge.io
+
+import io.bluetape4k.graph.io.csv.CsvGraphBulkImporter
+import io.bluetape4k.graph.io.csv.CsvGraphImportSource
+import io.bluetape4k.graph.io.csv.CsvGraphIoOptions
+import io.bluetape4k.graph.io.csv.SuspendCsvGraphBulkImporter
+import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.report.GraphImportReport
+import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import java.io.InputStream
+
+/**
+ * Imports the knowledge graph sample CSV dataset with graph-io.
+ *
+ * The default resources model documents, entities, and concepts as vertices, then imports mention, relationship, and
+ * classification edges for service-level graph traversal examples.
+ *
+ * ## Behavior / Contract
+ *
+ * - Default resources are resolved from the current thread context class loader first, then this loader's class loader.
+ * - Missing resource names are caller input errors and throw [IllegalArgumentException].
+ * - The loader owns and closes the resource input streams, including failure paths before graph-io consumes both files.
+ * - [GraphImportOptions] and [CsvGraphIoOptions] default to graph-io defaults unless callers override them.
+ * - The loader does not create or clear graphs; callers should initialize the target operations before import.
+ */
+object KnowledgeGraphSampleDatasetLoader {
+
+    const val DEFAULT_VERTICES_RESOURCE: String = "sample-data/knowledge/vertices.csv"
+    const val DEFAULT_EDGES_RESOURCE: String = "sample-data/knowledge/edges.csv"
+
+    fun importCsv(
+        operations: GraphOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSource(verticesResource, edgesResource) { source ->
+            CsvGraphBulkImporter().importGraph(source, operations, options, csvOptions)
+        }
+
+    suspend fun importCsvSuspending(
+        operations: GraphSuspendOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSourceSuspending(verticesResource, edgesResource) { source ->
+            SuspendCsvGraphBulkImporter().importGraphSuspending(source, operations, options, csvOptions)
+        }
+
+    private fun <T> withImportSource(
+        verticesResource: String,
+        edgesResource: String,
+        block: (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private suspend fun <T> withImportSourceSuspending(
+        verticesResource: String,
+        edgesResource: String,
+        block: suspend (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private fun InputStream.toSource(): GraphImportSource =
+        GraphImportSource.InputStreamSource(
+            input = this,
+            closeInput = false,
+        )
+
+    private fun resourceStreamOrThrow(resourceName: String): InputStream =
+        requireNotNull(
+            listOfNotNull(
+                Thread.currentThread().contextClassLoader,
+                KnowledgeGraphSampleDatasetLoader::class.java.classLoader,
+            ).asSequence()
+                .mapNotNull { it.getResourceAsStream(resourceName) }
+                .firstOrNull()
+        ) {
+            "Sample dataset resource not found: $resourceName"
+        }
+}

--- a/examples/knowledge-graph-examples/src/main/resources/sample-data/knowledge/edges.csv
+++ b/examples/knowledge-graph-examples/src/main/resources/sample-data/knowledge/edges.csv
@@ -1,0 +1,6 @@
+id,label,from,to,prop.confidence,prop.relationType
+mention-doc-kotlin,MENTIONS,doc-graph,entity-kotlin,95,
+mention-doc-graph,MENTIONS,doc-graph,entity-graph,90,
+related-kotlin-graph,RELATED_TO,entity-kotlin,entity-graph,,uses
+related-graph-falkordb,RELATED_TO,entity-graph,entity-falkordb,,backend
+is-a-falkordb-database,IS_A,entity-falkordb,concept-database,,

--- a/examples/knowledge-graph-examples/src/main/resources/sample-data/knowledge/vertices.csv
+++ b/examples/knowledge-graph-examples/src/main/resources/sample-data/knowledge/vertices.csv
@@ -1,0 +1,6 @@
+id,label,prop.entityId,prop.name,prop.entityType,prop.conceptId,prop.domain,prop.documentId,prop.title,prop.source
+entity-kotlin,Entity,entity-kotlin,Kotlin,Language,,,,,
+entity-graph,Entity,entity-graph,Graph,Concept,,,,,
+entity-falkordb,Entity,entity-falkordb,FalkorDB,Database,,,,,
+concept-database,Concept,,,,concept-database,graph,,,
+doc-graph,Document,,,,,,doc-graph,Graph API Notes,internal

--- a/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphSampleDatasetLoaderTest.kt
+++ b/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphSampleDatasetLoaderTest.kt
@@ -1,0 +1,112 @@
+package io.bluetape4k.graph.examples.knowledge
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import io.bluetape4k.graph.examples.knowledge.io.KnowledgeGraphSampleDatasetLoader
+import io.bluetape4k.graph.examples.knowledge.schema.DocumentLabel
+import io.bluetape4k.graph.examples.knowledge.schema.EntityLabel
+import io.bluetape4k.graph.examples.knowledge.service.KnowledgeGraphService
+import io.bluetape4k.graph.examples.knowledge.service.KnowledgeGraphSuspendService
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class KnowledgeGraphSampleDatasetLoaderTest {
+
+    @Test
+    fun `imports graph-io CSV sample dataset into TinkerGraph`() {
+        val ops = TinkerGraphOperations()
+        val service = KnowledgeGraphService(ops)
+        service.initialize()
+
+        val report = KnowledgeGraphSampleDatasetLoader.importCsv(ops)
+        val document = ops.findVerticesByLabel(
+            DocumentLabel.label,
+            mapOf(DocumentLabel.documentId.name to "doc-graph"),
+        ).single()
+        val kotlin = ops.findVerticesByLabel(
+            EntityLabel.label,
+            mapOf(EntityLabel.entityId.name to "entity-kotlin"),
+        ).single()
+        val falkorDb = ops.findVerticesByLabel(
+            EntityLabel.label,
+            mapOf(EntityLabel.entityId.name to "entity-falkordb"),
+        ).single()
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 5L
+        report.edgesCreated shouldBeEqualTo 5L
+        service.findMentionedEntities(document.id).map { it.properties[EntityLabel.entityId.name] } shouldContain "entity-kotlin"
+        service.findRelatedEntities(kotlin.id, depth = 2).map { it.properties[EntityLabel.entityId.name] } shouldContain "entity-falkordb"
+        service.inferRelationshipPaths(kotlin.id, falkorDb.id, maxDepth = 3).shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `imports graph-io CSV sample dataset into suspend TinkerGraph`() = runTest {
+        val ops = TinkerGraphSuspendOperations()
+        val service = KnowledgeGraphSuspendService(ops)
+        service.initialize()
+
+        val report = KnowledgeGraphSampleDatasetLoader.importCsvSuspending(ops)
+        val document = ops.findVerticesByLabel(
+            DocumentLabel.label,
+            mapOf(DocumentLabel.documentId.name to "doc-graph"),
+        ).toList().single()
+        val kotlin = ops.findVerticesByLabel(
+            EntityLabel.label,
+            mapOf(EntityLabel.entityId.name to "entity-kotlin"),
+        ).toList().single()
+        val falkorDb = ops.findVerticesByLabel(
+            EntityLabel.label,
+            mapOf(EntityLabel.entityId.name to "entity-falkordb"),
+        ).toList().single()
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 5L
+        report.edgesCreated shouldBeEqualTo 5L
+        service.findMentionedEntities(document.id).toList().map { it.properties[EntityLabel.entityId.name] } shouldContain "entity-kotlin"
+        service.findRelatedEntities(kotlin.id, depth = 2).toList().map { it.properties[EntityLabel.entityId.name] } shouldContain "entity-falkordb"
+        service.inferRelationshipPaths(kotlin.id, falkorDb.id, maxDepth = 3).toList().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `imports default resources when context class loader cannot see examples`() {
+        withContextClassLoader(object : ClassLoader(null) {}) {
+            val ops = TinkerGraphOperations()
+            KnowledgeGraphService(ops).initialize()
+
+            val report = KnowledgeGraphSampleDatasetLoader.importCsv(ops)
+
+            report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+            report.verticesCreated shouldBeEqualTo 5L
+            report.edgesCreated shouldBeEqualTo 5L
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when sample resource is missing`() {
+        assertFailsWith<IllegalArgumentException> {
+            KnowledgeGraphSampleDatasetLoader.importCsv(
+                TinkerGraphOperations(),
+                verticesResource = "sample-data/knowledge/missing-vertices.csv",
+            )
+        }
+    }
+
+    private fun <T> withContextClassLoader(classLoader: ClassLoader, block: () -> T): T {
+        val thread = Thread.currentThread()
+        val previous = thread.contextClassLoader
+        thread.contextClassLoader = classLoader
+
+        return try {
+            block()
+        } finally {
+            thread.contextClassLoader = previous
+        }
+    }
+}

--- a/examples/recommendation-examples/README.ko.md
+++ b/examples/recommendation-examples/README.ko.md
@@ -128,6 +128,26 @@ val products = service.recommendProducts(alice.id)
 val popular = service.rankPopularProducts(limit = 10)
 ```
 
+## 샘플 데이터셋 Import
+
+`RecommendationSampleDatasetLoader`는 번들된 graph-io CSV fixture를 임의의 `GraphOperations` 구현체로 import합니다.
+fixture에는 안정적인 상품 추천과 팔로우 추천을 만드는 사용자, 상품, 구매 edge, 팔로우 edge가 포함되어 있습니다.
+
+```kotlin
+val service = RecommendationService(ops)
+service.initialize()
+
+val report = RecommendationSampleDatasetLoader.importCsv(ops)
+val alice = ops.findVerticesByLabel("User", mapOf("userId" to "u-alice")).single()
+
+check(report.status == GraphIoStatus.COMPLETED)
+val products = service.recommendProducts(alice.id)
+val follows = service.recommendFollows(alice.id)
+```
+
+이 loader 경로는 TinkerGraph smoke test로 충분합니다. graph-io가 공통 `GraphOperations` 계약을 통해 데이터를 쓰기
+때문입니다. 컨테이너 기반 backend 동작은 기존 도메인 test matrix가 계속 담당합니다.
+
 ## 테스트 읽는 법
 
 Abstract test가 튜토리얼입니다. 작은 그래프를 만들고 추천을 실행한 뒤, backend별 점수나 정렬에 의존하지 않고 안정적인
@@ -151,10 +171,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":graph-core"))
-implementation(project(":graph-neo4j"))
-implementation(project(":graph-memgraph"))
-implementation(project(":graph-age"))
-implementation(project(":graph-falkordb"))
-implementation(project(":graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-core"))
+implementation(project(":bluetape4k-graph-neo4j"))
+implementation(project(":bluetape4k-graph-memgraph"))
+implementation(project(":bluetape4k-graph-age"))
+implementation(project(":bluetape4k-graph-falkordb"))
+implementation(project(":bluetape4k-graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-io-csv"))
 ```

--- a/examples/recommendation-examples/README.md
+++ b/examples/recommendation-examples/README.md
@@ -128,6 +128,27 @@ val products = service.recommendProducts(alice.id)
 val popular = service.rankPopularProducts(limit = 10)
 ```
 
+## Sample Dataset Import
+
+`RecommendationSampleDatasetLoader` imports the bundled graph-io CSV fixture into any `GraphOperations`
+implementation. The fixture contains users, products, purchase edges, and follow edges that produce stable product and
+follow recommendations.
+
+```kotlin
+val service = RecommendationService(ops)
+service.initialize()
+
+val report = RecommendationSampleDatasetLoader.importCsv(ops)
+val alice = ops.findVerticesByLabel("User", mapOf("userId" to "u-alice")).single()
+
+check(report.status == GraphIoStatus.COMPLETED)
+val products = service.recommendProducts(alice.id)
+val follows = service.recommendFollows(alice.id)
+```
+
+The TinkerGraph smoke test is sufficient for the loader path because graph-io writes through the shared
+`GraphOperations` contract. Container-backed backend behavior remains covered by the existing domain test matrix.
+
 ## How to Read the Tests
 
 The abstract tests are the tutorial. They build a tiny graph, run a recommendation, and assert stable membership rather
@@ -151,10 +172,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":graph-core"))
-implementation(project(":graph-neo4j"))
-implementation(project(":graph-memgraph"))
-implementation(project(":graph-age"))
-implementation(project(":graph-falkordb"))
-implementation(project(":graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-core"))
+implementation(project(":bluetape4k-graph-neo4j"))
+implementation(project(":bluetape4k-graph-memgraph"))
+implementation(project(":bluetape4k-graph-age"))
+implementation(project(":bluetape4k-graph-falkordb"))
+implementation(project(":bluetape4k-graph-tinkerpop"))
+implementation(project(":bluetape4k-graph-io-csv"))
 ```

--- a/examples/recommendation-examples/build.gradle.kts
+++ b/examples/recommendation-examples/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation(project(":bluetape4k-graph-memgraph"))
     implementation(project(":bluetape4k-graph-tinkerpop"))
     implementation(project(":bluetape4k-graph-falkordb"))
+    implementation(project(":bluetape4k-graph-io-csv"))
 
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core.lib)

--- a/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/io/RecommendationSampleDatasetLoader.kt
+++ b/examples/recommendation-examples/src/main/kotlin/io/bluetape4k/graph/examples/recommendation/io/RecommendationSampleDatasetLoader.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.graph.examples.recommendation.io
+
+import io.bluetape4k.graph.io.csv.CsvGraphBulkImporter
+import io.bluetape4k.graph.io.csv.CsvGraphImportSource
+import io.bluetape4k.graph.io.csv.CsvGraphIoOptions
+import io.bluetape4k.graph.io.csv.SuspendCsvGraphBulkImporter
+import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.report.GraphImportReport
+import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import java.io.InputStream
+
+/**
+ * Imports the recommendation sample CSV dataset with graph-io.
+ *
+ * The default resources model users and products as vertices, plus purchase and follow edges. The imported graph can
+ * be queried immediately by [io.bluetape4k.graph.examples.recommendation.service.RecommendationService].
+ *
+ * ## Behavior / Contract
+ *
+ * - Default resources are resolved from the current thread context class loader first, then this loader's class loader.
+ * - Missing resource names are caller input errors and throw [IllegalArgumentException].
+ * - The loader owns and closes the resource input streams, including failure paths before graph-io consumes both files.
+ * - [GraphImportOptions] and [CsvGraphIoOptions] default to graph-io defaults unless callers override them.
+ * - The loader does not create or clear graphs; callers should initialize the target operations before import.
+ */
+object RecommendationSampleDatasetLoader {
+
+    const val DEFAULT_VERTICES_RESOURCE: String = "sample-data/recommendation/vertices.csv"
+    const val DEFAULT_EDGES_RESOURCE: String = "sample-data/recommendation/edges.csv"
+
+    fun importCsv(
+        operations: GraphOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSource(verticesResource, edgesResource) { source ->
+            CsvGraphBulkImporter().importGraph(source, operations, options, csvOptions)
+        }
+
+    suspend fun importCsvSuspending(
+        operations: GraphSuspendOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSourceSuspending(verticesResource, edgesResource) { source ->
+            SuspendCsvGraphBulkImporter().importGraphSuspending(source, operations, options, csvOptions)
+        }
+
+    private fun <T> withImportSource(
+        verticesResource: String,
+        edgesResource: String,
+        block: (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private suspend fun <T> withImportSourceSuspending(
+        verticesResource: String,
+        edgesResource: String,
+        block: suspend (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private fun InputStream.toSource(): GraphImportSource =
+        GraphImportSource.InputStreamSource(
+            input = this,
+            closeInput = false,
+        )
+
+    private fun resourceStreamOrThrow(resourceName: String): InputStream =
+        requireNotNull(
+            listOfNotNull(
+                Thread.currentThread().contextClassLoader,
+                RecommendationSampleDatasetLoader::class.java.classLoader,
+            ).asSequence()
+                .mapNotNull { it.getResourceAsStream(resourceName) }
+                .firstOrNull()
+        ) {
+            "Sample dataset resource not found: $resourceName"
+        }
+}

--- a/examples/recommendation-examples/src/main/resources/sample-data/recommendation/edges.csv
+++ b/examples/recommendation-examples/src/main/resources/sample-data/recommendation/edges.csv
@@ -1,0 +1,7 @@
+id,label,from,to,prop.quantity,prop.purchasedAt
+purchase-alice-camera,PURCHASED,u-alice,p-camera,1,2026-05-01
+purchase-bob-camera,PURCHASED,u-bob,p-camera,1,2026-05-01
+purchase-bob-tripod,PURCHASED,u-bob,p-tripod,1,2026-05-02
+purchase-carol-light,PURCHASED,u-carol,p-light,1,2026-05-03
+follow-alice-bob,FOLLOWS,u-alice,u-bob,,
+follow-bob-carol,FOLLOWS,u-bob,u-carol,,

--- a/examples/recommendation-examples/src/main/resources/sample-data/recommendation/vertices.csv
+++ b/examples/recommendation-examples/src/main/resources/sample-data/recommendation/vertices.csv
@@ -1,0 +1,7 @@
+id,label,prop.userId,prop.displayName,prop.segment,prop.productId,prop.name,prop.category
+u-alice,User,u-alice,Alice,retail,,,
+u-bob,User,u-bob,Bob,retail,,,
+u-carol,User,u-carol,Carol,creator,,,
+p-camera,Product,,,,p-camera,Camera,photo
+p-tripod,Product,,,,p-tripod,Tripod,photo
+p-light,Product,,,,p-light,Light,studio

--- a/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationSampleDatasetLoaderTest.kt
+++ b/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationSampleDatasetLoaderTest.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.graph.examples.recommendation
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.examples.recommendation.io.RecommendationSampleDatasetLoader
+import io.bluetape4k.graph.examples.recommendation.schema.ProductLabel
+import io.bluetape4k.graph.examples.recommendation.schema.UserLabel
+import io.bluetape4k.graph.examples.recommendation.service.RecommendationService
+import io.bluetape4k.graph.examples.recommendation.service.RecommendationSuspendService
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class RecommendationSampleDatasetLoaderTest {
+
+    @Test
+    fun `imports graph-io CSV sample dataset into TinkerGraph`() {
+        val ops = TinkerGraphOperations()
+        val service = RecommendationService(ops)
+        service.initialize()
+
+        val report = RecommendationSampleDatasetLoader.importCsv(ops)
+        val alice = ops.findVerticesByLabel(UserLabel.label, mapOf(UserLabel.userId.name to "u-alice")).single()
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 6L
+        report.edgesCreated shouldBeEqualTo 6L
+        service.recommendProducts(alice.id).map { it.properties[ProductLabel.productId.name] } shouldContain "p-tripod"
+        service.recommendFollows(alice.id).map { it.properties[UserLabel.userId.name] } shouldContain "u-carol"
+        service.rankPopularProducts(limit = 3).map { it.vertex.properties[ProductLabel.productId.name] } shouldContain "p-camera"
+    }
+
+    @Test
+    fun `imports graph-io CSV sample dataset into suspend TinkerGraph`() = runTest {
+        val ops = TinkerGraphSuspendOperations()
+        val service = RecommendationSuspendService(ops)
+        service.initialize()
+
+        val report = RecommendationSampleDatasetLoader.importCsvSuspending(ops)
+        val alice = ops.findVerticesByLabel(UserLabel.label, mapOf(UserLabel.userId.name to "u-alice")).toList().single()
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesCreated shouldBeEqualTo 6L
+        report.edgesCreated shouldBeEqualTo 6L
+        service.recommendProducts(alice.id).toList().map { it.properties[ProductLabel.productId.name] } shouldContain "p-tripod"
+        service.recommendFollows(alice.id).toList().map { it.properties[UserLabel.userId.name] } shouldContain "u-carol"
+        service.rankPopularProducts(limit = 3).toList().map { it.vertex.properties[ProductLabel.productId.name] } shouldContain "p-camera"
+    }
+
+    @Test
+    fun `imports default resources when context class loader cannot see examples`() {
+        withContextClassLoader(object : ClassLoader(null) {}) {
+            val ops = TinkerGraphOperations()
+            RecommendationService(ops).initialize()
+
+            val report = RecommendationSampleDatasetLoader.importCsv(ops)
+
+            report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+            report.verticesCreated shouldBeEqualTo 6L
+            report.edgesCreated shouldBeEqualTo 6L
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when sample resource is missing`() {
+        assertFailsWith<IllegalArgumentException> {
+            RecommendationSampleDatasetLoader.importCsv(
+                TinkerGraphOperations(),
+                verticesResource = "sample-data/recommendation/missing-vertices.csv",
+            )
+        }
+    }
+
+    private fun <T> withContextClassLoader(classLoader: ClassLoader, block: () -> T): T {
+        val thread = Thread.currentThread()
+        val previous = thread.contextClassLoader
+        thread.contextClassLoader = classLoader
+
+        return try {
+            block()
+        } finally {
+            thread.contextClassLoader = previous
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add graph-io CSV sample dataset loaders for fraud detection, recommendation, and knowledge graph examples.
- Bundle small domain CSV fixtures under main resources so default loaders work from built example jars.
- Cover sync, suspend, context-classloader fallback, and missing-resource paths with TinkerGraph loader tests.
- Update English/Korean READMEs, CHANGELOG, WIP, design/plan, and lessons.

Fixes #111.

## Verification

- `./gradlew :fraud-detection-examples:compileKotlin :fraud-detection-examples:compileTestKotlin :fraud-detection-examples:test --tests "io.bluetape4k.graph.examples.fraud.FraudDetectionSampleDatasetLoaderTest" :recommendation-examples:compileKotlin :recommendation-examples:compileTestKotlin :recommendation-examples:test --tests "io.bluetape4k.graph.examples.recommendation.RecommendationSampleDatasetLoaderTest" :knowledge-graph-examples:compileKotlin :knowledge-graph-examples:compileTestKotlin :knowledge-graph-examples:test --tests "io.bluetape4k.graph.examples.knowledge.KnowledgeGraphSampleDatasetLoaderTest" --console=plain --no-daemon`
- `jar tf` for the three example jars includes `sample-data/**/{vertices,edges}.csv`
- `git diff --check`
- Codex review: no actionable defects
- Claude review: no merge blocker; earlier P1/P2 findings fixed

## Notes

- Example modules do not expose Detekt tasks. Repository-wide Detekt currently fails on pre-existing non-example findings.
- README dependency snippets also correct stale project paths from `:graph-*` to `:bluetape4k-graph-*`.
