### PR TITLE
docs: record Ktor API hygiene audit for #127

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-19 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 10 issues; 9 remain after #111 closes through this work.
+Open count: 9 issues; 8 remain after #127 closes through this work.
 
 ## Refresh Notes
 
@@ -30,23 +30,24 @@ Verified with `gh` on 2026-05-19 KST.
   already-exists or missing-resource fallbacks.
 - Issue #111 is handled by adding graph-io CSV sample dataset loaders, bundled fixtures, sync/suspend
   TinkerGraph smoke coverage, English/Korean README import flows, and release notes.
+- Issue #127 is handled by auditing `graph-ktor` and `ktor-graph-examples` against Ktor 3.5.0:
+  the latest stable 3.x BOM is already used, compile output has zero Ktor deprecation warnings, and
+  the targeted Ktor plugin/example tests pass without code changes.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Finish and merge graph-io backed sample dataset loaders (#111).
-2. Handle Ktor/FalkorDB hygiene items after feature work: #127, #135, #133, and #134.
+1. Close the Ktor API hygiene audit (#127) with verification evidence; no runtime change is required.
+2. Handle remaining Ktor/FalkorDB hygiene items after feature work: #135, #133, and #134.
 3. Keep Neptune testability research (#113) as the predecessor for the backlog backend epic (#30).
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111) graph-io backed sample dataset loaders | M | Handled by this work; remove from active queue after merge. |
-| P2 | [#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127) replace deprecated/internal Ktor APIs in graph-ktor | S | Next 0.3.1 maintenance work after #111 merges. |
-| P2 | [#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135) close FalkorDB driver in Ktor test teardown | S | Test hygiene after feature work. |
+| P1 | [#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135) close FalkorDB driver in Ktor test teardown | S | Next 0.3.1 Ktor hygiene item after #127 verification closes. |
 | P3 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation/adoption lane. |
 | P3 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
 | P3 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
@@ -76,6 +77,9 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 #111 graph-io backed sample dataset loaders
   -> improved examples onboarding
+
+#127 Ktor API hygiene audit
+  -> no Ktor deprecation or version work needed on 3.5.0
 ```
 
 ## WIP Limits
@@ -86,4 +90,4 @@ contracts and backend readiness before widening examples or benchmark lanes:
 | Suspend transaction safety | 1 | #160 merged; keep this lane idle unless a new transaction-safety issue appears. |
 | Research / backend readiness | 1 | `#113` before `#30`. |
 | CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
-| Examples / benchmarks | 1 | `#111` in PR; idle after merge unless another adoption issue is selected. |
+| Examples / benchmarks | 1 | #111 merged; idle unless another adoption issue is selected. |

--- a/docs/lessons/2026-05-19-issue-127-ktor-api-hygiene.md
+++ b/docs/lessons/2026-05-19-issue-127-ktor-api-hygiene.md
@@ -1,0 +1,32 @@
+# Issue #127 Ktor API Hygiene Audit
+
+## Context
+
+Issue #127 is a periodic audit for deprecated or internal Ktor APIs in `graph-ktor` and
+`ktor-graph-examples`.
+
+## Decision
+
+No code change is required for this audit. The repository already uses Ktor BOM `3.5.0`, which Maven
+Central metadata reports as the latest stable 3.x release, and the affected modules compile without Ktor
+deprecation warnings.
+
+## Outcome
+
+Kept the implementation unchanged and recorded the verification evidence. The issue can close as a
+verification-only maintenance item.
+
+## Verification
+
+- Maven Central `io.ktor:ktor-bom` metadata reports `<latest>3.5.0</latest>` and `<release>3.5.0</release>`.
+- `gradle/libs.versions.toml` already sets `ktor = "3.5.0"`.
+- `./gradlew :bluetape4k-graph-ktor:build :ktor-graph-examples:build --warning-mode=all --console=plain --no-daemon` passed.
+- The same build output showed zero `@Deprecated` or Ktor API deprecation warnings.
+- `BackendGraphPluginRuntimeTest` passed 4 tests.
+- `GraphPluginTest` passed 6 tests.
+- `ktor-graph-examples` passed 4 tests.
+
+## Future Guard
+
+When an issue body mentions `:graph-ktor`, verify the current Gradle project name first. The active project
+path is `:bluetape4k-graph-ktor`, while the source directory remains `ktor/graph-ktor`.


### PR DESCRIPTION
Fixes #127.

## Summary

- Recorded the Ktor API hygiene audit result for `graph-ktor` and `ktor-graph-examples`.
- Updated `WIP.md` so the 0.3.1 queue moves from #127 to #135.
- Added a lesson noting that no code refactor is currently required because Ktor 3.5.0 is already the latest stable 3.x BOM and the affected modules compile cleanly.

## Verification

- Maven Central `io.ktor:ktor-bom` metadata reports `<latest>3.5.0</latest>` and `<release>3.5.0</release>`.
- `gradle/libs.versions.toml` already sets `ktor = "3.5.0"`.
- `./gradlew :bluetape4k-graph-ktor:build :ktor-graph-examples:build --warning-mode=all --console=plain --no-daemon` passed.
- Build output showed zero Ktor `@Deprecated` or Ktor API deprecation warnings.
- `BackendGraphPluginRuntimeTest`: 4 tests passed.
- `GraphPluginTest`: 6 tests passed.
- `ktor-graph-examples`: 4 tests passed.
- `git diff --check HEAD~1 HEAD` passed.

## Review

- Codex review: no P0/P1 findings.
- Claude review: initial P1 was the untracked lesson evidence file; fixed by commit `7750c65`.
- Claude re-review: NO P0/P1 FINDINGS.

## Notes

No Kotlin source changed, so IDE diagnostics and Kotlin compile-after-edit gates are not applicable beyond the targeted Gradle build above.
