### PR TITLE
fix: close FalkorDB Ktor example driver after tests

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-19 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 9 issues; 8 remain after #127 closes through this work.
+Open count: 8 issues; 7 remain after #135 closes through this work.
 
 ## Refresh Notes
 
@@ -33,23 +33,24 @@ Verified with `gh` on 2026-05-19 KST.
 - Issue #127 is handled by auditing `graph-ktor` and `ktor-graph-examples` against Ktor 3.5.0:
   the latest stable 3.x BOM is already used, compile output has zero Ktor deprecation warnings, and
   the targeted Ktor plugin/example tests pass without code changes.
+- Issue #135 is handled by closing the caller-owned FalkorDB driver in
+  `FalkorDBKtorGraphAppTest` after the PER_CLASS test lifecycle completes.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Close the Ktor API hygiene audit (#127) with verification evidence; no runtime change is required.
-2. Handle remaining Ktor/FalkorDB hygiene items after feature work: #135, #133, and #134.
-3. Keep Neptune testability research (#113) as the predecessor for the backlog backend epic (#30).
+1. Finish the Ktor/FalkorDB hygiene lane with the remaining documentation/adoption items: #133 and #134.
+2. Then return to Neptune testability research (#113) before the backlog backend epic (#30).
+3. Keep benchmark work behind stable backend readiness and CI signal quality.
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135) close FalkorDB driver in Ktor test teardown | S | Next 0.3.1 Ktor hygiene item after #127 verification closes. |
-| P3 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation/adoption lane. |
-| P3 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
+| P1 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation/adoption lane. |
+| P2 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
 | P3 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
 | P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P4 | [#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14) backend JMH benchmark | M | After CI gates settle. |
@@ -80,6 +81,9 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 #127 Ktor API hygiene audit
   -> no Ktor deprecation or version work needed on 3.5.0
+
+#135 FalkorDB Ktor example teardown
+  -> caller-owned FalkorDB driver is closed after PER_CLASS test lifecycle
 ```
 
 ## WIP Limits

--- a/docs/lessons/2026-05-19-issue-135-falkordb-ktor-driver-teardown.md
+++ b/docs/lessons/2026-05-19-issue-135-falkordb-ktor-driver-teardown.md
@@ -1,0 +1,28 @@
+# Issue #135 FalkorDB Ktor Driver Teardown
+
+## Context
+
+`FalkorDBKtorGraphAppTest` creates a shared FalkorDB driver for the whole PER_CLASS test lifecycle. The
+`falkorDbModule(driver)` contract says the caller owns the driver and must close it, but the test did not close
+the companion-object driver.
+
+## Decision
+
+Keep the shared driver so the Testcontainers-backed Ktor example avoids per-test connection pool creation, and close
+it once in `@AfterAll` after all test methods complete.
+
+## Outcome
+
+Added a PER_CLASS teardown that closes the caller-owned FalkorDB driver only when the lazy fixture was initialized,
+and updated the test KDoc so the lifecycle contract is explicit.
+
+## Verification
+
+- `./gradlew :ktor-graph-examples:compileTestKotlin :ktor-graph-examples:test --tests "*.FalkorDBKtorGraphAppTest" --console=plain --no-daemon` passed.
+- `FalkorDBKtorGraphAppTest` passed 2 tests.
+- IntelliJ diagnostics were unavailable for this worktree because the IDE MCP did not have the worktree opened as a project; Gradle compile/test was used as the fallback.
+
+## Future Guard
+
+When Ktor example tests accept caller-owned drivers or clients, keep the shared fixture at class scope and close it in
+`@AfterAll`. Do not rely on `testApplication` teardown to close resources owned outside the application module.

--- a/examples/ktor-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphAppTest.kt
+++ b/examples/ktor-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/ktor/FalkorDBKtorGraphAppTest.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -19,7 +20,7 @@ import org.junit.jupiter.api.TestInstance
  * ## Behavior / Contract
  * - Uses the singleton [FalkorDBServer.Launcher.falkordb] Testcontainers instance.
  * - The shared [driver] is caller-owned and reused across tests; it is not closed
- *   between test methods.
+ *   between test methods and is closed after the test class completes.
  * - Each test calls `POST /demo/reset` before asserting state to ensure isolation.
  *
  * ```kotlin
@@ -33,7 +34,15 @@ class FalkorDBKtorGraphAppTest {
 
     companion object : KLogging() {
         private val server = FalkorDBServer.Launcher.falkordb
-        private val driver by lazy { FalkorDB.driver(server.host, server.port) }
+        private val driverLazy = lazy { FalkorDB.driver(server.host, server.port) }
+        private val driver by driverLazy
+    }
+
+    @AfterAll
+    fun tearDown() {
+        if (driverLazy.isInitialized()) {
+            driver.close()
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #135.

## Summary

- Close the shared caller-owned FalkorDB driver in `FalkorDBKtorGraphAppTest` after the PER_CLASS test lifecycle.
- Guard teardown with `Lazy.isInitialized()` so a skipped/uninitialized test class does not create a driver just to close it.
- Update `WIP.md` and add a lesson for the driver ownership rule.

## Verification

- `./gradlew :ktor-graph-examples:compileTestKotlin :ktor-graph-examples:test --tests "*.FalkorDBKtorGraphAppTest" --console=plain --no-daemon` passed.
- `FalkorDBKtorGraphAppTest`: 2 tests passed.
- `git diff --check HEAD~1 HEAD` passed.
- IntelliJ diagnostics were unavailable because this worktree is not open in the IDE MCP; Gradle compile/test was used as fallback.

## Review

- Codex review: no P0/P1 findings.
- Claude review: NO P0/P1 FINDINGS.
- Claude P2 observation about lazy initialization during teardown was fixed with `Lazy.isInitialized()` and re-reviewed as resolved.
