### PR TITLE
docs: add FalkorDB Ktor example to README tables

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -399,6 +399,7 @@ GitHub Actions는 전용 `Examples` workflow도 실행한다. 이 workflow는 �
 | `AbstractLinkedInGraphSuspendTest` | `Neo4j/Memgraph/TinkerGraph/Age/FalkorDBLinkedInGraphSuspendTest` |
 | `AbstractRecommendationTest` | user/product/category recommendation graph 예시 |
 | `KtorGraphAppTest` | TinkerGraph 기반 Ktor `GraphPlugin` smoke 예시 |
+| `FalkorDBKtorGraphAppTest` | FalkorDB 기반 Ktor `GraphPlugin` smoke 예시 |
 
 구체 클래스는 `ops` (`GraphOperations` 또는 `GraphSuspendOperations`) 와 서버 라이프사이클(`@BeforeAll`/`@AfterAll`)만 구현하면 된다.
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Each example module uses the **abstract test class pattern**. Common test logic 
 | `AbstractLinkedInGraphSuspendTest` | `Neo4j/Memgraph/TinkerGraph/Age/FalkorDBLinkedInGraphSuspendTest` |
 | `AbstractRecommendationTest` | User/product/category recommendation graph examples |
 | `KtorGraphAppTest` | TinkerGraph-backed Ktor `GraphPlugin` smoke example |
+| `FalkorDBKtorGraphAppTest` | FalkorDB-backed Ktor `GraphPlugin` smoke example |
 
 Concrete classes only need to implement `ops` (`GraphOperations` or `GraphSuspendOperations`) and the server lifecycle (`@BeforeAll`/`@AfterAll`).
 

--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-19 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 8 issues; 7 remain after #135 closes through this work.
+Open count: 7 issues; 6 remain after #133 closes through this work.
 
 ## Refresh Notes
 
@@ -35,13 +35,15 @@ Verified with `gh` on 2026-05-19 KST.
   the targeted Ktor plugin/example tests pass without code changes.
 - Issue #135 is handled by closing the caller-owned FalkorDB driver in
   `FalkorDBKtorGraphAppTest` after the PER_CLASS test lifecycle completes.
+- Issue #133 is handled by adding the FalkorDB-backed Ktor `GraphPlugin` smoke example to the
+  English and Korean README example module tables.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Finish the Ktor/FalkorDB hygiene lane with the remaining documentation/adoption items: #133 and #134.
+1. Finish the Ktor/FalkorDB hygiene lane with the remaining documentation item: #134.
 2. Then return to Neptune testability research (#113) before the backlog backend epic (#30).
 3. Keep benchmark work behind stable backend readiness and CI signal quality.
 
@@ -49,8 +51,7 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133) add FalkorDB Ktor example to README table | S | Documentation/adoption lane. |
-| P2 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
+| P1 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
 | P3 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
 | P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P4 | [#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14) backend JMH benchmark | M | After CI gates settle. |
@@ -84,6 +85,9 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 #135 FalkorDB Ktor example teardown
   -> caller-owned FalkorDB driver is closed after PER_CLASS test lifecycle
+
+#133 FalkorDB Ktor README discoverability
+  -> English/Korean README tables list FalkorDBKtorGraphAppTest
 ```
 
 ## WIP Limits

--- a/docs/lessons/2026-05-19-issue-133-falkordb-ktor-readme.md
+++ b/docs/lessons/2026-05-19-issue-133-falkordb-ktor-readme.md
@@ -1,0 +1,25 @@
+# Issue #133 FalkorDB Ktor README Discoverability
+
+## Context
+
+The root README example module table listed the TinkerGraph Ktor smoke test but did not list the FalkorDB-backed
+Ktor example added for this release.
+
+## Decision
+
+Add `FalkorDBKtorGraphAppTest` as its own row in both `README.md` and `README.ko.md` so English and Korean readers can
+discover the FalkorDB Ktor `GraphPlugin` smoke example from the same table.
+
+## Outcome
+
+The example module table now lists both the TinkerGraph and FalkorDB Ktor smoke examples.
+
+## Verification
+
+- `rg -n "FalkorDBKtorGraphAppTest|KtorGraphAppTest" README.md README.ko.md examples/ktor-graph-examples` confirms the README rows match real test classes.
+- `git diff --check` passed.
+
+## Future Guard
+
+When adding an example class that demonstrates a supported backend integration, update both root README locales in the
+same branch and grep for the real class name before committing.


### PR DESCRIPTION
Fixes #133.

## Summary

- Add `FalkorDBKtorGraphAppTest` to the root README example module table.
- Keep `README.md` and `README.ko.md` structurally aligned.
- Update `WIP.md` and add a lesson for README example discoverability.

## Verification

- `rg -n "FalkorDBKtorGraphAppTest|KtorGraphAppTest" README.md README.ko.md examples/ktor-graph-examples` confirmed both README rows match real test classes.
- `git diff --check HEAD~1 HEAD` passed.
- Gradle build not run because this is documentation-only.

## Review

- Codex review: no P0/P1 findings.
- Claude review: NO P0/P1 FINDINGS.
