### PR TITLE
docs: translate FalkorDB auto-configuration KDoc

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-05-19 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 7 issues; 6 remain after #133 closes through this work.
+Open count: 6 issues; 5 remain after #134 closes through this work.
 
 ## Refresh Notes
 
@@ -37,22 +37,23 @@ Verified with `gh` on 2026-05-19 KST.
   `FalkorDBKtorGraphAppTest` after the PER_CLASS test lifecycle completes.
 - Issue #133 is handled by adding the FalkorDB-backed Ktor `GraphPlugin` smoke example to the
   English and Korean README example module tables.
+- Issue #134 is handled by converting the public `GraphFalkorDBAutoConfiguration` KDoc blocks
+  for driver, operations, virtual-thread adapter, and health indicator beans to English.
 
 ## Current Direction
 
 0.3.0 is released. The next work should stabilize coroutine/cancellation
 contracts and backend readiness before widening examples or benchmark lanes:
 
-1. Finish the Ktor/FalkorDB hygiene lane with the remaining documentation item: #134.
-2. Then return to Neptune testability research (#113) before the backlog backend epic (#30).
+1. Return to Neptune testability research (#113) before the backlog backend epic (#30).
+2. Keep documentation-only cleanup behind backend-readiness blockers unless it reduces migration risk.
 3. Keep benchmark work behind stable backend readiness and CI signal quality.
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
-| P1 | [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134) convert GraphFalkorDBAutoConfiguration KDoc to English | S | Documentation lane. |
-| P3 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
+| P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
 | P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
 | P4 | [#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14) backend JMH benchmark | M | After CI gates settle. |
 | P4 | [#15](https://github.com/bluetape4k/bluetape4k-graph/issues/15) runtime comparison benchmark | M | After stable baselines. |
@@ -88,6 +89,9 @@ contracts and backend readiness before widening examples or benchmark lanes:
 
 #133 FalkorDB Ktor README discoverability
   -> English/Korean README tables list FalkorDBKtorGraphAppTest
+
+#134 FalkorDB auto-configuration KDoc language
+  -> public KDoc blocks are English and document bean registration contracts
 ```
 
 ## WIP Limits

--- a/docs/lessons/2026-05-19-issue-134-falkordb-autoconfig-kdoc.md
+++ b/docs/lessons/2026-05-19-issue-134-falkordb-autoconfig-kdoc.md
@@ -1,0 +1,27 @@
+# Issue #134 FalkorDB Auto-Configuration KDoc Language
+
+## Context
+
+Several public KDoc blocks in `GraphFalkorDBAutoConfiguration` were still Korean after the FalkorDB Spring Boot
+auto-configuration changed for the 0.3.x release line.
+
+## Decision
+
+Translate the public bean and nested health configuration KDoc to English and keep the one-line summary plus
+`## Behavior / Contract` style used for durable public API documentation.
+
+## Outcome
+
+The FalkorDB driver, synchronous operations, coroutine operations, virtual-thread adapter, health configuration, and
+health indicator KDoc blocks now describe their registration and ownership contracts in English.
+
+## Verification
+
+- `rg -n "[가-힣]" spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt` returns no Korean text.
+- `./gradlew :bluetape4k-graph-spring-boot:compileKotlin --console=plain --no-daemon` passed.
+- IntelliJ diagnostics were unavailable for this worktree because the IDE MCP did not have the worktree opened as a project; Gradle compile was used as the fallback.
+
+## Future Guard
+
+When Spring Boot auto-configuration bean signatures or nested configuration classes change, check public KDoc language
+in the same diff. For bluetape4k public API KDoc, use English even when adjacent older modules still have Korean KDoc.

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -51,9 +51,13 @@ class GraphFalkorDBAutoConfiguration {
     companion object : KLogging()
 
     /**
-     * FalkorDB Driver 빈. 이미 등록된 Driver 빈이 있으면 재사용한다.
+     * Creates the FalkorDB driver bean.
      *
-     * username이 비어있으면 인증 없이 접속하고, 아니면 username/password 인증을 사용한다.
+     * ## Behavior / Contract
+     * - Skips registration when the application already provides a [com.falkordb.Driver] bean.
+     * - Connects without authentication when [FalkorDBGraphProperties.username] is blank.
+     * - Uses username/password authentication when a username is configured.
+     * - Spring owns this auto-created driver and closes it through the bean destroy method.
      */
     @Bean(name = ["falkordbDriver"], destroyMethod = "close")
     @ConditionalOnMissingBean(com.falkordb.Driver::class)
@@ -67,7 +71,11 @@ class GraphFalkorDBAutoConfiguration {
     }
 
     /**
-     * FalkorDB 기반 [GraphOperations] 빈.
+     * Creates the synchronous FalkorDB [GraphOperations] bean.
+     *
+     * ## Behavior / Contract
+     * - Skips registration when another [GraphOperations] bean already exists.
+     * - Uses the configured FalkorDB graph name from [FalkorDBGraphProperties.graphName].
      */
     @Bean
     @ConditionalOnMissingBean(GraphOperations::class)
@@ -75,7 +83,12 @@ class GraphFalkorDBAutoConfiguration {
         FalkorDBGraphOperations(driver, props.graphName)
 
     /**
-     * FalkorDB 기반 [GraphSuspendOperations] 빈 (코루틴).
+     * Creates the coroutine FalkorDB [GraphSuspendOperations] bean.
+     *
+     * ## Behavior / Contract
+     * - Skips registration when another [GraphSuspendOperations] bean already exists.
+     * - Registers by default and can be disabled with `bluetape4k.graph.falkordb.register-suspend=false`.
+     * - Uses the configured FalkorDB graph name from [FalkorDBGraphProperties.graphName].
      */
     @Bean
     @ConditionalOnMissingBean(GraphSuspendOperations::class)
@@ -89,7 +102,13 @@ class GraphFalkorDBAutoConfiguration {
         FalkorDBGraphSuspendOperations(driver, props.graphName)
 
     /**
-     * Virtual Thread 기반 [GraphVirtualThreadOperations] 빈.
+     * Creates the virtual-thread [GraphVirtualThreadOperations] adapter bean.
+     *
+     * ## Behavior / Contract
+     * - Skips registration when another [GraphVirtualThreadOperations] bean already exists.
+     * - Registers by default and can be disabled with `bluetape4k.graph.falkordb.register-virtual-thread=false`.
+     * - Depends on the synchronous [GraphOperations] bean supplied to this adapter.
+     * - Adapts the synchronous [GraphOperations] bean without changing the underlying FalkorDB driver ownership.
      */
     @Bean
     @ConditionalOnMissingBean(GraphVirtualThreadOperations::class)
@@ -103,8 +122,11 @@ class GraphFalkorDBAutoConfiguration {
         ops.asVirtualThread()
 
     /**
-     * Actuator HealthIndicator — nested class로 격리.
-     * Actuator 미사용 앱에서 `NoClassDefFoundError` 방지.
+     * Health indicator configuration for the FalkorDB backend.
+     *
+     * ## Behavior / Contract
+     * - Loads only when Spring Boot Actuator's `HealthIndicator` type is present.
+     * - Keeps Actuator-only bean signatures isolated from applications that do not use Actuator.
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])
@@ -113,9 +135,12 @@ class GraphFalkorDBAutoConfiguration {
         companion object : KLogging()
 
         /**
-         * FalkorDB 연결 상태를 확인하는 HealthIndicator 빈.
+         * Creates the FalkorDB health indicator bean.
          *
-         * `__health__` 그래프에 `RETURN 1` 쿼리를 실행하여 연결 상태를 확인한다.
+         * ## Behavior / Contract
+         * - Skips registration when a bean named `falkordbHealthIndicator` already exists.
+         * - Runs `RETURN 1` against the `__health__` graph to verify driver connectivity.
+         * - Reports `UP` with the `backend=falkordb` detail on success and `DOWN` with the thrown exception on failure.
          */
         @Bean
         @ConditionalOnMissingBean(name = ["falkordbHealthIndicator"])


### PR DESCRIPTION
Fixes #134.

## Summary

- Translate the public `GraphFalkorDBAutoConfiguration` KDoc blocks to English.
- Keep one-line summary plus `## Behavior / Contract` wording for driver, operations, virtual-thread adapter, health config, and health indicator contracts.
- Update `WIP.md` and add a lesson for auto-configuration KDoc language checks.

## Verification

- `rg -n "[가-힣]" spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt` returned no matches.
- `./gradlew :bluetape4k-graph-spring-boot:compileKotlin --console=plain --no-daemon` passed.
- `git diff --check HEAD~1 HEAD` passed.
- IntelliJ diagnostics were unavailable because this worktree is not open in the IDE MCP; Gradle compile was used as fallback.

## Review

- Codex review: no P0/P1 findings.
- Claude review: NO P0/P1 FINDINGS.
- Claude P3 observation about virtual-thread KDoc dependency wording was fixed and re-reviewed as resolved.
