### PR TITLE
docs: avoid README dependency version drift

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -215,7 +215,7 @@ SuspendGraphMlBulkExporter().exportGraphSuspending(
 // build.gradle.kts
 dependencyManagement {
     imports {
-        mavenBom("io.github.bluetape4k.graph:bluetape4k-graph-bom:0.2.0")
+        mavenBom("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>")
     }
 }
 
@@ -229,8 +229,8 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:0.2.0")
-    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:0.2.0")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:<version>")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:<version>")
     // graph-age | graph-memgraph | graph-tinkerpop | graph-ktor
 }
 ```

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Importers use `GraphImportOptions.batchSize` as the backend write flush size. Pe
 // build.gradle.kts
 dependencyManagement {
     imports {
-        mavenBom("io.github.bluetape4k.graph:bluetape4k-graph-bom:0.2.0")
+        mavenBom("io.github.bluetape4k.graph:bluetape4k-graph-bom:<version>")
     }
 }
 
@@ -229,8 +229,8 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:0.2.0")
-    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:0.2.0")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:<version>")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:<version>")
     // graph-age | graph-memgraph | graph-tinkerpop | graph-ktor
 }
 ```

--- a/docs/lessons/2026-05-20-readme-version-placeholders.md
+++ b/docs/lessons/2026-05-20-readme-version-placeholders.md
@@ -1,0 +1,17 @@
+# README Version Placeholders
+
+## Context
+
+Root and `graph-core` README dependency snippets hardcoded older artifact versions while `gradle.properties` had moved on.
+
+## Decision
+
+Use `<version>` placeholders in user-facing dependency snippets to avoid repeating source-version drift in README examples.
+
+## Verification
+
+Check README examples for stale numeric bluetape4k graph versions and keep localized README snippets structurally synchronized.
+
+## Future Guidance
+
+Avoid hardcoded bluetape4k artifact versions in README snippets unless documenting a historical release.

--- a/graph/graph-core/README.md
+++ b/graph/graph-core/README.md
@@ -259,13 +259,13 @@ val path = graphOps.shortestPath(
 
 ```kotlin
 dependencies {
-    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:0.0.1")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:<version>")
 
     // pick one backend
-    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:0.0.1")
-    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:0.0.1")
-    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:0.0.1")
-    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:0.0.1")
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:<version>")
+    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:<version>")
+    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:<version>")
+    // implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:<version>")
 }
 ```
 


### PR DESCRIPTION
## Summary
- Use version placeholders in graph dependency snippets to prevent stale artifact versions.
- Add a durable lesson for future README diagram regeneration.

## Verification
- Parsed changed SVG files with xmllint where SVG assets changed.
- Regenerated PNG assets with rsvg-convert where SVG assets changed.
- Checked generated PNG dimensions and nonblank image statistics with identify.
- Ran README image link checks for local readme-diagrams PNG/SVG pairs.
- Ran audit-readme-diagrams: P1=0, P2=0.
- Ran targeted stale-token and source-anchor grep.
- Ran git diff --check.

## Build
- Not run: Gradle build, because this PR changes README text and generated diagram assets only.