### PR TITLE
[build] Sync Fory catalog upgrade

### DIFF
--- a/docs/lessons/2026-05-20-dependency-catalog-upgrades.md
+++ b/docs/lessons/2026-05-20-dependency-catalog-upgrades.md
@@ -1,0 +1,18 @@
+# Dependency Catalog Upgrades
+
+## Context
+
+`bluetape4k-dependencies` folded the Apache Fory Dependabot PRs into the
+central dependency upgrade batch.
+
+## Decision
+
+Materialize the central Fory Kotlin catalog version in this repository.
+
+## Outcome
+
+`gradle/libs.versions.toml` now carries Fory Kotlin `0.17.0`.
+
+## Verification
+
+- `./gradlew build -x test --no-daemon`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -172,7 +172,7 @@ findbugs = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }  # 
 guava = { module = "com.google.guava:guava", version = "33.6.0-jre" }  # https://mvnrepository.com/artifact/com.google.guava/guava
 
 kryo5 = { module = "com.esotericsoftware:kryo", version = "5.6.2" }  # https://mvnrepository.com/artifact/com.esotericsoftware/kryo
-fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.15.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
+fory-kotlin = { module = "org.apache.fory:fory-kotlin", version = "0.17.0" }  # https://mvnrepository.com/artifact/org.apache.fory/fory-kotlin
 
 # Spring Boot
 spring-boot4-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot4" }


### PR DESCRIPTION
## Summary

Refs bluetape4k/bluetape4k-dependencies#51
Refs bluetape4k/bluetape4k-dependencies#53

- Materialize Fory Kotlin 0.17.0 from the central catalog.
- Add a catalog-upgrade lesson.

## Validation

- `./gradlew build -x test --no-daemon`