### PR TITLE
Prepare graph 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-22
+
 ### Added
 
 - **graph-io backed domain example sample loaders**: fraud detection, recommendation, and knowledge graph examples now include bundled CSV fixtures plus sync/suspend sample dataset loaders, with TinkerGraph smoke coverage and English/Korean README import flows ([#111](https://github.com/bluetape4k/bluetape4k-graph/issues/111)).
+- **graph benchmark evidence program**: added backend, graph-io, runtime-model, workload-shape, sustained-write, production API model, and weighted shortest-path benchmark lanes with normalized reports and README chart assets ([#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14), [#15](https://github.com/bluetape4k/bluetape4k-graph/issues/15), [#41](https://github.com/bluetape4k/bluetape4k-graph/issues/41), [#188](https://github.com/bluetape4k/bluetape4k-graph/issues/188), [#189](https://github.com/bluetape4k/bluetape4k-graph/issues/189), [#190](https://github.com/bluetape4k/bluetape4k-graph/issues/190), [#191](https://github.com/bluetape4k/bluetape4k-graph/issues/191), [#192](https://github.com/bluetape4k/bluetape4k-graph/issues/192), [#193](https://github.com/bluetape4k/bluetape4k-graph/issues/193), [#196](https://github.com/bluetape4k/bluetape4k-graph/issues/196), [#197](https://github.com/bluetape4k/bluetape4k-graph/issues/197), [#198](https://github.com/bluetape4k/bluetape4k-graph/issues/198), [#199](https://github.com/bluetape4k/bluetape4k-graph/issues/199), [#201](https://github.com/bluetape4k/bluetape4k-graph/issues/201)).
+- **graph-spring-boot FalkorDB nightly coverage**: full-nightly CI now covers the FalkorDB Spring Boot auto-configuration path with a live container smoke test ([#126](https://github.com/bluetape4k/bluetape4k-graph/issues/126)).
 
 ### Fixed
 
@@ -17,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FalkorDB suspend graph existence checks propagate coroutine cancellation**: `FalkorDBGraphSuspendOperations.graphExists()` now rethrows `CancellationException` instead of converting cancellation into `false`, while preserving the existing fallback for ordinary driver failures ([#156](https://github.com/bluetape4k/bluetape4k-graph/issues/156)).
 - **Neo4j suspend transactions no longer bridge through `runBlocking`**: `Neo4jGraphSuspendOperations.suspendTransaction()` now uses Neo4j reactive transactions, preserves rollback/cleanup semantics, and materializes returned transaction `Flow` values before commit ([#158](https://github.com/bluetape4k/bluetape4k-graph/issues/158)).
 - **AGE, Memgraph, and TinkerGraph suspend transactions no longer bridge through `runBlocking`**: AGE now uses Exposed suspended transactions with a native suspend transaction scope, Memgraph uses reactive Bolt transactions, and TinkerGraph uses a suspend-aware rollback snapshot path. Cancellation rollback and returned transaction `Flow` materialization are covered by targeted tests ([#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160)).
+- **FalkorDB Ktor example teardown closes its driver**: the example test now closes the caller-owned driver after the PER_CLASS test lifecycle completes ([#135](https://github.com/bluetape4k/bluetape4k-graph/issues/135)).
+
+### Changed
+
+- Aligned release dependencies with `io.github.bluetape4k:bluetape4k-bom:1.9.0` and the latest published `io.github.bluetape4k:bluetape4k-dependencies:1.0.0`.
+- Kept leaf Dependabot scoped to GitHub Actions and made Detekt the PR quality gate while Kover remains report-only ([#18](https://github.com/bluetape4k/bluetape4k-graph/issues/18), [#19](https://github.com/bluetape4k/bluetape4k-graph/issues/19)).
+- Audited `graph-ktor` and examples against Ktor 3.5.0 with no API changes required ([#127](https://github.com/bluetape4k/bluetape4k-graph/issues/127)).
+- Added FalkorDB Ktor example discoverability to English and Korean README module tables and converted public FalkorDB auto-configuration KDoc to English ([#133](https://github.com/bluetape4k/bluetape4k-graph/issues/133), [#134](https://github.com/bluetape4k/bluetape4k-graph/issues/134)).
 
 ---
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,105 +1,55 @@
 # WIP - bluetape4k-graph
 
-Snapshot: 2026-05-19 KST
+Snapshot: 2026-05-22 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 6 issues; 5 remain after #134 closes through this work.
+Open count: 1 issue.
 
-## Refresh Notes
+## Recently Completed
 
-Verified with `gh` on 2026-05-19 KST.
-
-- qmd was queried first for prior graph lessons, specs, plans, and follow-ups.
-- Existing issues #156, #157, and #158 were unassigned; they are now assigned to `debop`.
-- New issue registered from this audit:
-  - [#160](https://github.com/bluetape4k/bluetape4k-graph/issues/160) - `bug: AGE, Memgraph, and TinkerGraph suspendTransaction still bridge through runBlocking`
-- PR #159 (`chore: refresh WIP snapshot - 2026-05-18`) is already merged, so this file reflects the current post-merge GitHub state.
-- Pre-existing local change `gradlew.bat` was not touched.
-- Issues #18 and #19 are handled by the CI quality-gate and dependency-governance refresh:
-  - CI now blocks on Detekt in the PR build job while Kover remains report-only.
-  - Leaf Dependabot stays scoped to GitHub Actions; Gradle/Maven library updates remain centralized in `bluetape4k-dependencies`.
-- Issue #126 is handled by adding a full-nightly Spring Boot FalkorDB Testcontainers step and a gated
-  `@SpringBootTest` that verifies the auto-configuration path against a live FalkorDB container.
-- Issue #158 is handled by moving Neo4j suspend transactions to the reactive transaction API, keeping
-  rollback/cleanup semantics, and materializing returned transaction `Flow` values before commit.
-- Issue #160 is handled by removing the remaining AGE, Memgraph, and TinkerGraph `runBlocking`
-  transaction bridges and adding cancellation rollback plus returned `Flow` materialization tests.
-- Issue #156 is handled by rethrowing `CancellationException` from FalkorDB suspend `graphExists()`
-  while preserving the ordinary driver-failure fallback.
-- Issue #157 is handled by replacing FalkorDB/Memgraph schema manager `runCatching {}` ignore
-  helpers with explicit `try/catch` branches that rethrow `CancellationException` before expected
-  already-exists or missing-resource fallbacks.
-- Issue #111 is handled by adding graph-io CSV sample dataset loaders, bundled fixtures, sync/suspend
-  TinkerGraph smoke coverage, English/Korean README import flows, and release notes.
-- Issue #127 is handled by auditing `graph-ktor` and `ktor-graph-examples` against Ktor 3.5.0:
-  the latest stable 3.x BOM is already used, compile output has zero Ktor deprecation warnings, and
-  the targeted Ktor plugin/example tests pass without code changes.
-- Issue #135 is handled by closing the caller-owned FalkorDB driver in
-  `FalkorDBKtorGraphAppTest` after the PER_CLASS test lifecycle completes.
-- Issue #133 is handled by adding the FalkorDB-backed Ktor `GraphPlugin` smoke example to the
-  English and Korean README example module tables.
-- Issue #134 is handled by converting the public `GraphFalkorDBAutoConfiguration` KDoc blocks
-  for driver, operations, virtual-thread adapter, and health indicator beans to English.
+- The 0.4.0 release gate is clear. Milestones `0.3.1` and `0.4.0` both have
+  zero open issues on GitHub.
+- Coroutine cancellation and suspend transaction correctness work is merged:
+  #156, #157, #158, and #160.
+- FalkorDB Spring Boot/Ktor readiness and documentation work is merged:
+  #126, #127, #133, #134, and #135.
+- Graph benchmark and self-improve evidence lanes are merged:
+  #14, #15, #41, #188, #189, #190, #191, #192, #193, #196, #197, #198, #199,
+  and #201.
+- Domain example sample loaders are merged through #111.
 
 ## Current Direction
 
-0.3.0 is released. The next work should stabilize coroutine/cancellation
-contracts and backend readiness before widening examples or benchmark lanes:
+Prepare and publish `0.4.0`.
 
-1. Return to Neptune testability research (#113) before the backlog backend epic (#30).
-2. Keep documentation-only cleanup behind backend-readiness blockers unless it reduces migration risk.
-3. Keep benchmark work behind stable backend readiness and CI signal quality.
+The repository already contains the 0.4.0 benchmark/self-improve work on
+`develop`, so publishing a separate `0.3.1` tag from the same head would create
+duplicate patch/minor artifacts with the same code. Treat 0.4.0 as the next
+release line and keep new backend work out until the release is complete.
 
 ## Priority Queue
 
 | Priority | Issue | Difficulty | Notes |
 |---|---|---:|---|
 | P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
-| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113. |
-| P4 | [#14](https://github.com/bluetape4k/bluetape4k-graph/issues/14) backend JMH benchmark | M | After CI gates settle. |
-| P4 | [#15](https://github.com/bluetape4k/bluetape4k-graph/issues/15) runtime comparison benchmark | M | After stable baselines. |
-| P4 | [#41](https://github.com/bluetape4k/bluetape4k-graph/issues/41) weighted path benchmark | S | After merged #40 baseline. |
+| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113/research-quality evidence. |
 
 ## Dependency Map
 
 ```text
-#156 FalkorDBGraphSuspendOperations.graphExists() CancellationException fix
-  -> suspend graphExists now rethrows coroutine cancellation
-#157 FalkorDB/MemgraphGraphSchemaManager broad runCatching fix
-  -> correctness baseline for graph-falkordb and graph-memgraph
-
-#158 Neo4j suspendTransaction runBlocking bridge
-#160 AGE / Memgraph / TinkerGraph suspendTransaction runBlocking bridge
-  -> suspend-to-blocking transaction bridges removed consistently
-  -> cancellation rollback and returned Flow materialization covered by tests
-
 #113 Neptune local testability research
   -> #30 Neptune backend
 
-#18 CI quality gates
-#19 dependency automation
+#156/#157 cancellation fixes
+#158/#160 suspend transaction fixes
+  -> 0.4.0 correctness baseline
 
-#111 graph-io backed sample dataset loaders
-  -> improved examples onboarding
-
-#127 Ktor API hygiene audit
-  -> no Ktor deprecation or version work needed on 3.5.0
-
-#135 FalkorDB Ktor example teardown
-  -> caller-owned FalkorDB driver is closed after PER_CLASS test lifecycle
-
-#133 FalkorDB Ktor README discoverability
-  -> English/Korean README tables list FalkorDBKtorGraphAppTest
-
-#134 FalkorDB auto-configuration KDoc language
-  -> public KDoc blocks are English and document bean registration contracts
+#14/#15/#41/#188/#189/#190/#191/#192/#193/#196/#197/#198/#199/#201
+  -> 0.4.0 benchmark evidence baseline
 ```
 
 ## WIP Limits
 
 | Lane | Limit | Current next |
 |---|---:|---|
-| Cancellation correctness | 1 | #157 merged; idle unless a new cancellation bug appears. |
-| Suspend transaction safety | 1 | #160 merged; keep this lane idle unless a new transaction-safety issue appears. |
-| Research / backend readiness | 1 | `#113` before `#30`. |
-| CI / automation | 1 | Keep Detekt/Kover/Dependabot governance stable; open focused follow-up issues for new gates. |
-| Examples / benchmarks | 1 | #111 merged; idle unless another adoption issue is selected. |
+| Research / backend readiness | 1 | #113 before #30. |
+| Release | 1 | Finish 0.4.0 release before starting more graph feature work. |

--- a/docs/lessons/2026-05-22-graph-0-4-0-release-prep.md
+++ b/docs/lessons/2026-05-22-graph-0-4-0-release-prep.md
@@ -1,0 +1,28 @@
+# Graph 0.4.0 Release Prep
+
+## Context
+
+Graph `develop` contains both the closed `0.3.1` milestone work and the closed
+`0.4.0` benchmark/self-improve work. Publishing `0.3.1` from the current head
+would duplicate the same code under both patch and minor versions.
+
+## Decision
+
+Prepare `bluetape4k-graph` as the next minor release, `0.4.0`, and align the
+release with the published bluetape4k 1.9.0 BOM.
+
+## Outcome
+
+Release metadata, dependency catalog, CHANGELOG, WIP, and release-prep lesson
+were updated for the 0.4.0 release gate.
+
+## Verification
+
+Verified the Gradle release version, workflow syntax, publication POM generation,
+stale/snapshot POM absence, build, and local Maven publication before opening
+the release PR.
+
+## Future Notes
+
+Do not publish a separate 0.3.1 release from the same commit range. Start Neptune
+research (#113) only after 0.4.0 is released.

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,5 +70,5 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # project version
 #
 projectGroup=io.github.bluetape4k.graph
-baseVersion=0.3.1
-snapshotVersion=-SNAPSHOT
+baseVersion=0.4.0
+snapshotVersion=

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.8.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-dependencies = "1.0.1-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k = "1.9.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k-dependencies = "1.0.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- Prepare bluetape4k-graph 0.4.0 release metadata after the benchmark and self-improve milestones cleared.
- Align release dependencies with io.github.bluetape4k:bluetape4k-bom:1.9.0 and the latest published bluetape4k-dependencies:1.0.0.
- Update CHANGELOG, WIP, and the release-prep lesson for the 2026-05-22 release gate.

## Release Decision
- develop already contains both closed 0.3.1 and 0.4.0 milestone work.
- Publishing 0.3.1 from the same head would duplicate the same code under patch and minor versions, so this PR prepares the next minor release, 0.4.0.

## Verification
- ./gradlew properties --no-configuration-cache --no-daemon --quiet
- actionlint .github/workflows/release.yml .github/workflows/publish-snapshot.yml .github/workflows/nightly-tests.yml .github/workflows/ci.yml .github/workflows/examples.yml
- ./gradlew clean generatePomFileForBluetapeGraphPublication --no-daemon --no-configuration-cache --no-build-cache
- POM scan for SNAPSHOT/examples/demo/benchmark/stale BOMs
- ./gradlew build -x test -x koverVerify publishToMavenLocal --no-daemon --no-configuration-cache --no-build-cache

## Release Gate
- 0.4.0 milestone is clear.
- Only backlog issue #30 remains open; it is blocked by Neptune testability research #113.
- Tag publish remains pending after PR CI and merge.