### PR TITLE
chore: align bluetape4k-dependencies 1.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 bluetape4k = "1.9.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-dependencies = "1.0.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k-dependencies = "1.0.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- Align shared bluetape4k-dependencies catalog version with the released 1.0.1 train.

## Verification
- ./gradlew help --no-daemon
- scripts/sync-shared-versions.py --workspace .. --check --summary from bluetape4k-dependencies

## Notes
- This is a downstream sync-only change required by the dependencies repo shared-version gate.