### PR TITLE
build: sync dependencies 1.1.1 catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 bluetape4k = "1.9.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-dependencies = "1.0.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k-dependencies = "1.1.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 bluetape4k = "1.9.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-dependencies = "1.1.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k-dependencies = "1.1.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary

- update `bluetape4k-dependencies` from 1.0.1 to the 1.1.1 release catalog
- consume the patched publishable BOM surface that supersedes 1.1.0

## Verification

- CI rerun on this PR branch
