### PR TITLE
build: prepare graph 0.4.1 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -318,7 +318,6 @@ subprojects {
 
         imports {
             mavenBom(rootLibs.bluetape4k.bom.get().toString())
-            mavenBom(rootLibs.bluetape4k.dependencies.get().toString())
             mavenBom(rootLibs.spring.boot4.dependencies.get().toString())
 
             mavenBom(rootLibs.feign.bom.get().toString())

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,8 +70,7 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # project version
 #
 projectGroup=io.github.bluetape4k.graph
-baseVersion=0.4.0
+baseVersion=0.4.1
 snapshotVersion=
 
-# Shared bluetape4k ecosystem catalog/BOM version
-bluetape4kDependenciesVersion=1.1.1
+# Shared bluetape4k ecosystem catalog version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.9.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-dependencies = "1.1.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-dependencies
+bluetape4k = "1.9.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
@@ -87,7 +86,6 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.
 
 # bluetape4k
 bluetape4k-bom = { module = "io.github.bluetape4k:bluetape4k-bom", version.ref = "bluetape4k" }
-bluetape4k-dependencies = { module = "io.github.bluetape4k:bluetape4k-dependencies", version.ref = "bluetape4k-dependencies" }
 bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core", version.ref = "bluetape4k" }
 bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines", version.ref = "bluetape4k" }
 bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging", version.ref = "bluetape4k" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,41 @@ pluginManagement {
 
 val baseProjectName = "bluetape4k"
 
-val bluetape4kDependenciesVersion = providers.gradleProperty("bluetape4kDependenciesVersion").get()
+val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
+    .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
+    .orElse("develop")
+    .get()
+
+fun resolveBluetape4kDependenciesCatalogFile(): File {
+    providers.gradleProperty("bluetape4kDependenciesCatalogPath")
+        .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_PATH"))
+        .orNull
+        ?.let(::file)
+        ?.let { return it }
+
+    listOf(
+        "../bluetape4k-dependencies/gradle/libs.versions.toml",
+        "bluetape4k-dependencies/gradle/libs.versions.toml",
+    ).map(::file).firstOrNull { it.isFile }?.let { return it }
+
+    val catalogFile = file(".gradle/bluetape4k-dependencies/libs.versions.toml")
+    if (!catalogFile.isFile) {
+        catalogFile.parentFile.mkdirs()
+        val catalogUrl =
+            "https://raw.githubusercontent.com/bluetape4k/bluetape4k-dependencies/$bluetape4kDependenciesCatalogRef/gradle/libs.versions.toml"
+        uri(catalogUrl).toURL().openStream().use { input ->
+            catalogFile.outputStream().use { output -> input.copyTo(output) }
+        }
+    }
+    return catalogFile
+}
+
+val bluetape4kDependenciesCatalogFile = resolveBluetape4kDependenciesCatalogFile()
+
+require(bluetape4kDependenciesCatalogFile.isFile) {
+    "bluetape4k-dependencies catalog not found: $bluetape4kDependenciesCatalogFile. " +
+        "Checkout bluetape4k-dependencies at the release-train tag or set bluetape4kDependenciesCatalogPath."
+}
 
 dependencyResolutionManagement {
     repositories {
@@ -21,7 +55,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("bt4k") {
-            from("io.github.bluetape4k:bluetape4k-version-catalog:$bluetape4kDependenciesVersion")
+            from(files(bluetape4kDependenciesCatalogFile))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Set graph release metadata to 0.4.1.
- Remove the final dependencies BOM shortcut from library release metadata.
- Resolve shared build aliases from the bluetape4k-dependencies catalog source.

## Validation
- ./gradlew help -Pbluetape4kDependenciesCatalogPath=<dependencies>/gradle/libs.versions.toml
- git diff --check

## Release Notes
- Build metadata preparation for the 0.4.1 release train.

## Release Order
- Release after bluetape4k-projects 1.9.1 is available.