### PR TITLE
chore: open snapshot validation line

### DIFF
--- a/docs/lessons/2026-05-24-snapshot-validation-line.md
+++ b/docs/lessons/2026-05-24-snapshot-validation-line.md
@@ -1,0 +1,21 @@
+# Snapshot Validation Line
+
+## Context
+
+After the previous release, snapshot validation needed the repository reopened
+on the next development line while consuming the matching upstream bluetape4k
+snapshot.
+
+## Decision
+
+Set `baseVersion=0.4.2`, keep `snapshotVersion=` empty, and consume
+`bluetape4k-bom:1.9.2-SNAPSHOT`.
+
+## Outcome
+
+The repository can publish `0.4.2-SNAPSHOT` through `publish-snapshot.yml`
+without checking a snapshot suffix into `gradle.properties`.
+
+## Verification
+
+Pending in the snapshot validation train.

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # project version
 #
 projectGroup=io.github.bluetape4k.graph
-baseVersion=0.4.1
+baseVersion=0.4.2
 snapshotVersion=
 
 # Shared bluetape4k ecosystem catalog version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.9.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.9.2-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- Open the post-release snapshot validation line.
- Keep snapshotVersion empty in git so publish-snapshot injects -SNAPSHOT.
- Consume bluetape4k 1.9.2-SNAPSHOT for downstream validation.

## Verification
- git diff --check