### PR TITLE
docs: refresh benchmark report links after 0.4.0 release

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -213,7 +213,7 @@ SuspendGraphMlBulkExporter().exportGraphSuspending(
 | `graph-io-graphml` | GraphML XML (StAX) | [README](graph-io/graphml/README.ko.md) |
 | `graph-okio` | OkIO 기반 통합 어댑터 — 세그먼트 스트리밍, 압축 체이닝, FakeFileSystem 지원, DAEAD chunk encryption | [README](graph-io/okio/README.ko.md) |
 
-> **벤치마크 결과**: [2026-04-18 graph-io 벌크 I/O 결과](docs/benchmark/2026-04-18-graph-io-bulk-results.md)
+> **벤치마크 결과 (graph-io)**: [2026-04-18 graph-io 벌크 I/O 결과](docs/benchmark/2026-04-18-graph-io-bulk-results.md) — 전체 0.4.0 결과셋(graph-db 백엔드 비교, 쓰기 ingestion, 도메인 워크로드, API 모델 비교)은 [벤치마크 의사결정 가이드](benchmark/README.md)를 참고하세요.
 
 ---
 
@@ -374,3 +374,4 @@ GitHub Actions는 전용 `Examples` workflow도 실행한다. 이 workflow는 �
 ## 문서
 
 - [Graph Database 장단점 및 선택 가이드](docs/graphdb-tradeoffs.md) — GraphDB의 장단점과 bluetape4k-graph 백엔드(Neo4j, Memgraph, AGE, TinkerPop) 선택 가이드
+- [벤치마크 의사결정 가이드](benchmark/README.md) — 실측 데이터 기반 백엔드 선택 가이드: graph-db 백엔드 비교(small/medium/large), 지속 쓰기 ingestion, 도메인 워크로드, 10k 쓰기 ingestion, API 모델(Sync / Virtual Thread / Coroutine) 비교 — 0.4.0 릴리즈 벤치마크 결과(2026년 5월) 기준

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Importers use `GraphImportOptions.batchSize` as the backend write flush size. Pe
 | `graph-io-graphml` | GraphML XML (StAX) | [README](graph-io/graphml/README.md) |
 | `graph-okio` | OkIO-based adapter — segment streaming, compression chaining, FakeFileSystem support, and DAEAD chunk encryption | [README](graph-io/okio/README.md) |
 
-> **Benchmark results**: [2026-04-18 graph-io bulk I/O results](docs/benchmark/2026-04-18-graph-io-bulk-results.md)
+> **Benchmark results (graph-io)**: [2026-04-18 graph-io bulk I/O results](docs/benchmark/2026-04-18-graph-io-bulk-results.md) — see [Benchmark Decision Guide](benchmark/README.md) for the full 0.4.0 result set including graph-db backend, write ingestion, domain workload, and API model comparisons.
 
 ---
 
@@ -374,3 +374,4 @@ Concrete classes only need to implement `ops` (`GraphOperations` or `GraphSuspen
 ## Documentation
 
 - [Graph Database Pros & Cons and Selection Guide](docs/graphdb-tradeoffs.md) — GraphDB trade-offs and backend selection guide for bluetape4k-graph (Neo4j, Memgraph, AGE, TinkerPop)
+- [Benchmark Decision Guide](benchmark/README.md) — Backend selection guide with measured evidence: graph-db backend comparison (small/medium/large), sustained write ingestion, domain workloads, 10k write ingestion, and API model (Sync / Virtual Thread / Coroutine) results from the 0.4.0 release benchmark run (May 2026)

--- a/docs/lessons/2026-05-25-benchmark-report-refresh-0.4.1.md
+++ b/docs/lessons/2026-05-25-benchmark-report-refresh-0.4.1.md
@@ -1,0 +1,47 @@
+# Benchmark Report Refresh — 0.4.1 Patch (Issue #214)
+
+**Date**: 2026-05-25
+**Issue**: [#214](https://github.com/bluetape4k/bluetape4k-graph/issues/214)
+**Milestone**: 0.4.1
+
+## Context
+
+0.4.0 added a comprehensive benchmark evidence program (`graph-db` backend comparison,
+sustained write ingestion, domain workloads, 10k write ingestion, and API model benchmarks)
+with results stored under `docs/benchmark/2026-05-21-*` and a full decision guide at
+`benchmark/README.md`.
+
+After the 0.4.0 release, the root `README.md` and `README.ko.md` only linked the
+original `2026-04-18-graph-io-bulk-results.md` from the graph-io section and had no
+pointer to the broader benchmark decision guide.
+
+## Decision
+
+1. Updated the graph-io section benchmark link in `README.md` and `README.ko.md` to
+   clarify it is graph-io-specific and to add a pointer to `benchmark/README.md` for
+   the full result set.
+2. Added a `benchmark/README.md` entry to the `## Documentation` / `## 문서` sections
+   in both README files so library users can discover the decision guide from the root.
+
+## What Was NOT Changed
+
+- No benchmark implementation changes.
+- `docs/benchmark/2026-04-18-graph-io-bulk-results.md` is still valid; it remains the
+  most recent graph-io bulk I/O report (no graph-io benchmark was re-run in 0.4.0).
+- `benchmark/README.md` already contained the full 0.4.0 result set and required no edits.
+
+## Outcome
+
+- `git diff --check`: passes (no trailing whitespace or line-ending issues).
+- All referenced files verified to exist.
+- README locale set (`README.md` + `README.ko.md`) synchronized.
+
+## Future Guidance
+
+When a new benchmark run is completed, update the following together:
+1. Add new `docs/benchmark/YYYY-MM-DD-*.md` and `*.json` result files.
+2. Update `benchmark/README.md` evidence base table and raw artifact list.
+3. Update root `README.md` and `README.ko.md` links if the graph-io-specific link
+   or the Documentation section pointer becomes stale.
+4. If new chart images are generated, follow `benchmark/README.md` image embedding
+   conventions and store assets under `docs/images/readme-charts/`.


### PR DESCRIPTION
## Summary

Refreshes benchmark report links and documentation pointers in the root README files after the 0.4.0 release, per milestone 0.4.1 issue #214.

## Changes

### `README.md` and `README.ko.md`

- **graph-io section (line 216)**: Updated the benchmark result link to clarify it is graph-io-specific and added a pointer to `benchmark/README.md` for the full 0.4.0 result set (graph-db backend comparison, sustained write ingestion, domain workloads, 10k write ingestion, and API model comparisons).
- **Documentation section**: Added a `[Benchmark Decision Guide](benchmark/README.md)` entry so library users can discover the decision guide from the root README.

### `docs/lessons/2026-05-25-benchmark-report-refresh-0.4.1.md`

Lessons doc capturing the rationale, what was changed, what was intentionally left unchanged, and future guidance for keeping benchmark links fresh.

## What Was NOT Changed

- No benchmark implementation changes.
- `docs/benchmark/2026-04-18-graph-io-bulk-results.md` remains valid (most recent graph-io bulk I/O report; no graph-io benchmark was re-run in 0.4.0).
- `benchmark/README.md` already contained the full 0.4.0 result set and required no edits.

## Verification

```
git diff --check   # passes — no trailing whitespace or line-ending issues
```

All referenced files verified to exist:
- `docs/benchmark/2026-04-18-graph-io-bulk-results.md` ✅
- `benchmark/README.md` ✅

## Acceptance Criteria (Issue #214)

| Criterion | Status |
|-----------|--------|
| Benchmark report links match current release state | ✅ |
| Stale README/chart references refreshed | ✅ |
| `git diff --check` passes | ✅ |

Closes #214