### PR TITLE
chore: ignore generated graph output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ replay_pid*
 build/
 !gradle/wrapper/gradle-wrapper.jar
 
+# Generated graph outputs
+output/
+outputs/
+
 # AI - 임시 상태/로그 제외, 계획/설정은 추적
 .claude/settings.local.json
 .cluade/worktrees/

--- a/docs/lessons/2026-05-25-ignore-graph-outputs.md
+++ b/docs/lessons/2026-05-25-ignore-graph-outputs.md
@@ -1,0 +1,19 @@
+# Ignore Graph Outputs
+
+## Context
+
+Local graph runs can create repository-root `output/` or `outputs/`
+directories.
+
+## Decision
+
+Ignore both generated output directories in `.gitignore`.
+
+## Outcome
+
+Generated graph output artifacts no longer appear as untracked source changes.
+
+## Verification
+
+- `git diff --check`
+- `git status --ignored --short` shows `outputs/` as ignored


### PR DESCRIPTION
## Summary
- Ignore repository-root `output/` and `outputs/` generated graph output directories.
- Record a short lesson for future generated artifacts.

## Verification
- `git diff --check`
- `git status --ignored --short` shows `outputs/` ignored

## Notes
- No Gradle build was run because this is ignore-only maintenance.
