### PR TITLE
build: pin graph catalog ref to 2026-05-25-01

### DIFF
--- a/docs/lessons/2026-05-25-catalog-ref-2026-05-25-01.md
+++ b/docs/lessons/2026-05-25-catalog-ref-2026-05-25-01.md
@@ -1,0 +1,27 @@
+# Catalog Ref 2026-05-25-01
+
+## Context
+
+The shared `bluetape4k-dependencies` catalog was retagged as
+`catalog/2026-05-25-01` after a consumer-facing version alias fix.
+
+## Decision
+
+Pin the default `bluetape4kDependenciesCatalogRef` to
+`catalog/2026-05-25-01` instead of floating on `develop`.
+
+## Outcome
+
+Graph snapshot-train builds now resolve the immutable release-train catalog by
+default while still allowing local overrides through
+`bluetape4kDependenciesCatalogRef` or
+`BLUETAPE4K_DEPENDENCIES_CATALOG_REF`.
+
+## Verification
+
+- `./gradlew compileTestKotlin --refresh-dependencies --console=plain -PsnapshotVersion=-SNAPSHOT`
+- `git diff --check`
+
+## Future Guard
+
+Use dated catalog tags for coordinated dependency train updates.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("develop")
+    .orElse("catalog/2026-05-25-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary\n- Pin the default dependency catalog ref to catalog/2026-05-25-01 instead of floating on develop.\n- Add a lesson for the corrected catalog train source.\n\n## Validation\n- ./gradlew compileTestKotlin --refresh-dependencies --console=plain -PsnapshotVersion=-SNAPSHOT\n- git diff --check\n\n## Scheduled Follow-up\n- The 23:00 KST catalog snapshot train job expects develop to contain this ref before dispatching Nightly and snapshot publish.