### PR TITLE
build: consume projects 1.9.2 BOM

### DIFF
--- a/docs/lessons/2026-05-26-projects-1-9-2-bom-handoff.md
+++ b/docs/lessons/2026-05-26-projects-1-9-2-bom-handoff.md
@@ -1,0 +1,21 @@
+# Projects 1.9.2 BOM handoff
+
+## Context
+
+`bluetape4k-projects` 1.9.2 was released and `bluetape4k-bom:1.9.2` is visible
+from Maven Central.
+
+## Decision
+
+Use the stable `bluetape4k-bom` 1.9.2 line for this release-prep branch instead
+of the matching projects snapshot.
+
+## Outcome
+
+The version catalog now resolves `io.github.bluetape4k:bluetape4k-bom` from the
+stable 1.9.2 release while leaving this repository's own release line unchanged.
+
+## Verification
+
+- Maven Central HTTP 200 for `bluetape4k-bom:1.9.2`
+- `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.9.2-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.9.2"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- switch the projects BOM reference from 1.9.2-SNAPSHOT to the released 1.9.2 artifact
- add a release-train handoff lesson
- keep other repository BOM snapshot lines unchanged

## Validation
- Maven Central HTTP 200 for io.github.bluetape4k:bluetape4k-bom:1.9.2
- git diff --check
- ./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache

## Release note
This is the downstream handoff after bluetape4k-projects 1.9.2 was published.