### PR TITLE
chore: align dependencies catalog ref

### DIFF
--- a/docs/lessons/2026-05-26-dependencies-catalog-2026-05-26-01.md
+++ b/docs/lessons/2026-05-26-dependencies-catalog-2026-05-26-01.md
@@ -1,0 +1,21 @@
+# Dependencies Catalog 2026-05-26-01
+
+## Context
+
+`bluetape4k-dependencies` published `catalog/2026-05-26-01` with centralized security dependency lines.
+
+## Decision
+
+Update the downstream default `bluetape4kDependenciesCatalogRef` to the new catalog tag instead of pinning shared external library versions locally.
+
+## Outcome
+
+The repository now resolves shared dependency versions from `catalog/2026-05-26-01` by default.
+
+## Verification
+
+Checked the catalog ref in `settings.gradle.kts`.
+
+## Future Notes
+
+For shared external libraries, update `bluetape4k-dependencies` first, tag the catalog, then move downstream repositories to that tag.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-05-25-01")
+    .orElse("catalog/2026-05-26-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary
- Move the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-05-26-01`.
- Sync downstream shared version aliases from `bluetape4k-dependencies` where applicable.
- Record the catalog handoff lesson for future downstream updates.

## Validation
- `scripts/sync-shared-versions.py --workspace .. --repo <repo> --check --summary`
- `./gradlew -q help`

## Notes
- Shared external library versions remain governed by `bluetape4k-dependencies`; downstream repositories only consume the published catalog tag.
