### PR TITLE
fix: preserve TinkerPop shortest path edges

### DIFF
--- a/docs/lessons/2026-05-26-tinkerpop-shortest-path-edges.md
+++ b/docs/lessons/2026-05-26-tinkerpop-shortest-path-edges.md
@@ -1,0 +1,25 @@
+# TinkerPop Shortest Path Edges
+
+## Context
+
+TinkerPop shortest-path traversals based on `both()` can return vertex-only
+Gremlin paths.
+
+## Decision
+
+Rebuild `GraphPath` results by inserting the connecting edge between consecutive
+vertices so `GraphPath.length` reflects the hop count.
+
+## Outcome
+
+`shortestPath` and `allShortestPaths` now return paths with edge steps for
+TinkerGraph traversal results.
+
+## Verification
+
+Added sync and suspend shortest-path assertions for edge count and path length.
+
+## Future Notes
+
+When mapping Gremlin `Path` values, verify both vertex order and edge steps;
+vertex-only assertions are not enough for path APIs.

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -488,7 +488,8 @@ class TinkerGraphOperations :
             emptyList()
         }
 
-        return paths.firstOrNull()?.let { GremlinRecordMapper.pathToGraphPath(it) }
+        // Post-process: vertex-only paths from both() need edges inserted between consecutive vertices.
+        return paths.firstOrNull()?.let { buildGraphPathWithEdges(it, options.edgeLabel) }
     }
 
     override fun aStarPath(
@@ -527,7 +528,43 @@ class TinkerGraphOperations :
             emptyList()
         }
 
-        return paths.map { GremlinRecordMapper.pathToGraphPath(it) }
+        // Post-process: vertex-only paths from both() need edges inserted between consecutive vertices.
+        return paths.map { buildGraphPathWithEdges(it, options.edgeLabel) }
+    }
+
+    /**
+     * Builds a [GraphPath] from a Gremlin [Path] that contains only vertices (as returned by `both()`).
+     * Looks up the connecting edge between each consecutive vertex pair so that
+     * [GraphPath.length] (edge count) correctly reflects the hop count.
+     */
+    private fun buildGraphPathWithEdges(
+        gremlinPath: org.apache.tinkerpop.gremlin.process.traversal.Path,
+        edgeLabel: String?,
+    ): GraphPath {
+        val vertices = gremlinPath.objects().filterIsInstance<Vertex>()
+        if (vertices.isEmpty()) return GraphPath.EMPTY
+
+        val steps = mutableListOf<PathStep>()
+        steps.add(PathStep.VertexStep(GremlinRecordMapper.vertexToGraphVertex(vertices.first())))
+
+        for (i in 1 until vertices.size) {
+            val fromV = vertices[i - 1]
+            val toVId = vertices[i].id()
+
+            // Find the edge connecting fromV → toV (either direction)
+            val edgeOpt = if (edgeLabel != null) {
+                g.V(fromV.id()).bothE(edgeLabel).toList()
+            } else {
+                g.V(fromV.id()).bothE().toList()
+            }.firstOrNull { e -> e.inVertex().id() == toVId || e.outVertex().id() == toVId }
+
+            if (edgeOpt != null) {
+                steps.add(PathStep.EdgeStep(GremlinRecordMapper.edgeToGraphEdge(edgeOpt)))
+            }
+            steps.add(PathStep.VertexStep(GremlinRecordMapper.vertexToGraphVertex(vertices[i])))
+        }
+
+        return GraphPath(steps)
     }
 
     // -- GraphAlgorithmRepository --

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperationsTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperationsTest.kt
@@ -280,6 +280,8 @@ class TinkerGraphOperationsTest {
         val path = ops.shortestPath(a.id, c.id, PathOptions(edgeLabel = "KNOWS"))
         path.shouldNotBeNull()
         path.vertices.shouldNotBeEmpty()
+        path.edges shouldHaveSize 2
+        path.length shouldBeEqualTo 2
     }
 
     @Test

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperationsTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperationsTest.kt
@@ -399,6 +399,8 @@ class TinkerGraphSuspendOperationsTest {
         val path = ops.shortestPath(a.id, c.id, PathOptions(edgeLabel = "KNOWS"))
         path.shouldNotBeNull()
         path.vertices.shouldNotBeEmpty()
+        path.edges shouldHaveSize 2
+        path.length shouldBeEqualTo 2
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Preserve edge steps when TinkerPop shortest-path traversals return vertex-only Gremlin paths.
- Add sync and suspend shortest-path assertions for edge count and path length.
- Record the TinkerPop path-mapping lesson.

## Validation
- `./gradlew :bluetape4k-graph-tinkerpop:test --tests 'io.bluetape4k.graph.tinkerpop.TinkerGraphOperationsTest' --tests 'io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperationsTest'`

## Notes
- `WIP.md` local planning changes are intentionally excluded from this PR and will be handled separately.
