### PR TITLE
docs: refresh WIP milestone queue

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -1,8 +1,61 @@
 # WIP - bluetape4k-graph
 
-Snapshot: 2026-05-22 KST
+Snapshot: 2026-05-24 KST
 Scope: open GitHub issues assigned to `debop`.
 Open count: 1 issue.
+
+## 2026-05-24 Milestone Refresh
+
+Current evidence: latest tags `v0.3.0`, `v0.1.0`. Milestones `0.3.1` and
+`0.4.0` are complete, `0.4.1` has zero open issues, and backlog has #30 marked
+`invalid,Epic,research`.
+
+| Lane | Candidate milestone | Current candidates | Decision |
+|---|---|---|---|
+| Patch | `0.4.1` | none yet | Keep as the next patch slot only for release fallout, benchmark/report drift, CI failures, or dependency/catalog sync. |
+| Minor | `0.5.0` | revalidate #30 first | Do not schedule Amazon Neptune implementation while #30 is still `invalid`/research. Reopen only after AWS SDK, Testcontainers/localstack feasibility, and API boundary are revalidated. |
+
+Recommended order: keep `0.4.1` empty until a real patch appears; revalidate #30
+as research before creating a `0.5.0` implementation epic.
+
+## New Milestone Queue - 2026-05-24
+
+### New patch milestone `0.4.1`
+
+1. [#214](https://github.com/bluetape4k/bluetape4k-graph/issues/214)
+   `docs: refresh graph benchmark report after 0.4.0 release`
+
+### New minor milestone `0.5.0`
+
+1. [#215](https://github.com/bluetape4k/bluetape4k-graph/issues/215)
+   `research: revalidate Amazon Neptune backend feasibility`
+2. [#216](https://github.com/bluetape4k/bluetape4k-graph/issues/216)
+   `perf: unify AGE and Neo4j benchmark report output`
+3. [#217](https://github.com/bluetape4k/bluetape4k-graph/issues/217)
+   `docs: map graph backend capability matrix into README diagrams`
+
+### Backlog reference
+
+1. [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30)
+   `[Epic] Amazon Neptune 그래프 DB 백엔드 구현 (graph-neptune)` remains backlog
+   research until #215 decides whether to revive it.
+
+## Issue Discovery - 2026-05-24
+
+Patch candidates:
+
+- `docs: refresh graph benchmark report after 0.4.0 release`
+  - Keep patch-scoped: no benchmark implementation change unless current reports
+    fail to reproduce.
+
+Minor candidates:
+
+- `research: revalidate Amazon Neptune backend feasibility` (#30)
+  - Keep as research while #30 is still marked `invalid`.
+- `perf: unify AGE and Neo4j benchmark report output`
+  - Evidence: `scripts/benchmark-neo4j-age.sh` combines benchmark JSON summaries.
+- `docs: map graph backend capability matrix into README diagrams`
+  - Candidate only after benchmark/provider direction is settled.
 
 ## Recently Completed
 

--- a/docs/lessons/2026-05-26-wip-milestone-refresh.md
+++ b/docs/lessons/2026-05-26-wip-milestone-refresh.md
@@ -1,0 +1,21 @@
+# WIP Milestone Refresh
+
+## Context
+
+The local WIP queue had a newer milestone discovery snapshot.
+
+## Decision
+
+Publish the WIP refresh as documentation-only repo planning state.
+
+## Outcome
+
+Patch and minor milestone candidates are captured for future graph work.
+
+## Verification
+
+Reviewed the WIP diff; no runtime files changed.
+
+## Future Notes
+
+Keep WIP planning updates separate from feature implementation PRs.


### PR DESCRIPTION
## Summary
- Refresh `WIP.md` with the 2026-05-24 milestone discovery snapshot.
- Capture patch/minor candidate ordering for future work.
- Record a short lesson to keep WIP planning refreshes separate from implementation PRs.

## Validation
- `git diff --cached --check`

## Notes
- Documentation-only change; no runtime behavior changed.
