### PR TITLE
test: lock graph 0.4.2 evidence paths

### DIFF
--- a/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkScriptContractTest.kt
+++ b/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkScriptContractTest.kt
@@ -1,0 +1,140 @@
+package io.bluetape4k.graph.benchmark
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+
+class BenchmarkScriptContractTest {
+
+    @Test
+    fun `age benchmark wrapper emits one valid json summary line`(@TempDir dir: Path) {
+        val reportRoot = jmhReportRoot(dir, "age")
+        writeJmhReport(
+            reportRoot.resolve("main.json"),
+            """
+            [
+              {"benchmark": "pkg.CreateVertexBenchmark.createVertex", "primaryMetric": {"score": 1.5, "scoreUnit": "ms/op"}},
+              {"benchmark": "pkg.FindVerticesBenchmark.findVertices", "primaryMetric": {"score": 250.0, "scoreUnit": "us/op"}}
+            ]
+            """.trimIndent(),
+        )
+
+        val result = runScript(
+            "benchmark-age.sh",
+            "BENCHMARK_SKIP_RUN" to "true",
+            "BENCHMARK_AGE_REPORT_ROOT" to reportRoot.parent.toString(),
+        )
+
+        result.exitCode shouldBeEqualTo 0
+        result.stdoutLines shouldHaveSingleLineContaining "\"primary\": 875"
+        result.stdoutLines.single() shouldContain "\"createVertex\": 1500"
+        result.stdoutLines.single() shouldContain "\"findVertices\": 250"
+        assertJson(result.stdoutLines.single())
+    }
+
+    @Test
+    fun `neo4j age benchmark wrapper emits combined age and neo4j keys`(@TempDir dir: Path) {
+        val ageRoot = jmhReportRoot(dir, "age")
+        val neo4jRoot = jmhReportRoot(dir, "neo4j")
+        writeJmhReport(
+            ageRoot.resolve("main.json"),
+            """
+            [
+              {"benchmark": "pkg.CreateVertexBenchmark.createVertex", "primaryMetric": {"score": 1.0, "scoreUnit": "ms/op"}}
+            ]
+            """.trimIndent(),
+        )
+        writeJmhReport(
+            neo4jRoot.resolve("main.json"),
+            """
+            [
+              {"benchmark": "pkg.Neo4jCreateVertexBenchmark.createVertex", "primaryMetric": {"score": 2.0, "scoreUnit": "ms/op"}}
+            ]
+            """.trimIndent(),
+        )
+
+        val result = runScript(
+            "benchmark-neo4j-age.sh",
+            "BENCHMARK_SKIP_RUN" to "true",
+            "BENCHMARK_AGE_REPORT_ROOT" to ageRoot.parent.toString(),
+            "BENCHMARK_NEO4J_REPORT_ROOT" to neo4jRoot.parent.toString(),
+        )
+
+        result.exitCode shouldBeEqualTo 0
+        result.stdoutLines shouldHaveSingleLineContaining "\"primary\": 1500"
+        result.stdoutLines.single() shouldContain "\"age_createVertex\": 1000"
+        result.stdoutLines.single() shouldContain "\"neo4j_createVertex\": 2000"
+        assertJson(result.stdoutLines.single())
+    }
+
+    @Test
+    fun `age benchmark wrapper fails when report is missing`(@TempDir dir: Path) {
+        val reportRoot = dir.resolve("missing")
+
+        val result = runScript(
+            "benchmark-age.sh",
+            "BENCHMARK_SKIP_RUN" to "true",
+            "BENCHMARK_AGE_REPORT_ROOT" to reportRoot.toString(),
+        )
+
+        (result.exitCode != 0).shouldBeTrue()
+        result.stderr shouldContain "ERROR: benchmark JSON report not found"
+        result.stdoutLines shouldBeEqualTo emptyList()
+    }
+
+    private fun jmhReportRoot(dir: Path, name: String): Path =
+        dir.resolve(name).resolve("main").also { it.createDirectories() }
+
+    private fun writeJmhReport(path: Path, content: String) {
+        path.parent.createDirectories()
+        path.writeText(content)
+    }
+
+    private fun runScript(scriptName: String, vararg env: Pair<String, String>): ProcessResult {
+        val process = ProcessBuilder(repoRoot().resolve("scripts").resolve(scriptName).toString())
+            .directory(repoRoot().toFile())
+            .redirectErrorStream(false)
+            .apply {
+                environment().putAll(env.toMap())
+            }
+            .start()
+        return ProcessResult(
+            exitCode = process.waitFor(),
+            stdout = process.inputStream.bufferedReader().readText().trim(),
+            stderr = process.errorStream.bufferedReader().readText().trim(),
+        )
+    }
+
+    private fun assertJson(json: String) {
+        val process = ProcessBuilder("python3", "-c", "import json,sys; json.loads(sys.argv[1])", json)
+            .start()
+        process.waitFor() shouldBeEqualTo 0
+    }
+
+    private fun repoRoot(): Path {
+        var current = Path.of(System.getProperty("user.dir"))
+        while (!current.resolve("settings.gradle.kts").exists()) {
+            current = current.parent ?: error("Repository root not found")
+        }
+        return current
+    }
+
+    private data class ProcessResult(
+        val exitCode: Int,
+        val stdout: String,
+        val stderr: String,
+    ) {
+        val stdoutLines: List<String> = stdout.lines().filter { it.isNotBlank() }
+    }
+}
+
+private infix fun List<String>.shouldHaveSingleLineContaining(expected: String) {
+    this.size shouldBeEqualTo 1
+    this.single() shouldContain expected
+}

--- a/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkSvgRendererTest.kt
+++ b/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkSvgRendererTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.graph.benchmark
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class BenchmarkSvgRendererTest {
+
+    @Test
+    fun `renderer writes grouped svg from benchmark json`(@TempDir dir: Path) {
+        val input = dir.resolve("sample-main.json").also {
+            it.writeText(
+                """
+                [
+                  {
+                    "benchmark": "io.bluetape4k.graph.benchmark.SampleBenchmark.syncRead",
+                    "primaryMetric": {"score": 1.2, "scoreError": 0.1, "scoreUnit": "ms/op"}
+                  },
+                  {
+                    "benchmark": "io.bluetape4k.graph.benchmark.SampleBenchmark.virtualThreadRead",
+                    "primaryMetric": {"score": 2.4, "scoreError": 0.2, "scoreUnit": "ms/op"}
+                  }
+                ]
+                """.trimIndent(),
+            )
+        }
+
+        val process = ProcessBuilder("python3", repoRoot().resolve("benchmark/scripts/render_benchmark_svg.py").toString(), input.toString())
+            .directory(dir.toFile())
+            .start()
+        val stdout = process.inputStream.bufferedReader().readText().trim()
+        val stderr = process.errorStream.bufferedReader().readText().trim()
+
+        process.waitFor() shouldBeEqualTo 0
+        stderr shouldBeEqualTo ""
+        stdout shouldContain "docs/benchmark-results/SampleBenchmark.svg"
+
+        val svg = dir.resolve("docs/benchmark-results/SampleBenchmark.svg")
+        svg.exists().shouldBeTrue()
+        val content = svg.readText()
+        content shouldContain "SampleBenchmark"
+        content shouldContain "syncRead"
+        content shouldContain "virtualThreadRead"
+        content shouldContain "ms/op"
+    }
+
+    private fun repoRoot(): Path {
+        var current = Path.of(System.getProperty("user.dir"))
+        while (!current.resolve("settings.gradle.kts").exists()) {
+            current = current.parent ?: error("Repository root not found")
+        }
+        return current
+    }
+}

--- a/benchmark/graph-io-benchmark/README.ko.md
+++ b/benchmark/graph-io-benchmark/README.ko.md
@@ -32,6 +32,16 @@ graph bulk import/export format과 I/O adapter를 측정하는 JMH 벤치마크 
 
 벤치마크는 각 trial 동안 임시 파일을 쓰고 teardown에서 제거합니다.
 
+작은 데이터셋으로 wiring과 kotlinx-benchmark JSON report 생성을 빠르게 확인하려면 다음 smoke 구성을 사용합니다:
+
+```bash
+./gradlew :graph-io-benchmark:smokeBenchmark
+```
+
+smoke 구성은 `sizeName=smoke`로 CSV, Jackson 3 OkIO, GraphML OkIO round-trip 대표 경로를 비교합니다.
+이는 benchmark method와 report 생성이 동작한다는 CI 근거이며, 성능 수치로 해석하지 않습니다.
+생성된 JSON report는 `benchmark/graph-io-benchmark/build/reports/benchmarks/smoke/*/main.json` 아래에 있습니다.
+
 ## 최신 결과
 
 최신 공개 `small` dataset 결과는 `docs/benchmark/2026-04-18-graph-io-bulk-results.md`에 있습니다.

--- a/benchmark/graph-io-benchmark/README.md
+++ b/benchmark/graph-io-benchmark/README.md
@@ -32,6 +32,16 @@ JMH benchmarks for bulk graph import/export formats and I/O adapters.
 
 The benchmark writes temporary files during each trial and removes them in teardown.
 
+For a fast wiring check that runs a tiny dataset and emits a normal kotlinx-benchmark JSON report, use:
+
+```bash
+./gradlew :graph-io-benchmark:smokeBenchmark
+```
+
+The smoke configuration compares representative CSV, Jackson 3 OkIO, and GraphML OkIO round-trip paths with `sizeName=smoke`.
+Use it as CI evidence that benchmark methods and report generation still work, not as performance data.
+The generated JSON report is under `benchmark/graph-io-benchmark/build/reports/benchmarks/smoke/*/main.json`.
+
 ## Latest Results
 
 The latest published `small` dataset result is from `docs/benchmark/2026-04-18-graph-io-bulk-results.md`.

--- a/benchmark/graph-io-benchmark/build.gradle.kts
+++ b/benchmark/graph-io-benchmark/build.gradle.kts
@@ -18,6 +18,15 @@ benchmark {
             iterationTime = 3
             iterationTimeUnit = "s"
         }
+        register("smoke") {
+            include(".*(BulkGraphIoBenchmark|OkioGraphIoBenchmark)\\.(csvSyncRoundTrip|jackson3OkioRoundTrip|graphMlOkioRoundTrip)")
+            param("sizeName", "smoke")
+            warmups = 1
+            iterations = 1
+            iterationTime = 200
+            iterationTimeUnit = "ms"
+            reportFormat = "json"
+        }
     }
 }
 

--- a/benchmark/graph-io-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/io/BulkGraphIoBenchmarkState.kt
+++ b/benchmark/graph-io-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/io/BulkGraphIoBenchmarkState.kt
@@ -28,6 +28,7 @@ open class BulkGraphIoBenchmarkState {
         ops = TinkerGraphOperations()
 
         val (vCount, eCount) = when (sizeName) {
+            "smoke" -> 10 to 20
             "small" -> 1_000 to 2_000
             "medium" -> 10_000 to 20_000
             else -> 100_000 to 200_000

--- a/benchmark/graph-io-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/io/GraphIoBenchmarkSmokeTest.kt
+++ b/benchmark/graph-io-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/io/GraphIoBenchmarkSmokeTest.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.graph.benchmark.io
+
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import kotlin.io.path.exists
+
+class GraphIoBenchmarkSmokeTest {
+
+    @Test
+    fun `smoke size exercises representative graph io benchmark methods`() {
+        val state = BulkGraphIoBenchmarkState().apply {
+            sizeName = "smoke"
+            setup()
+        }
+
+        try {
+            BulkGraphIoBenchmark().csvSyncRoundTrip(state)
+            OkioGraphIoBenchmark().jackson3OkioRoundTrip(state)
+            OkioGraphIoBenchmark().graphMlOkioRoundTrip(state)
+
+            state.tempDir.resolve("v.csv").exists().shouldBeTrue()
+            state.tempDir.resolve("g3ok.ndjson").exists().shouldBeTrue()
+            state.tempDir.resolve("gok.graphml").exists().shouldBeTrue()
+        } finally {
+            state.teardown()
+        }
+    }
+}

--- a/benchmark/graph-io-benchmark/src/test/resources/junit-platform.properties
+++ b/benchmark/graph-io-benchmark/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/benchmark/graph-io-benchmark/src/test/resources/logback-test.xml
+++ b/benchmark/graph-io-benchmark/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/docs/lessons/2026-05-27-graph-0-4-2-evidence.md
+++ b/docs/lessons/2026-05-27-graph-0-4-2-evidence.md
@@ -1,0 +1,31 @@
+# Graph 0.4.2 Evidence Bundle
+
+## Context
+
+Milestone 0.4.2 grouped follow-up issues for benchmark contract visibility and graph-io failure accounting:
+`#231`, `#236`, `#237`, `#238`, and `#239`.
+
+## Decision
+
+Add lightweight, deterministic tests instead of expanding long-running integration coverage:
+
+- benchmark wrappers can skip the expensive Gradle run and consume fixture reports for one-line JSON stdout contract tests.
+- the SVG renderer is tested against a temp working directory so it does not write generated artifacts into the repo.
+- graph-io benchmark has a `smoke` kotlinx-benchmark configuration with `sizeName=smoke`.
+- GraphML import now records unsupported constructs and turns `FAIL` policy errors into a failed report before creating elements.
+- CSV and GraphML skipped-record paths assert failure severity, phase, role, counts, and messages.
+
+## Outcome
+
+The bundle closes the visibility gap without making the normal test suite run full benchmarks.
+The actual smoke benchmark remains available as an explicit Gradle task for release or CI evidence.
+
+## Verification
+
+- `./gradlew :graph-benchmark:test --tests '*BenchmarkScriptContractTest' --tests '*BenchmarkSvgRendererTest' :graph-io-benchmark:test --tests '*GraphIoBenchmarkSmokeTest' :bluetape4k-graph-io-csv:test --tests '*CsvImportErrorTest' --tests '*SuspendCsvImportErrorTest' :bluetape4k-graph-io-graphml:test --tests '*StaxGraphMlReaderWriterTest' --tests '*GraphMlRoundTripTest'`
+- `./gradlew :graph-io-benchmark:smokeBenchmark`
+- `git diff --check`
+
+## Future Guidance
+
+Keep benchmark CI evidence split from real performance claims. Use fixture tests for wrapper contracts, explicit smoke tasks for wiring, and full benchmark runs only when the result is intended to be interpreted.

--- a/docs/lessons/2026-05-27-graph-0-4-2-evidence.md
+++ b/docs/lessons/2026-05-27-graph-0-4-2-evidence.md
@@ -29,3 +29,5 @@ The actual smoke benchmark remains available as an explicit Gradle task for rele
 ## Future Guidance
 
 Keep benchmark CI evidence split from real performance claims. Use fixture tests for wrapper contracts, explicit smoke tasks for wiring, and full benchmark runs only when the result is intended to be interpreted.
+When touching graph-io suspend tests, re-scan sibling tests for real file IO still using `runTest` and migrate touched coverage to `runSuspendIO`.
+When documenting GraphML support, avoid "full compatibility" wording unless unsupported constructs are actually implemented.

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvImportErrorTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvImportErrorTest.kt
@@ -3,9 +3,13 @@ package io.bluetape4k.graph.io.csv
 import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
 import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.options.MissingEndpointPolicy
+import io.bluetape4k.graph.io.report.GraphIoFailureSeverity
+import io.bluetape4k.graph.io.report.GraphIoFileRole
+import io.bluetape4k.graph.io.report.GraphIoPhase
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -59,6 +63,10 @@ class CsvImportErrorTest {
         report.verticesCreated shouldBeEqualTo 1L
         report.skippedVertices shouldBeEqualTo 1L
         report.failures shouldHaveSize 1
+        report.failures.single().phase shouldBeEqualTo GraphIoPhase.CREATE_VERTEX
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.WARN
+        report.failures.single().fileRole shouldBeEqualTo GraphIoFileRole.VERTICES
+        report.failures.single().message shouldContain "Duplicate vertex externalId skipped"
     }
 
     @Test
@@ -79,6 +87,10 @@ class CsvImportErrorTest {
         report.edgesCreated shouldBeEqualTo 0L
         report.skippedEdges shouldBeEqualTo 1L
         report.failures shouldHaveSize 1
+        report.failures.single().phase shouldBeEqualTo GraphIoPhase.READ_EDGE
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.WARN
+        report.failures.single().fileRole shouldBeEqualTo GraphIoFileRole.EDGES
+        report.failures.single().message shouldContain "Missing endpoint skipped"
     }
 
     @Test

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvSuspendRoundTripTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvSuspendRoundTripTest.kt
@@ -6,19 +6,19 @@ import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
-import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 class CsvSuspendRoundTripTest {
 
-    companion object: KLoggingChannel()
+    companion object : KLoggingChannel()
 
     @Test
-    fun `suspend round trip two vertices and one edge`(@TempDir dir: Path) = runTest {
+    fun `suspend round trip two vertices and one edge`(@TempDir dir: Path) = runSuspendIO {
         val vOut = dir.resolve("v.csv")
         val eOut = dir.resolve("e.csv")
 

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvImportErrorTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvImportErrorTest.kt
@@ -3,11 +3,15 @@ package io.bluetape4k.graph.io.csv
 import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
 import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.options.MissingEndpointPolicy
+import io.bluetape4k.graph.io.report.GraphIoFailureSeverity
+import io.bluetape4k.graph.io.report.GraphIoFileRole
+import io.bluetape4k.graph.io.report.GraphIoPhase
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldHaveSize
@@ -30,7 +34,7 @@ class SuspendCsvImportErrorTest {
     }
 
     @Test
-    fun `blank vertex id causes FAILED status`(@TempDir dir: Path) = runTest {
+    fun `blank vertex id causes FAILED status`(@TempDir dir: Path) = runSuspendIO {
         val src = source(
             dir,
             vCsv = "id,label\n,Person\n",
@@ -44,7 +48,7 @@ class SuspendCsvImportErrorTest {
     }
 
     @Test
-    fun `duplicate vertex id with SKIP policy gives PARTIAL status`(@TempDir dir: Path) = runTest {
+    fun `duplicate vertex id with SKIP policy gives PARTIAL status`(@TempDir dir: Path) = runSuspendIO {
         val src = source(
             dir,
             vCsv = "id,label\nv1,Person\nv1,Person\n",
@@ -60,10 +64,14 @@ class SuspendCsvImportErrorTest {
         report.verticesCreated shouldBeEqualTo 1L
         report.skippedVertices shouldBeEqualTo 1L
         report.failures shouldHaveSize 1
+        report.failures.single().phase shouldBeEqualTo GraphIoPhase.CREATE_VERTEX
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.WARN
+        report.failures.single().fileRole shouldBeEqualTo GraphIoFileRole.VERTICES
+        report.failures.single().message shouldContain "Duplicate vertex externalId skipped"
     }
 
     @Test
-    fun `missing edge endpoint with SKIP_EDGE policy gives PARTIAL status`(@TempDir dir: Path) = runTest {
+    fun `missing edge endpoint with SKIP_EDGE policy gives PARTIAL status`(@TempDir dir: Path) = runSuspendIO {
         val src = source(
             dir,
             vCsv = "id,label\nv1,Person\n",
@@ -80,10 +88,14 @@ class SuspendCsvImportErrorTest {
         report.edgesCreated shouldBeEqualTo 0L
         report.skippedEdges shouldBeEqualTo 1L
         report.failures shouldHaveSize 1
+        report.failures.single().phase shouldBeEqualTo GraphIoPhase.READ_EDGE
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.WARN
+        report.failures.single().fileRole shouldBeEqualTo GraphIoFileRole.EDGES
+        report.failures.single().message shouldContain "Missing endpoint skipped"
     }
 
     @Test
-    fun `missing edge endpoint with FAIL policy gives FAILED status`(@TempDir dir: Path) = runTest {
+    fun `missing edge endpoint with FAIL policy gives FAILED status`(@TempDir dir: Path) = runSuspendIO {
         val src = source(
             dir,
             vCsv = "id,label\nv1,Person\n",
@@ -101,7 +113,7 @@ class SuspendCsvImportErrorTest {
     }
 
     @Test
-    fun `import with multiple vertices and edges sets correct counts`(@TempDir dir: Path) = runTest {
+    fun `import with multiple vertices and edges sets correct counts`(@TempDir dir: Path) = runSuspendIO {
         val src = source(
             dir,
             vCsv = "id,label,prop.name\nv1,Person,Alice\nv2,Person,Bob\nv3,Person,Carol\n",

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/internal/CsvRecordCodecTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/internal/CsvRecordCodecTest.kt
@@ -2,14 +2,14 @@ package io.bluetape4k.graph.io.csv.internal
 
 import io.bluetape4k.graph.io.csv.CsvPropertyMode
 import io.bluetape4k.graph.io.model.GraphIoVertexRecord
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.logging.KLogging
 import org.junit.jupiter.api.Test
-import kotlin.test.assertFailsWith
 
 class CsvRecordCodecTest {
 
-    companion object: KLogging()
+    companion object : KLogging()
 
     @Test
     fun `union header sorts property keys after reserved columns`() {

--- a/graph-io/graphml/README.ko.md
+++ b/graph-io/graphml/README.ko.md
@@ -15,7 +15,7 @@ StAX 스트리밍 파서를 이용한 GraphML (XML) 대량 임포터 및 익스�
 ## 기능
 
 - **StAX 기반 스트리밍**: 메모리 효율적인 파싱 및 직렬화
-- **GraphML 2.4 표준 지원**: GraphML 사양과의 완벽한 호환성
+- **GraphML subset 지원**: directed graph, node, edge, scalar data를 처리하고 미지원 construct를 명시적으로 리포팅
 - **세 가지 실행 모델**: 동기, 비동기, 가상 스레드 변형
 - **상세한 임포트 리포트**: 단계(phase)와 심각도(severity)를 포함한 종합 실패 리포팅
 - **유연한 설정**: 속성 이름, 기본 레이블, 오류 처리 정책 커스터마이징 가능

--- a/graph-io/graphml/README.ko.md
+++ b/graph-io/graphml/README.ko.md
@@ -157,6 +157,14 @@ data class GraphMlImportOptions(
 )
 ```
 
+지원하는 import subset:
+
+- `<node>`, `<edge>`, scalar `<data>` 자식을 가진 directed `<graph>` 문서.
+- scalar GraphML attribute type을 사용하는 `key` 정의.
+- undirected graph, undirected edge, nested graph, port, hyperedge 같은 미지원 GraphML construct는 import failure 목록에 기록됩니다.
+- `UnsupportedGraphMlElementPolicy.SKIP`은 `WARN` failure를 기록하고 지원되는 subset 처리를 계속합니다.
+- `UnsupportedGraphMlElementPolicy.FAIL`은 `ERROR` failure를 기록하며 bulk importer는 graph element를 생성하지 않고 `FAILED`를 반환합니다.
+
 ### 익스포트 옵션
 
 `GraphMlExportOptions`는 현재 비어 있지만 향후 기능 확장을 위한 확장 포인트를 제공합니다:

--- a/graph-io/graphml/README.md
+++ b/graph-io/graphml/README.md
@@ -15,7 +15,7 @@ All implementations use StAX (Streaming API for XML) for memory-efficient parsin
 ## Features
 
 - **StAX-based streaming**: Memory-efficient parsing and serialization
-- **GraphML 2.4 standard support**: Full compatibility with GraphML specification
+- **GraphML subset support**: Directed graphs with nodes, edges, scalar data, and explicit reporting for unsupported constructs
 - **Three execution models**: Sync, async, and virtual thread variants
 - **Detailed import reports**: Comprehensive failure reporting with phase and severity tracking
 - **Flexible configuration**: Customizable attribute names, default labels, and error handling policies

--- a/graph-io/graphml/README.md
+++ b/graph-io/graphml/README.md
@@ -157,6 +157,14 @@ data class GraphMlImportOptions(
 )
 ```
 
+Supported import subset:
+
+- Directed `<graph>` documents with `<node>`, `<edge>`, and scalar `<data>` children.
+- `key` definitions with scalar GraphML attribute types.
+- Unsupported GraphML constructs such as undirected graphs, undirected edges, nested graphs, ports, and hyperedges are recorded in the import failure list.
+- `UnsupportedGraphMlElementPolicy.SKIP` records `WARN` failures and continues with the supported subset.
+- `UnsupportedGraphMlElementPolicy.FAIL` records `ERROR` failures and the bulk importer returns `FAILED` without creating graph elements.
+
 ### Export Options
 
 `GraphMlExportOptions` is currently empty but provides extension point for future features:

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/GraphMlBulkImporter.kt
@@ -78,7 +78,15 @@ class GraphMlBulkImporter : GraphBulkImporter<GraphImportSource> {
         var ec = 0L
         var sv = 0L
         var se = 0L
-        var status = GraphIoStatus.COMPLETED
+        var status = when {
+            parsed.failures.any { it.severity == GraphIoFailureSeverity.ERROR } -> GraphIoStatus.FAILED
+            parsed.failures.any { it.severity == GraphIoFailureSeverity.WARN } -> GraphIoStatus.PARTIAL
+            else -> GraphIoStatus.COMPLETED
+        }
+
+        if (status == GraphIoStatus.FAILED) {
+            return GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
+        }
 
         for (v in parsed.vertices) {
             val props = options.preserveExternalIdProperty

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
@@ -84,7 +84,9 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
         }
 
         if (status == GraphIoStatus.FAILED) {
-            return@withContext GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
+            return@withContext GraphImportReport(
+                status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures
+            )
         }
 
         for (v in parsed.vertices) {

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
@@ -25,11 +25,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * GraphML 코루틴(suspend) 벌크 임포터.
- * StAX 파싱은 IO 디스패처에서 수행하고, 정점/간선 생성은 suspend 함수로 호출한다.
- */
-/**
  * Coroutine bulk importer for GraphML.
+ *
+ * StAX parsing runs on [Dispatchers.IO], and vertex/edge creation is delegated
+ * to the provided suspend graph operations.
  *
  * Example:
  *

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
@@ -78,7 +78,15 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
         var ec = 0L
         var sv = 0L
         var se = 0L
-        var status = GraphIoStatus.COMPLETED
+        var status = when {
+            parsed.failures.any { it.severity == GraphIoFailureSeverity.ERROR } -> GraphIoStatus.FAILED
+            parsed.failures.any { it.severity == GraphIoFailureSeverity.WARN } -> GraphIoStatus.PARTIAL
+            else -> GraphIoStatus.COMPLETED
+        }
+
+        if (status == GraphIoStatus.FAILED) {
+            return@withContext GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
+        }
 
         for (v in parsed.vertices) {
             val props = options.preserveExternalIdProperty

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
@@ -2,9 +2,11 @@ package io.bluetape4k.graph.io.graphml.internal
 
 import io.bluetape4k.graph.io.graphml.GraphMlAttrType
 import io.bluetape4k.graph.io.graphml.GraphMlImportOptions
+import io.bluetape4k.graph.io.graphml.UnsupportedGraphMlElementPolicy
 import io.bluetape4k.graph.io.model.GraphIoEdgeRecord
 import io.bluetape4k.graph.io.model.GraphIoVertexRecord
 import io.bluetape4k.graph.io.report.GraphIoFailure
+import io.bluetape4k.graph.io.report.GraphIoFailureSeverity
 import io.bluetape4k.graph.io.report.GraphIoFileRole
 import io.bluetape4k.graph.io.report.GraphIoPhase
 import io.bluetape4k.logging.KLogging
@@ -43,6 +45,8 @@ internal class StaxGraphMlReader {
                 if (event == XMLStreamConstants.START_ELEMENT) {
                     when (reader.localName) {
                         "key" -> parseKey(reader, keyIdToName, keyIdToType)
+                        "graph" -> recordUnsupportedGraph(reader, options, failures)
+                        "hyperedge", "port" -> recordUnsupportedElement(reader, options, failures)
                         "node" -> parseNode(reader, keyIdToName, keyIdToType, options, vertices, failures)
                         "edge" -> parseEdge(reader, keyIdToName, keyIdToType, options, edges, failures)
                     }
@@ -54,6 +58,35 @@ internal class StaxGraphMlReader {
 
         log.debug { "GraphML parsed: vertices=${vertices.size}, edges=${edges.size}, failures=${failures.size}" }
         return GraphMlReadResult(vertices, edges, failures)
+    }
+
+    private fun recordUnsupportedGraph(
+        reader: XMLStreamReader,
+        options: GraphMlImportOptions,
+        failures: MutableList<GraphIoFailure>,
+    ) {
+        if (reader.getAttributeValue(null, "edgedefault") == "undirected") {
+            recordUnsupportedElement(reader, options, failures, "GraphML undirected graphs are not supported")
+        }
+    }
+
+    private fun recordUnsupportedElement(
+        reader: XMLStreamReader,
+        options: GraphMlImportOptions,
+        failures: MutableList<GraphIoFailure>,
+        message: String = "Unsupported GraphML element: ${reader.localName}",
+        phase: GraphIoPhase = GraphIoPhase.READ_VERTEX,
+    ) {
+        failures += GraphIoFailure(
+            phase = phase,
+            severity = when (options.unsupportedElementPolicy) {
+                UnsupportedGraphMlElementPolicy.SKIP -> GraphIoFailureSeverity.WARN
+                UnsupportedGraphMlElementPolicy.FAIL -> GraphIoFailureSeverity.ERROR
+            },
+            fileRole = GraphIoFileRole.UNIFIED,
+            elementName = reader.localName,
+            message = message,
+        )
     }
 
     private fun parseKey(
@@ -86,7 +119,7 @@ internal class StaxGraphMlReader {
             return
         }
 
-        val dataMap = readDataChildren(reader, "node")
+        val dataMap = readDataChildren(reader, "node", options, failures)
 
         var label = options.defaultVertexLabel
         val props = mutableMapOf<String, Any?>()
@@ -113,6 +146,15 @@ internal class StaxGraphMlReader {
         val edgeId = reader.getAttributeValue(null, "id")
         val source = reader.getAttributeValue(null, "source")
         val target = reader.getAttributeValue(null, "target")
+        if (reader.getAttributeValue(null, "directed") == "false") {
+            recordUnsupportedElement(
+                reader,
+                options,
+                failures,
+                "GraphML undirected edges are not supported",
+                GraphIoPhase.READ_EDGE,
+            )
+        }
         if (source.isNullOrBlank() || target.isNullOrBlank()) {
             failures += GraphIoFailure(
                 phase = GraphIoPhase.READ_EDGE,
@@ -123,7 +165,7 @@ internal class StaxGraphMlReader {
             return
         }
 
-        val dataMap = readDataChildren(reader, "edge")
+        val dataMap = readDataChildren(reader, "edge", options, failures)
 
         var label = options.defaultEdgeLabel
         val props = mutableMapOf<String, Any?>()
@@ -146,7 +188,12 @@ internal class StaxGraphMlReader {
     }
 
     /** 현재 요소의 `<data key="...">text</data>` 자식들을 읽어 keyId→value 맵으로 반환한다. */
-    private fun readDataChildren(reader: XMLStreamReader, parentLocalName: String): Map<String, String> {
+    private fun readDataChildren(
+        reader: XMLStreamReader,
+        parentLocalName: String,
+        options: GraphMlImportOptions,
+        failures: MutableList<GraphIoFailure>,
+    ): Map<String, String> {
         val result = mutableMapOf<String, String>()
         while (reader.hasNext()) {
             when (reader.next()) {
@@ -155,6 +202,12 @@ internal class StaxGraphMlReader {
                         val key = reader.getAttributeValue(null, "key") ?: continue
                         val value = reader.elementText ?: ""
                         result[key] = value
+                    } else {
+                        when (reader.localName) {
+                            "graph" -> recordUnsupportedElement(reader, options, failures, "Nested GraphML graphs are not supported")
+                            "port" -> recordUnsupportedElement(reader, options, failures)
+                        }
+                        skipElement(reader, reader.localName)
                     }
                 }
                 XMLStreamConstants.END_ELEMENT -> {
@@ -163,6 +216,16 @@ internal class StaxGraphMlReader {
             }
         }
         return result
+    }
+
+    private fun skipElement(reader: XMLStreamReader, localName: String) {
+        var depth = 1
+        while (reader.hasNext() && depth > 0) {
+            when (reader.next()) {
+                XMLStreamConstants.START_ELEMENT -> if (reader.localName == localName) depth++
+                XMLStreamConstants.END_ELEMENT -> if (reader.localName == localName) depth--
+            }
+        }
     }
 
     companion object : KLogging() {

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
@@ -204,7 +204,9 @@ internal class StaxGraphMlReader {
                         result[key] = value
                     } else {
                         when (reader.localName) {
-                            "graph" -> recordUnsupportedElement(reader, options, failures, "Nested GraphML graphs are not supported")
+                            "graph" -> recordUnsupportedElement(
+                                reader, options, failures, "Nested GraphML graphs are not supported"
+                            )
                             "port" -> recordUnsupportedElement(reader, options, failures)
                         }
                         skipElement(reader, reader.localName)

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlRoundTripTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlRoundTripTest.kt
@@ -1,15 +1,21 @@
 package io.bluetape4k.graph.io.graphml
 
+import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
 import io.bluetape4k.graph.io.options.GraphExportOptions
 import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.options.MissingEndpointPolicy
+import io.bluetape4k.graph.io.report.GraphIoFailureSeverity
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import kotlin.io.path.writeText
 
 class GraphMlRoundTripTest {
 
@@ -67,5 +73,94 @@ class GraphMlRoundTripTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `duplicate vertex skip policy records partial report failure`(@TempDir dir: Path) {
+        val graphml = dir.resolve("duplicate.graphml").also {
+            it.writeText(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <graph id="G" edgedefault="directed">
+    <node id="n1"/>
+    <node id="n1"/>
+  </graph>
+</graphml>""",
+            )
+        }
+
+        val report = GraphMlBulkImporter().importGraph(
+            GraphImportSource.PathSource(graphml),
+            TinkerGraphOperations(),
+            GraphImportOptions(onDuplicateVertexId = DuplicateVertexPolicy.SKIP),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.PARTIAL
+        report.verticesRead shouldBeEqualTo 2L
+        report.verticesCreated shouldBeEqualTo 1L
+        report.skippedVertices shouldBeEqualTo 1L
+        report.failures shouldHaveSize 1
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.WARN
+        report.failures.single().message shouldContain "Duplicate vertex skipped"
+    }
+
+    @Test
+    fun `missing endpoint skip policy records partial report failure`(@TempDir dir: Path) {
+        val graphml = dir.resolve("missing-endpoint.graphml").also {
+            it.writeText(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <graph id="G" edgedefault="directed">
+    <node id="n1"/>
+    <edge id="e1" source="n1" target="missing"/>
+  </graph>
+</graphml>""",
+            )
+        }
+
+        val report = GraphMlBulkImporter().importGraph(
+            GraphImportSource.PathSource(graphml),
+            TinkerGraphOperations(),
+            GraphImportOptions(onMissingEdgeEndpoint = MissingEndpointPolicy.SKIP_EDGE),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.PARTIAL
+        report.verticesCreated shouldBeEqualTo 1L
+        report.edgesRead shouldBeEqualTo 1L
+        report.edgesCreated shouldBeEqualTo 0L
+        report.skippedEdges shouldBeEqualTo 1L
+        report.failures shouldHaveSize 1
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.WARN
+        report.failures.single().message shouldContain "Missing endpoint skipped"
+    }
+
+    @Test
+    fun `unsupported port fail policy returns failed report without creating elements`(@TempDir dir: Path) {
+        val graphml = dir.resolve("unsupported-port.graphml").also {
+            it.writeText(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <graph id="G" edgedefault="directed">
+    <node id="n1">
+      <port name="p1"/>
+    </node>
+  </graph>
+</graphml>""",
+            )
+        }
+
+        val report = GraphMlBulkImporter().importGraph(
+            GraphImportSource.PathSource(graphml),
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+            GraphMlImportOptions(unsupportedElementPolicy = UnsupportedGraphMlElementPolicy.FAIL),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.verticesRead shouldBeEqualTo 1L
+        report.verticesCreated shouldBeEqualTo 0L
+        report.failures shouldHaveSize 1
+        report.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.ERROR
+        report.failures.single().elementName shouldBeEqualTo "port"
     }
 }

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlSuspendTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlSuspendTest.kt
@@ -7,8 +7,8 @@ import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -16,7 +16,7 @@ import java.nio.file.Path
 class GraphMlSuspendTest {
 
     @Test
-    fun `suspend import and export round trip`(@TempDir dir: Path) = runTest {
+    fun `suspend import and export round trip`(@TempDir dir: Path) = runSuspendIO {
         val out = dir.resolve("graph-suspend.graphml")
 
         val src = TinkerGraphOperations()

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
@@ -2,8 +2,11 @@ package io.bluetape4k.graph.io.graphml.internal
 
 import io.bluetape4k.graph.io.graphml.GraphMlExportOptions
 import io.bluetape4k.graph.io.graphml.GraphMlImportOptions
+import io.bluetape4k.graph.io.graphml.UnsupportedGraphMlElementPolicy
 import io.bluetape4k.graph.io.model.GraphIoEdgeRecord
 import io.bluetape4k.graph.io.model.GraphIoVertexRecord
+import io.bluetape4k.graph.io.report.GraphIoFailureSeverity
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
@@ -113,6 +116,53 @@ class StaxGraphMlReaderWriterTest {
 </graphml>"""
         val result = reader.read(ByteArrayInputStream(xml.toByteArray()))
         result.failures.isEmpty().not().shouldBeTrue()
+    }
+
+    @Test
+    fun `reader records warnings for unsupported graphml elements with SKIP policy`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <graph id="G" edgedefault="undirected">
+    <node id="n1">
+      <port name="p1"/>
+      <graph id="nested" edgedefault="directed">
+        <node id="n2"/>
+      </graph>
+    </node>
+    <hyperedge id="h1"/>
+    <edge id="e1" source="n1" target="n1" directed="false"/>
+  </graph>
+</graphml>"""
+        val result = reader.read(ByteArrayInputStream(xml.toByteArray()))
+
+        result.vertices shouldHaveSize 1
+        result.edges shouldHaveSize 1
+        result.failures shouldHaveSize 5
+        result.failures.map { it.severity }.toSet() shouldBeEqualTo setOf(GraphIoFailureSeverity.WARN)
+        result.failures.map { it.elementName } shouldContain "graph"
+        result.failures.map { it.elementName } shouldContain "port"
+        result.failures.map { it.elementName } shouldContain "hyperedge"
+        result.failures.map { it.message } shouldContain "Nested GraphML graphs are not supported"
+        result.failures.map { it.message } shouldContain "GraphML undirected edges are not supported"
+    }
+
+    @Test
+    fun `reader records errors for unsupported graphml elements with FAIL policy`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <graph id="G" edgedefault="undirected">
+    <node id="n1"/>
+  </graph>
+</graphml>"""
+        val result = reader.read(
+            ByteArrayInputStream(xml.toByteArray()),
+            GraphMlImportOptions(unsupportedElementPolicy = UnsupportedGraphMlElementPolicy.FAIL),
+        )
+
+        result.vertices shouldHaveSize 1
+        result.failures shouldHaveSize 1
+        result.failures.single().severity shouldBeEqualTo GraphIoFailureSeverity.ERROR
+        result.failures.single().message shouldContain "undirected graphs"
     }
 
     @Test

--- a/scripts/benchmark-age.sh
+++ b/scripts/benchmark-age.sh
@@ -8,14 +8,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-MODULE=":graph-age-benchmark"
-REPORT_ROOT="$REPO_ROOT/benchmark/graph-age-benchmark/build/reports/benchmarks/main"
+MODULE="${BENCHMARK_AGE_MODULE:-:graph-age-benchmark}"
+REPORT_ROOT="${BENCHMARK_AGE_REPORT_ROOT:-$REPO_ROOT/benchmark/graph-age-benchmark/build/reports/benchmarks/main}"
 
-# Remove previous runs so we can pick the freshest report deterministically.
-rm -rf "$REPORT_ROOT" 2>/dev/null || true
+if [[ "${BENCHMARK_SKIP_RUN:-false}" != "true" ]]; then
+    # Remove previous runs so we can pick the freshest report deterministically.
+    rm -rf "$REPORT_ROOT" 2>/dev/null || true
 
-# Run benchmark; stream raw output to stderr so only the JSON line hits stdout.
-./gradlew "$MODULE:benchmark" --rerun --console=plain 1>&2
+    # Run benchmark; stream raw output to stderr so only the JSON line hits stdout.
+    ./gradlew "$MODULE:benchmark" --rerun --console=plain 1>&2
+fi
 
 # Pick the newest JSON report produced by the run (fd-based, avoids `ls`).
 REPORT_FILE="$(fd --type f --extension json . "$REPORT_ROOT" 2>/dev/null | head -n1 || true)"

--- a/scripts/benchmark-neo4j-age.sh
+++ b/scripts/benchmark-neo4j-age.sh
@@ -10,17 +10,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-AGE_MODULE=":graph-age-benchmark"
-NEO4J_MODULE=":graph-neo4j-benchmark"
-AGE_REPORT_ROOT="$REPO_ROOT/benchmark/graph-age-benchmark/build/reports/benchmarks/main"
-NEO4J_REPORT_ROOT="$REPO_ROOT/benchmark/graph-neo4j-benchmark/build/reports/benchmarks/main"
+AGE_MODULE="${BENCHMARK_AGE_MODULE:-:graph-age-benchmark}"
+NEO4J_MODULE="${BENCHMARK_NEO4J_MODULE:-:graph-neo4j-benchmark}"
+AGE_REPORT_ROOT="${BENCHMARK_AGE_REPORT_ROOT:-$REPO_ROOT/benchmark/graph-age-benchmark/build/reports/benchmarks/main}"
+NEO4J_REPORT_ROOT="${BENCHMARK_NEO4J_REPORT_ROOT:-$REPO_ROOT/benchmark/graph-neo4j-benchmark/build/reports/benchmarks/main}"
 
-# Remove previous runs so we can pick the freshest report deterministically.
-rm -rf "$AGE_REPORT_ROOT" "$NEO4J_REPORT_ROOT" 2>/dev/null || true
+if [[ "${BENCHMARK_SKIP_RUN:-false}" != "true" ]]; then
+    # Remove previous runs so we can pick the freshest report deterministically.
+    rm -rf "$AGE_REPORT_ROOT" "$NEO4J_REPORT_ROOT" 2>/dev/null || true
 
-# Run both benchmarks; stream raw output to stderr so only the JSON line hits stdout.
-./gradlew "$AGE_MODULE:benchmark" --rerun --console=plain 1>&2
-./gradlew "$NEO4J_MODULE:benchmark" --rerun --console=plain 1>&2
+    # Run both benchmarks; stream raw output to stderr so only the JSON line hits stdout.
+    ./gradlew "$AGE_MODULE:benchmark" --rerun --console=plain 1>&2
+    ./gradlew "$NEO4J_MODULE:benchmark" --rerun --console=plain 1>&2
+fi
 
 pick_report() {
     local root="$1"


### PR DESCRIPTION
## Summary

- Add fixture-backed benchmark wrapper contract tests for AGE and Neo4j/AGE JSON stdout.
- Add SVG renderer coverage and a graph-io benchmark smoke lane for CSV, Jackson 3 OkIO, and GraphML OkIO round trips.
- Lock CSV and GraphML skipped-record accounting with status, count, severity, phase, role, and message assertions.
- Record unsupported GraphML constructs in read failures and make strict GraphML import fail before creating elements.
- Align touched graph-io tests and GraphML docs with `bluetape4k-patterns` after the follow-up skill audit.

Fixes #231
Fixes #236
Fixes #237
Fixes #238
Fixes #239

## Verification

- `./gradlew :graph-benchmark:test --tests '*BenchmarkScriptContractTest' --tests '*BenchmarkSvgRendererTest' :graph-io-benchmark:test --tests '*GraphIoBenchmarkSmokeTest' :bluetape4k-graph-io-csv:test --tests '*CsvImportErrorTest' --tests '*SuspendCsvImportErrorTest' --tests '*CsvSuspendRoundTripTest' --tests '*CsvRecordCodecTest' :bluetape4k-graph-io-graphml:test --tests '*StaxGraphMlReaderWriterTest' --tests '*GraphMlRoundTripTest' --tests '*GraphMlSuspendTest'`
- `./gradlew :bluetape4k-graph-io-graphml:detekt :bluetape4k-graph-io-graphml:test --tests '*StaxGraphMlReaderWriterTest' --tests '*GraphMlRoundTripTest' --tests '*GraphMlSuspendTest'`
- `./gradlew :graph-io-benchmark:smokeBenchmark --console=plain`
- `rg -n "runTest|assertThrows|assertThat|kotlin\\.test|org\\.junit\\.jupiter\\.api\\.Assertions|!!|GraphML 2\\.4 standard support|완벽한 호환성" ... -S || true`
- `git diff --check`
- Native code-reviewer: P0=0; P1 fixed; P2 addressed with smoke report path documentation.

## Notes

- `smokeBenchmark` writes JSON under `benchmark/graph-io-benchmark/build/reports/benchmarks/smoke/*/main.json`.
- Full repository test suite and IDE diagnostics were not run in this session.
