### PR TITLE
test: align suspend graph tests with runSuspendIO

### DIFF
--- a/docs/lessons/2026-05-27-issue-241-suspend-test-harness.md
+++ b/docs/lessons/2026-05-27-issue-241-suspend-test-harness.md
@@ -1,0 +1,29 @@
+# Issue 241 Suspend Test Harness
+
+## Context
+
+The 0.4.2 pre-release repository scan found remaining suspend tests using
+`runTest` around real graph IO and Testcontainers-backed graph operations.
+
+## Decision
+
+Use `runSuspendIO` for real IO and backend-backed suspend tests, and keep
+bluetape4k assertion helpers for exception checks.
+
+## Outcome
+
+The Okio graph-io suspend tests and code-graph example suspend tests now use
+the same coroutine test harness policy as the rest of the 0.4.2 release line.
+
+## Verification
+
+- `./gradlew :bluetape4k-graph-okio:test --tests '*SuspendAdapterTest' --tests '*CsvOkioExtensionsTest' --tests '*GraphMLOkioExtensionsTest' --tests '*JacksonOkioExtensionsTest' :code-graph-examples:test --tests '*CodeGraphSuspendTest'`
+- Pattern scan for `runTest`, `kotlin.test`, JUnit assertion imports, and
+  AssertJ-style assertions in touched test paths.
+- `git diff --check`
+
+## Future Notes
+
+Before releasing a milestone, scan example modules as well as library modules
+for coroutine harness drift; example Testcontainers tests can hide the same
+`runTest` risk as production module tests.

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
@@ -1,15 +1,15 @@
 package io.bluetape4k.graph.examples.code
 
-import io.bluetape4k.graph.examples.code.service.CodeGraphSuspendService
-import io.bluetape4k.graph.repository.GraphSuspendOperations
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.debug
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.graph.examples.code.service.CodeGraphSuspendService
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -22,13 +22,13 @@ abstract class AbstractCodeGraphSuspendTest {
     protected val service: CodeGraphSuspendService by lazy { CodeGraphSuspendService(ops, graphName) }
 
     @BeforeEach
-    fun cleanGraph() = runTest {
+    fun cleanGraph() = runSuspendIO {
         if (ops.graphExists(graphName)) ops.dropGraph(graphName)
         service.initialize()
     }
 
     @Test
-    fun `모듈 추가 및 의존성 관계 구성`() = runTest {
+    fun `모듈 추가 및 의존성 관계 구성`() = runSuspendIO {
         val core = service.addModule("core", "graph/graph-core", "1.0.0")
         val middle = service.addModule("middle", "graph/middle", "1.0.0")
         val app = service.addModule("app", "examples/app", "1.0.0")
@@ -45,7 +45,7 @@ abstract class AbstractCodeGraphSuspendTest {
     }
 
     @Test
-    fun `의존성 경로 탐색`() = runTest {
+    fun `의존성 경로 탐색`() = runSuspendIO {
         val core = service.addModule("core", path = "", version = "1.0.0")
         val mid = service.addModule("middle", path = "", version = "1.0.0")
         val top = service.addModule("top", path = "", version = "1.0.0")
@@ -60,7 +60,7 @@ abstract class AbstractCodeGraphSuspendTest {
     }
 
     @Test
-    fun `영향 범위 분석 - 역방향 탐색`() = runTest {
+    fun `영향 범위 분석 - 역방향 탐색`() = runSuspendIO {
         val core = service.addModule("core", path = "", version = "1.0.0")
         val moduleA = service.addModule("moduleA", path = "", version = "1.0.0")
         val moduleB = service.addModule("moduleB", path = "", version = "1.0.0")
@@ -74,7 +74,7 @@ abstract class AbstractCodeGraphSuspendTest {
     }
 
     @Test
-    fun `클래스 상속 계층 탐색`() = runTest {
+    fun `클래스 상속 계층 탐색`() = runSuspendIO {
         val baseClass = service.addClass("Animal", "io.example.Animal")
         val midClass = service.addClass("Mammal", "io.example.Mammal")
         val leafClass = service.addClass("Dog", "io.example.Dog")
@@ -88,7 +88,7 @@ abstract class AbstractCodeGraphSuspendTest {
     }
 
     @Test
-    fun `함수 호출 체인 분석`() = runTest {
+    fun `함수 호출 체인 분석`() = runSuspendIO {
         val funcA = service.addFunction("processOrder", "fun processOrder(orderId: Long)")
         val funcB = service.addFunction("validateOrder", "fun validateOrder(orderId: Long)")
         val funcC = service.addFunction("saveOrder", "fun saveOrder(order: Order)")
@@ -103,7 +103,7 @@ abstract class AbstractCodeGraphSuspendTest {
     }
 
     @Test
-    fun `의존성 없는 경우 경로 null`() = runTest {
+    fun `의존성 없는 경우 경로 null`() = runSuspendIO {
         val isolated = service.addModule("isolated", path = "", version = "1.0.0")
         val other = service.addModule("other", path = "", version = "1.0.0")
 

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendAdapterTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/coroutines/SuspendAdapterTest.kt
@@ -1,5 +1,8 @@
 package io.bluetape4k.graph.io.okio.coroutines
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.graph.io.okio.OkioGraphBulkExporter
 import io.bluetape4k.graph.io.okio.OkioGraphBulkImporter
 import io.bluetape4k.graph.io.okio.OkioGraphExportSink
@@ -9,15 +12,12 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlin.test.assertFailsWith
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -48,7 +48,7 @@ class SuspendAdapterTest {
     )
 
     @Test
-    fun `importGraphAwait returns completed report`() = runTest {
+    fun `importGraphAwait returns completed report`() = runSuspendIO {
         val path = "/await.ndjson".toPath()
         val src = buildSourceGraph()
         val sink = OkioGraphExportSink.PathSink(path, fakeFs)
@@ -66,7 +66,7 @@ class SuspendAdapterTest {
     }
 
     @Test
-    fun `exportGraphAwait returns completed report`() = runTest {
+    fun `exportGraphAwait returns completed report`() = runSuspendIO {
         val path = "/await-export.ndjson".toPath()
         val src = buildSourceGraph()
 
@@ -82,7 +82,7 @@ class SuspendAdapterTest {
     }
 
     @Test
-    fun `importGraph Flow emits start and completion progress`() = runTest {
+    fun `importGraph Flow emits start and completion progress`() = runSuspendIO {
         val path = "/flow.ndjson".toPath()
         val src = buildSourceGraph()
         adapter.exportGraphAwait(
@@ -104,7 +104,7 @@ class SuspendAdapterTest {
     }
 
     @Test
-    fun `exportGraph Flow emits start and completion progress`() = runTest {
+    fun `exportGraph Flow emits start and completion progress`() = runSuspendIO {
         val path = "/flow-export.ndjson".toPath()
         val src = buildSourceGraph()
 
@@ -122,7 +122,7 @@ class SuspendAdapterTest {
     // ─── 다중 포맷 커버리지 ───────────────────────────────────────────────────────
 
     @Test
-    fun `importGraphAwait with NDJSON_JACKSON2 format returns correct counts`() = runTest {
+    fun `importGraphAwait with NDJSON_JACKSON2 format returns correct counts`() = runSuspendIO {
         val path = "/await-j2.ndjson".toPath()
         val src = buildSourceGraph()
         adapter.exportGraphAwait(OkioGraphExportSink.PathSink(path, fakeFs), GraphIoFormat.NDJSON_JACKSON2, src, exportOptions)
@@ -139,7 +139,7 @@ class SuspendAdapterTest {
     }
 
     @Test
-    fun `importGraphAwait with GRAPHML format returns correct counts`() = runTest {
+    fun `importGraphAwait with GRAPHML format returns correct counts`() = runSuspendIO {
         val path = "/await-graphml.xml".toPath()
         val src = buildSourceGraph()
         adapter.exportGraphAwait(OkioGraphExportSink.PathSink(path, fakeFs), GraphIoFormat.GRAPHML, src, exportOptions)
@@ -156,7 +156,7 @@ class SuspendAdapterTest {
     }
 
     @Test
-    fun `exportGraphAwait with GRAPHML format returns completed report`() = runTest {
+    fun `exportGraphAwait with GRAPHML format returns completed report`() = runSuspendIO {
         val path = "/await-export-graphml.xml".toPath()
         val src = buildSourceGraph()
 
@@ -174,7 +174,7 @@ class SuspendAdapterTest {
     // ─── 취소 전파 ────────────────────────────────────────────────────────────
 
     @Test
-    fun `exportGraphAwait throws CancellationException when coroutine is pre-cancelled`() = runTest {
+    fun `exportGraphAwait throws CancellationException when coroutine is pre-cancelled`() = runSuspendIO {
         val cancelledJob = Job().apply { cancel() }
 
         assertFailsWith<kotlinx.coroutines.CancellationException> {
@@ -191,7 +191,7 @@ class SuspendAdapterTest {
     }
 
     @Test
-    fun `importGraphAwait throws CancellationException when coroutine is pre-cancelled`() = runTest {
+    fun `importGraphAwait throws CancellationException when coroutine is pre-cancelled`() = runSuspendIO {
         val path = "/cancel-import.ndjson".toPath()
         adapter.exportGraphAwait(
             OkioGraphExportSink.PathSink(path, fakeFs),

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/CsvOkioExtensionsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/CsvOkioExtensionsTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.graph.io.okio.extension
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.graph.io.csv.CsvGraphBulkExporter
 import io.bluetape4k.graph.io.csv.CsvGraphBulkImporter
 import io.bluetape4k.graph.io.okio.OkioGraphExportSink
@@ -8,12 +10,10 @@ import io.bluetape4k.graph.io.options.GraphExportOptions
 import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import okio.FileSystem
 import okio.Path.Companion.toPath
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -104,13 +104,13 @@ class CsvOkioExtensionsTest {
     // ─── Suspend ─────────────────────────────────────────────────────────────
 
     @Test
-    fun `CSV exportGraphAwait completes via coroutine`() = runTest {
+    fun `CSV exportGraphAwait completes via coroutine`() = runSuspendIO {
         val report = exporter.exportGraphAwait(csvSink(), buildSourceGraph(), exportOptions)
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
     }
 
     @Test
-    fun `CSV importGraphAwait completes via coroutine`() = runTest {
+    fun `CSV importGraphAwait completes via coroutine`() = runSuspendIO {
         exporter.exportGraph(csvSink(), buildSourceGraph(), exportOptions)
         val report = importer.importGraphAwait(csvSource(), TinkerGraphOperations(), GraphImportOptions())
         report.verticesCreated shouldBeEqualTo 2L
@@ -118,13 +118,13 @@ class CsvOkioExtensionsTest {
     }
 
     @Test
-    fun `CSV exportGraphFlow emits progress`() = runTest {
+    fun `CSV exportGraphFlow emits progress`() = runSuspendIO {
         val events = exporter.exportGraphFlow(csvSink(), buildSourceGraph(), exportOptions).toList()
         events shouldHaveSize 2
     }
 
     @Test
-    fun `CSV importGraphFlow emits progress`() = runTest {
+    fun `CSV importGraphFlow emits progress`() = runSuspendIO {
         exporter.exportGraph(csvSink(), buildSourceGraph(), exportOptions)
         val events = importer.importGraphFlow(csvSource(), TinkerGraphOperations(), GraphImportOptions()).toList()
         events shouldHaveSize 2

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/GraphMLOkioExtensionsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/GraphMLOkioExtensionsTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.graph.io.okio.extension
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.graph.io.graphml.GraphMlBulkExporter
 import io.bluetape4k.graph.io.graphml.GraphMlBulkImporter
 import io.bluetape4k.graph.io.okio.OkioGraphExportSink
@@ -8,12 +10,10 @@ import io.bluetape4k.graph.io.options.GraphExportOptions
 import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -104,7 +104,7 @@ class GraphMLOkioExtensionsTest {
     // ─── Suspend ─────────────────────────────────────────────────────────────
 
     @Test
-    fun `GraphML exportGraphAwait returns completed report`() = runTest {
+    fun `GraphML exportGraphAwait returns completed report`() = runSuspendIO {
         val path = "/graph-await.graphml".toPath()
         val report = GraphMlBulkExporter().exportGraphAwait(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -114,7 +114,7 @@ class GraphMLOkioExtensionsTest {
     }
 
     @Test
-    fun `GraphML importGraphAwait returns completed report`() = runTest {
+    fun `GraphML importGraphAwait returns completed report`() = runSuspendIO {
         val path = "/graph-await-import.graphml".toPath()
         GraphMlBulkExporter().exportGraph(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -128,7 +128,7 @@ class GraphMLOkioExtensionsTest {
     }
 
     @Test
-    fun `GraphML exportGraphFlow emits progress`() = runTest {
+    fun `GraphML exportGraphFlow emits progress`() = runSuspendIO {
         val path = "/graph-flow-export.graphml".toPath()
         val events = GraphMlBulkExporter().exportGraphFlow(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -137,7 +137,7 @@ class GraphMLOkioExtensionsTest {
     }
 
     @Test
-    fun `GraphML importGraphFlow emits progress`() = runTest {
+    fun `GraphML importGraphFlow emits progress`() = runSuspendIO {
         val path = "/graph-flow-import.graphml".toPath()
         GraphMlBulkExporter().exportGraph(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/JacksonOkioExtensionsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/extension/JacksonOkioExtensionsTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.graph.io.okio.extension
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.graph.io.jackson2.Jackson2NdJsonBulkExporter
 import io.bluetape4k.graph.io.jackson2.Jackson2NdJsonBulkImporter
 import io.bluetape4k.graph.io.jackson3.Jackson3NdJsonBulkExporter
@@ -10,12 +12,10 @@ import io.bluetape4k.graph.io.options.GraphExportOptions
 import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -157,7 +157,7 @@ class JacksonOkioExtensionsTest {
     // ─── Suspend ─────────────────────────────────────────────────────────────
 
     @Test
-    fun `Jackson3 exportGraphAwait returns completed report`() = runTest {
+    fun `Jackson3 exportGraphAwait returns completed report`() = runSuspendIO {
         val path = "/j3-await.ndjson".toPath()
         val report = Jackson3NdJsonBulkExporter().exportGraphAwait(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -167,7 +167,7 @@ class JacksonOkioExtensionsTest {
     }
 
     @Test
-    fun `Jackson3 importGraphFlow emits progress`() = runTest {
+    fun `Jackson3 importGraphFlow emits progress`() = runSuspendIO {
         val path = "/j3-flow.ndjson".toPath()
         Jackson3NdJsonBulkExporter().exportGraph(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -180,7 +180,7 @@ class JacksonOkioExtensionsTest {
     }
 
     @Test
-    fun `Jackson3 importGraphAwait returns completed report`() = runTest {
+    fun `Jackson3 importGraphAwait returns completed report`() = runSuspendIO {
         val path = "/j3-await-import.ndjson".toPath()
         Jackson3NdJsonBulkExporter().exportGraph(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -196,7 +196,7 @@ class JacksonOkioExtensionsTest {
     // ─── Jackson 2 Suspend / Flow ─────────────────────────────────────────────
 
     @Test
-    fun `Jackson2 exportGraphAwait returns completed report`() = runTest {
+    fun `Jackson2 exportGraphAwait returns completed report`() = runSuspendIO {
         val path = "/j2-await.ndjson".toPath()
         val report = Jackson2NdJsonBulkExporter().exportGraphAwait(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -205,7 +205,7 @@ class JacksonOkioExtensionsTest {
     }
 
     @Test
-    fun `Jackson2 importGraphAwait returns completed report`() = runTest {
+    fun `Jackson2 importGraphAwait returns completed report`() = runSuspendIO {
         val path = "/j2-await-import.ndjson".toPath()
         Jackson2NdJsonBulkExporter().exportGraph(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -219,7 +219,7 @@ class JacksonOkioExtensionsTest {
     }
 
     @Test
-    fun `Jackson2 exportGraphFlow emits progress`() = runTest {
+    fun `Jackson2 exportGraphFlow emits progress`() = runSuspendIO {
         val path = "/j2-flow-export.ndjson".toPath()
         val events = Jackson2NdJsonBulkExporter().exportGraphFlow(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -228,7 +228,7 @@ class JacksonOkioExtensionsTest {
     }
 
     @Test
-    fun `Jackson2 importGraphFlow emits progress`() = runTest {
+    fun `Jackson2 importGraphFlow emits progress`() = runSuspendIO {
         val path = "/j2-flow-import.ndjson".toPath()
         Jackson2NdJsonBulkExporter().exportGraph(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,
@@ -255,7 +255,7 @@ class JacksonOkioExtensionsTest {
     }
 
     @Test
-    fun `Jackson3 exportGraphFlow emits progress`() = runTest {
+    fun `Jackson3 exportGraphFlow emits progress`() = runSuspendIO {
         val path = "/j3-flow-export.ndjson".toPath()
         val events = Jackson3NdJsonBulkExporter().exportGraphFlow(
             OkioGraphExportSink.PathSink(path, fakeFs), buildSourceGraph(), exportOptions,


### PR DESCRIPTION
## Summary

- Replace remaining `runTest` usage in graph-io Okio suspend tests with `runSuspendIO`.
- Replace the remaining `kotlin.test.assertFailsWith` in Okio suspend adapter coverage with the bluetape4k assertion helper.
- Align code-graph example suspend tests, including Testcontainers-backed AGE/Neo4j/Memgraph/FalkorDB paths, with the same real-IO coroutine test harness policy.
- Record the release-line lesson for future pre-release scans.

Fixes #241

## Verification

- `./gradlew :bluetape4k-graph-okio:test --tests '*SuspendAdapterTest' --tests '*CsvOkioExtensionsTest' --tests '*GraphMLOkioExtensionsTest' --tests '*JacksonOkioExtensionsTest' :code-graph-examples:test --tests '*CodeGraphSuspendTest' --console=plain`
- `./gradlew :bluetape4k-graph-okio:detekt --console=plain`
- `rg -n 'kotlinx\\.coroutines\\.test\\.runTest|\\brunTest\\b|kotlin\\.test|org\\.junit\\.jupiter\\.api\\.Assertions|assertThrows|assertThat\\(' graph-io/okio/src/test/kotlin examples/code-graph-examples/src/test/kotlin -S || true`
- `git diff --check`
- Native Codex `code-reviewer`: P0=0, P1=0, P2=0.

## Notes

- `:code-graph-examples` does not define a `detekt` task, so Gradle compile/test plus bounded pattern scans were used for that module.
- Full repository test suite and IDE diagnostics were not run in this session.
