### PR TITLE
ci: declare workflow token permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
@@ -76,6 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: validate-wrapper
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       graph-core: ${{ steps.filter.outputs.graph-core }}
       graph-neo4j: ${{ steps.filter.outputs.graph-neo4j }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -39,6 +39,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -15,6 +15,9 @@ on:
           - smoke
           - full
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -11,6 +11,9 @@ concurrency:
   group: publish-snapshot
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ concurrency:
   group: publish-release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'

--- a/docs/lessons/2026-05-27-issue-243-workflow-permissions.md
+++ b/docs/lessons/2026-05-27-issue-243-workflow-permissions.md
@@ -1,0 +1,30 @@
+# Issue 243 - Workflow permissions hardening
+
+## Context
+
+GitHub CodeQL Actions analysis reported `actions/missing-workflow-permissions`
+alerts on CI, Nightly, Examples, Benchmark, Snapshot publish, and Release
+workflows before the 0.4.2 release.
+
+## Decision
+
+Declare workflow-level `contents: read` as the default token permission and add
+job-local permissions only where a job needs more than repository read access.
+The CI path detection job keeps `pull-requests: read`, and the release creation
+job keeps its existing `contents: write` override.
+
+## Outcome
+
+The workflow token defaults are now explicit and least-privilege oriented without
+changing build, test, benchmark, or publish commands.
+
+## Verification
+
+- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml .github/workflows/examples.yml .github/workflows/release.yml .github/workflows/benchmark.yml .github/workflows/publish-snapshot.yml`
+- `yq '.permissions'` confirms read-only defaults on each touched workflow.
+
+## Future guard
+
+For new or edited GitHub Actions workflows, add explicit top-level or job-level
+`permissions:` in the first PR rather than waiting for CodeQL code-scanning
+alerts.


### PR DESCRIPTION
## Summary

- Fixes #243.
- Add explicit workflow-level `contents: read` permissions to CI, Nightly, Examples, Benchmark, Snapshot publish, and Release workflows.
- Add job-local `pull-requests: read` for the CI path detector.
- Preserve `contents: write` only for the GitHub Release creation job.
- Add a lesson for future workflow permission hardening.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml .github/workflows/examples.yml .github/workflows/release.yml .github/workflows/benchmark.yml .github/workflows/publish-snapshot.yml`
- `yq '.permissions'` confirmed `contents: read` defaults on each touched workflow.
- `yq '.jobs.changes.permissions' .github/workflows/ci.yml` confirmed `contents: read` and `pull-requests: read`.
- `yq '.jobs.github-release.permissions' .github/workflows/release.yml` confirmed `contents: write` remains scoped to release creation.
- `git diff --check`

## Code scanning

The CodeQL `actions/missing-workflow-permissions` alerts are expected to close after the next CodeQL Actions analysis on this branch or after merge to `develop`.
