### PR TITLE
docs: backfill 0.4.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-27
+
+### Fixed
+
+- **Release catalog selection is deterministic for tag-triggered releases**:
+  release workflow tag runs now ignore stale repository catalog variables and
+  use the checked-in catalog default, while manual dispatch can still override
+  `catalogRef` explicitly ([#227](https://github.com/bluetape4k/bluetape4k-graph/issues/227)).
+- **TinkerGraph shortest-path facade warning cleanup**: suppressed the
+  facade-size warning without changing the shortest-path behavior stabilized in
+  the 0.4.x line.
+
+### Changed
+
+- **Dependency alignment for the 0.4.2 release line**: updated the graph build to
+  consume the `bluetape4k-projects` 1.9.2 BOM and the
+  `catalog/2026-05-26-01` shared catalog reference.
+- **GitHub Actions token hardening**: CI, Nightly, Examples, Benchmark,
+  Snapshot publish, and Release workflows now declare explicit read-only default
+  `GITHUB_TOKEN` permissions, with narrow job-level write/read overrides only
+  where required ([#243](https://github.com/bluetape4k/bluetape4k-graph/issues/243)).
+
+### Tests
+
+- **GraphML unsupported element policy matrix**: locked reader behavior for
+  unsupported GraphML elements so future parser changes preserve the documented
+  skip/fail policy ([#231](https://github.com/bluetape4k/bluetape4k-graph/issues/231)).
+- **Graph-io skipped-record failure accounting**: added coverage for skipped
+  record accounting on graph-io failure paths ([#239](https://github.com/bluetape4k/bluetape4k-graph/issues/239)).
+- **Benchmark evidence contracts**: added lightweight coverage for benchmark
+  wrapper JSON stdout, benchmark SVG rendering, and graph-io benchmark smoke
+  execution paths ([#236](https://github.com/bluetape4k/bluetape4k-graph/issues/236),
+  [#237](https://github.com/bluetape4k/bluetape4k-graph/issues/237),
+  [#238](https://github.com/bluetape4k/bluetape4k-graph/issues/238)).
+- **Suspend graph test harness alignment**: remaining IO/Testcontainers-backed
+  suspend graph tests now use `runSuspendIO` and bluetape4k assertion helpers
+  instead of virtual-time or Kotlin test assertions ([#241](https://github.com/bluetape4k/bluetape4k-graph/issues/241)).
+
 ## [0.4.0] - 2026-05-22
 
 ### Added

--- a/docs/lessons/2026-05-27-release-changelog-gate.md
+++ b/docs/lessons/2026-05-27-release-changelog-gate.md
@@ -1,0 +1,33 @@
+# Release changelog gate
+
+## Context
+
+The graph 0.4.2 release was published successfully, but `CHANGELOG.md` did not
+contain a `0.4.2` section before the release tag was created. The GitHub Release
+workflow therefore used fallback notes.
+
+## Decision
+
+Treat a current-version `CHANGELOG.md` section as a release preflight gate before
+tagging or dispatching a stable release. If the section is missing, stop the
+release flow and add it before creating the release tag.
+
+## Outcome
+
+The 0.4.2 changelog section and GitHub Release notes were backfilled after the
+release. The tag was not moved because the published artifacts already use that
+commit.
+
+## Verification
+
+- `CHANGELOG.md` now includes a `0.4.2` section.
+- GitHub Release notes for `0.4.2` were updated to match the changelog summary.
+
+## Future guard
+
+Before any stable release tag push, verify:
+
+- `CHANGELOG.md` has a section for the target version.
+- The section includes the release date.
+- The release notes summarize closed milestone issues and release workflow
+  changes.


### PR DESCRIPTION
## Summary

- Backfill the missing `CHANGELOG.md` section for the already-published 0.4.2 release.
- Record a release lesson so future stable releases stop before tagging when the target changelog section is missing.
- GitHub Release notes for `0.4.2` have already been updated to match this release summary.

## Verification

- `git diff --check`
- `gh release view 0.4.2 --json body,url` confirms the GitHub Release notes no longer use fallback content.

## Release note

This is a post-release documentation correction only. The `0.4.2` tag was not moved because Maven Central artifacts and the GitHub Release already point at the published release commit.
