### PR TITLE
chore: start 0.5.0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.4.2] - 2026-05-27
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # project version
 #
 projectGroup=io.github.bluetape4k.graph
-baseVersion=0.4.2
+baseVersion=0.5.0
 snapshotVersion=
 
 # Shared bluetape4k ecosystem catalog version


### PR DESCRIPTION
## Summary

- Advance `baseVersion` from `0.4.2` to `0.5.0` after the 0.4.2 release.
- Add a `0.5.0` changelog section for upcoming milestone work.
- Confirm the existing `0.5.0` milestone remains open.

## Verification

- `git diff --check`
- `./gradlew help --no-daemon --no-configuration-cache --console=plain`
