### PR TITLE
feat: add graph-ktor managed backend DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Ktor managed backend DSL**: `graph-ktor` can now create and own Neo4j,
+  Memgraph, and FalkorDB drivers through `neo4j { ... }`, `memgraph { ... }`,
+  and `falkorDB { ... }`, while preserving caller-owned helper overloads
+  ([#232](https://github.com/bluetape4k/bluetape4k-graph/issues/232)).
+
 ### Changed
 
 ### Fixed

--- a/docs/lessons/2026-05-28-issue-232-ktor-managed-backend-dsl.md
+++ b/docs/lessons/2026-05-28-issue-232-ktor-managed-backend-dsl.md
@@ -1,0 +1,35 @@
+# 2026-05-28 - Issue #232 Ktor Managed Backend DSL
+
+## Context
+
+Issue #232 added a managed backend property DSL for `graph-ktor` so small Ktor services can let the plugin create
+Neo4j, Memgraph, or FalkorDB drivers directly.
+
+## Decision
+
+Keep caller-owned helpers unchanged and add managed-driver overloads:
+
+- `neo4j { uri; username; password; database }`
+- `memgraph { uri; username; password; database }`
+- `falkorDB { host; port; username; password; graphName }`
+
+Apache AGE managed `DataSource` setup is separate issue #254 because Exposed `Database.connect(...)`, global
+transaction-manager state, and pool ownership need a narrower contract.
+
+## Outcome
+
+Future Ktor examples should prefer the managed-driver DSL when the example owns the backend connection. Use the
+caller-owned overloads only when a test fixture, DI container, or external lifecycle clearly owns the driver.
+
+## Verification
+
+Planned gates:
+
+- `./gradlew :bluetape4k-graph-ktor:compileKotlin :bluetape4k-graph-ktor:compileTestKotlin --no-daemon`
+- `./gradlew :bluetape4k-graph-ktor:test --no-daemon`
+- `git diff --check`
+
+## Future Guidance
+
+When implementing example issues #247 through #252, use the latest Ktor managed-driver DSL for Ktor setup examples unless
+the example deliberately demonstrates externally owned driver lifecycle.

--- a/docs/superpowers/plans/2026-05-28-issue-232-ktor-managed-backend-dsl-plan.md
+++ b/docs/superpowers/plans/2026-05-28-issue-232-ktor-managed-backend-dsl-plan.md
@@ -1,0 +1,35 @@
+# Issue #232 Ktor Managed Backend DSL Plan
+
+> Spec: [2026-05-28-issue-232-ktor-managed-backend-dsl-design.md](../specs/2026-05-28-issue-232-ktor-managed-backend-dsl-design.md)
+> Related issue: [#232](https://github.com/bluetape4k/bluetape4k-graph/issues/232)
+
+## Tasks
+
+| Task | Scope | Verification |
+|---|---|---|
+| T1. Managed config API | Add Neo4j, Memgraph, FalkorDB property DSL overloads under `ktor/graph-ktor` | `:bluetape4k-graph-ktor:compileKotlin` |
+| T2. Lifecycle wiring | Register operation close actions and managed driver close actions in stop order | `:bluetape4k-graph-ktor:test` |
+| T3. Runtime tests | Update backend Ktor smoke tests to use managed DSL for Neo4j/Memgraph/FalkorDB | targeted test task |
+| T4. Docs | Update `README.md` / `README.ko.md` and record AGE split to #254 | `git diff --check` |
+| T5. Lesson | Add future guard for example issues to use the latest Ktor DSL | content review |
+
+## Validation Commands
+
+```bash
+./gradlew :bluetape4k-graph-ktor:compileKotlin :bluetape4k-graph-ktor:compileTestKotlin --no-daemon
+./gradlew :bluetape4k-graph-ktor:test --no-daemon
+git diff --check
+```
+
+If Testcontainers or Docker is unavailable, rerun the non-container compile/test subset and record the
+environment gap instead of claiming full backend runtime proof.
+
+## Plan Review
+
+Local 7-tier plan review:
+
+- P0/P1: none.
+- P2: AGE managed `DataSource` could be perceived as part of #232. Mitigation: create #254 and document the exclusion.
+- P2: managed DSL may tempt examples to hide backend dependencies. Mitigation: README states applications still declare the concrete backend module.
+
+Convergence: P0 = 0, P1 = 0.

--- a/docs/superpowers/specs/2026-05-28-issue-232-ktor-managed-backend-dsl-design.md
+++ b/docs/superpowers/specs/2026-05-28-issue-232-ktor-managed-backend-dsl-design.md
@@ -1,0 +1,92 @@
+# Issue #232 Ktor Managed Backend DSL Design
+
+> Related issue: [#232](https://github.com/bluetape4k/bluetape4k-graph/issues/232)
+
+## Context
+
+`graph-ktor` currently supports explicit backend selection through caller-owned resources:
+`neo4j(driver)`, `memgraph(driver)`, `falkorDB(driver)`, `age(graphName)`, and `tinkerGraph()`.
+That is the correct low-level contract, but small Ktor services still need to create backend drivers
+outside the plugin before they can install `GraphPlugin`.
+
+The 0.5.0 slice should add a narrowly scoped property DSL for backends where driver ownership is
+straightforward. Future example modules should prefer this latest DSL when they demonstrate Ktor
+backend setup.
+
+## Scope
+
+Included:
+
+- `neo4j { uri; username; password; database }` managed-driver DSL.
+- `memgraph { uri; username; password; database }` managed-driver DSL.
+- `falkorDB { host; port; username; password; graphName }` managed-driver DSL.
+- Ktor plugin tests proving the managed DSL still exposes sync and suspend operations through routes.
+- README examples and lifecycle notes.
+- A lesson/future guard telling new example issues to use the latest DSL.
+
+Excluded:
+
+- Apache AGE managed `DataSource` creation. That requires a separate ownership decision for Exposed
+  `Database.connect(...)`, process-level transaction manager state, and pool shutdown. Tracked by
+  [#254](https://github.com/bluetape4k/bluetape4k-graph/issues/254).
+- New dependencies. The DSL reuses backend driver dependencies already required by the existing helpers.
+
+## Design
+
+Existing helper overloads remain caller-owned:
+
+```kotlin
+install(GraphPlugin) {
+    neo4j(driver, database = "neo4j")
+}
+```
+
+Managed helper overloads create and own the driver:
+
+```kotlin
+install(GraphPlugin) {
+    neo4j {
+        uri = "bolt://localhost:7687"
+        username = "neo4j"
+        password = "secret"
+        database = "neo4j"
+    }
+}
+```
+
+Lifecycle:
+
+- The plugin owns only drivers created by the managed DSL.
+- On `ApplicationStopped`, operation close actions run before the managed driver close action.
+- Caller-owned helpers do not close injected drivers.
+- AGE remains caller-owned until #254 defines how `DataSource` and Exposed lifecycle should work.
+
+Validation:
+
+- URI/host/database/graphName must not be blank.
+- FalkorDB port must be positive.
+- Blank username means no-auth for Neo4j/Memgraph and unauthenticated driver creation for FalkorDB.
+
+## Acceptance Mapping
+
+| Acceptance criterion | Decision |
+|---|---|
+| Supports backends where lifecycle ownership is straightforward | Neo4j, Memgraph, FalkorDB managed drivers |
+| Explicit ownership and close behavior | Managed DSL closes created driver; caller-owned helpers unchanged |
+| Keeps coroutine-first access | `GraphSuspendOperations` remains resolved and exposed by `ApplicationCall.graphSuspendOperations()` |
+| Adds tests and README examples | Ktor runtime tests plus README/README.ko updates |
+| No new dependency unless justified | No new dependency |
+
+## Review Notes
+
+Local 7-tier design review:
+
+- Security: no credential logging; README uses placeholder passwords.
+- Ops/SRE: managed driver close runs through existing isolated close-action path.
+- Structural: overloads preserve existing source compatibility.
+- Kotlin quality: property config classes are mutable Ktor DSL objects, not data classes.
+- Tests: existing backend smoke can exercise managed helper overloads with Testcontainers.
+- Performance: no extra driver pools beyond the explicitly selected backend.
+- Docs/evidence: README lifecycle table must distinguish caller-owned and managed helpers.
+
+Convergence: P0 = 0, P1 = 0.

--- a/ktor/graph-ktor/README.ko.md
+++ b/ktor/graph-ktor/README.ko.md
@@ -16,6 +16,7 @@
 - `Application.graphOperations()` / `Application.graphSuspendOperations()`.
 - Route handler용 `ApplicationCall.graphOperations()` / `ApplicationCall.graphSuspendOperations()`.
 - TinkerGraph, Neo4j, Memgraph, Apache AGE, FalkorDB backend helper.
+- Neo4j, Memgraph, FalkorDB용 managed-driver property DSL.
 - Plugin-owned resource lifecycle cleanup.
 
 ## 의존성
@@ -68,15 +69,39 @@ fun Application.module(driver: Driver) {
 }
 ```
 
+### Managed Neo4j Driver
+
+```kotlin
+fun Application.module() {
+    install(GraphPlugin) {
+        neo4j {
+            uri = "bolt://localhost:7687"
+            username = "neo4j"
+            password = "secret"
+            database = "neo4j"
+        }
+    }
+}
+```
+
+같은 managed-driver pattern은 `memgraph { ... }`, `falkorDB { ... }`에서도 사용할 수 있습니다.
+Application은 여전히 실제 사용할 backend module dependency를 직접 선언해야 합니다.
+
 ## Backend 참고
 
 | Backend | Helper | Lifecycle |
 |---|---|---|
 | TinkerGraph | `tinkerGraph()` | Plugin이 in-memory graph delegate를 생성하고 닫습니다. |
 | Neo4j | `neo4j(driver, database)` | Driver는 caller-owned이며 plugin이 닫지 않습니다. |
+| Neo4j | `neo4j { uri; username; password; database }` | Plugin이 driver를 생성하고 닫습니다. |
 | Memgraph | `memgraph(driver, database)` | Driver는 caller-owned이며 plugin이 닫지 않습니다. |
+| Memgraph | `memgraph { uri; username; password; database }` | Plugin이 driver를 생성하고 닫습니다. |
 | Apache AGE | `age(graphName)` | Graph 사용 전에 caller가 Exposed `Database.connect(...)`를 호출해야 합니다. |
 | FalkorDB | `falkorDB(driver, graphName)` | Driver는 caller-owned이며 plugin이 닫지 않습니다. |
+| FalkorDB | `falkorDB { host; port; username; password; graphName }` | Plugin이 driver를 생성하고 닫습니다. |
+
+Apache AGE managed `DataSource` 생성은 Exposed transaction manager와 pool ownership 계약이 필요하므로
+[#254](https://github.com/bluetape4k/bluetape4k-graph/issues/254)에서 별도로 다룹니다.
 
 ## 테스트
 

--- a/ktor/graph-ktor/README.md
+++ b/ktor/graph-ktor/README.md
@@ -15,6 +15,7 @@ Ktor 3.x plugin integration for `bluetape4k-graph`. It exposes `GraphOperations`
 - `Application.graphOperations()` / `Application.graphSuspendOperations()`.
 - `ApplicationCall.graphOperations()` / `ApplicationCall.graphSuspendOperations()` for route handlers.
 - Backend helper functions for TinkerGraph, Neo4j, Memgraph, Apache AGE, and FalkorDB.
+- Managed-driver property DSLs for Neo4j, Memgraph, and FalkorDB.
 - Lifecycle cleanup for plugin-owned resources.
 
 ## Dependencies
@@ -67,15 +68,40 @@ fun Application.module(driver: Driver) {
 }
 ```
 
+### Managed Neo4j Driver
+
+```kotlin
+fun Application.module() {
+    install(GraphPlugin) {
+        neo4j {
+            uri = "bolt://localhost:7687"
+            username = "neo4j"
+            password = "secret"
+            database = "neo4j"
+        }
+    }
+}
+```
+
+The same managed-driver pattern is available through `memgraph { ... }` and
+`falkorDB { ... }`. Applications still declare the concrete backend module as a dependency.
+
 ## Backend Notes
 
 | Backend | Helper | Lifecycle |
 |---|---|---|
 | TinkerGraph | `tinkerGraph()` | Plugin creates and closes the in-memory graph delegate. |
 | Neo4j | `neo4j(driver, database)` | Driver is caller-owned and is not closed by the plugin. |
+| Neo4j | `neo4j { uri; username; password; database }` | Plugin creates and closes the driver. |
 | Memgraph | `memgraph(driver, database)` | Driver is caller-owned and is not closed by the plugin. |
+| Memgraph | `memgraph { uri; username; password; database }` | Plugin creates and closes the driver. |
 | Apache AGE | `age(graphName)` | Caller must call Exposed `Database.connect(...)` before graph use. |
 | FalkorDB | `falkorDB(driver, graphName)` | Driver is caller-owned and is not closed by the plugin. |
+| FalkorDB | `falkorDB { host; port; username; password; graphName }` | Plugin creates and closes the driver. |
+
+Managed Apache AGE `DataSource` creation is intentionally tracked separately in
+[#254](https://github.com/bluetape4k/bluetape4k-graph/issues/254) because Exposed
+transaction-manager and pool ownership need a dedicated contract.
 
 ## Testing
 

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedFalkorDBGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedFalkorDBGraphPluginConfig.kt
@@ -1,0 +1,71 @@
+package io.bluetape4k.graph.ktor
+
+import com.falkordb.FalkorDB
+import io.bluetape4k.graph.falkordb.FalkorDBGraphOperations
+import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+
+/**
+ * Ktor DSL for creating a FalkorDB driver owned by [GraphPlugin].
+ *
+ * ## Behavior / Contract
+ * - [host] and [graphName] must not be blank.
+ * - [port] must be positive.
+ * - A blank [username] uses unauthenticated `FalkorDB.driver(host, port)`.
+ * - The driver created by this DSL is plugin-owned and is closed on `ApplicationStopped`.
+ *
+ * ```kotlin
+ * install(GraphPlugin) {
+ *     falkorDB {
+ *         host = "localhost"
+ *         port = 6379
+ *         graphName = "social"
+ *     }
+ * }
+ * ```
+ */
+class ManagedFalkorDBGraphPluginConfig {
+    var host: String = "localhost"
+    var port: Int = 6379
+    var username: String = ""
+    var password: String = ""
+    var graphName: String = FalkorDBGraphOperations.DEFAULT_GRAPH_NAME
+}
+
+/**
+ * Configures [GraphPlugin] with a plugin-owned FalkorDB driver.
+ */
+fun GraphPluginConfig.falkorDB(
+    configure: ManagedFalkorDBGraphPluginConfig.() -> Unit,
+): GraphPluginConfig = apply {
+    val props = ManagedFalkorDBGraphPluginConfig().apply(configure)
+    props.host.requireNotBlank("host")
+    props.port.requirePositiveNumber("port")
+    props.graphName.requireNotBlank("graphName")
+
+    val driver = if (props.username.isBlank()) {
+        FalkorDB.driver(props.host, props.port)
+    } else {
+        FalkorDB.driver(props.host, props.port, props.username, props.password)
+    }
+    val graphOperations = FalkorDBGraphOperations(driver, props.graphName)
+    val graphSuspendOperations = FalkorDBGraphSuspendOperations(driver, props.graphName)
+
+    configure(
+        backendName = "managedFalkorDB",
+        graphOperationsFactory = { graphOperations },
+        graphSuspendOperationsFactory = { graphSuspendOperations },
+        closeActions = listOf(
+            GraphPluginCloseAction("FalkorDBGraphOperations") {
+                graphOperations.close()
+            },
+            GraphPluginCloseAction("FalkorDBGraphSuspendOperations") {
+                graphSuspendOperations.close()
+            },
+            GraphPluginCloseAction("FalkorDBDriver") {
+                driver.close()
+            },
+        ),
+    )
+}

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedMemgraphGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedMemgraphGraphPluginConfig.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.graph.ktor
+
+import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
+import io.bluetape4k.graph.memgraph.MemgraphGraphSuspendOperations
+import io.bluetape4k.support.requireNotBlank
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * Ktor DSL for creating a Memgraph driver owned by [GraphPlugin].
+ *
+ * ## Behavior / Contract
+ * - Memgraph uses the Neo4j Bolt-compatible Java driver.
+ * - [uri] and [database] must not be blank.
+ * - A blank [username] creates an unauthenticated driver.
+ * - The driver created by this DSL is plugin-owned and is closed on `ApplicationStopped`.
+ *
+ * ```kotlin
+ * install(GraphPlugin) {
+ *     memgraph {
+ *         uri = "bolt://localhost:7687"
+ *         database = "memgraph"
+ *     }
+ * }
+ * ```
+ */
+class ManagedMemgraphGraphPluginConfig {
+    var uri: String = "bolt://localhost:7687"
+    var username: String = ""
+    var password: String = ""
+    var database: String = "memgraph"
+}
+
+/**
+ * Configures [GraphPlugin] with a plugin-owned Memgraph driver.
+ */
+fun GraphPluginConfig.memgraph(
+    configure: ManagedMemgraphGraphPluginConfig.() -> Unit,
+): GraphPluginConfig = apply {
+    val props = ManagedMemgraphGraphPluginConfig().apply(configure)
+    props.uri.requireNotBlank("uri")
+    props.database.requireNotBlank("database")
+
+    val authToken = if (props.username.isBlank()) {
+        AuthTokens.none()
+    } else {
+        AuthTokens.basic(props.username, props.password)
+    }
+    val driver = GraphDatabase.driver(props.uri, authToken)
+    val graphOperations = MemgraphGraphOperations(driver, props.database)
+    val graphSuspendOperations = MemgraphGraphSuspendOperations(driver, props.database)
+
+    configure(
+        backendName = "managedMemgraph",
+        graphOperationsFactory = { graphOperations },
+        graphSuspendOperationsFactory = { graphSuspendOperations },
+        closeActions = listOf(
+            GraphPluginCloseAction("MemgraphGraphOperations") {
+                graphOperations.close()
+            },
+            GraphPluginCloseAction("MemgraphGraphSuspendOperations") {
+                graphSuspendOperations.close()
+            },
+            GraphPluginCloseAction("MemgraphDriver") {
+                driver.close()
+            },
+        ),
+    )
+}

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedNeo4jGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedNeo4jGraphPluginConfig.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.graph.ktor
+
+import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
+import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
+import io.bluetape4k.support.requireNotBlank
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.GraphDatabase
+
+/**
+ * Ktor DSL for creating a Neo4j driver owned by [GraphPlugin].
+ *
+ * ## Behavior / Contract
+ * - [uri] and [database] must not be blank.
+ * - A blank [username] creates the driver with `AuthTokens.none()`.
+ * - The driver created by this DSL is plugin-owned and is closed on `ApplicationStopped`.
+ * - The existing `neo4j(driver, database)` helper keeps its caller-owned driver contract.
+ *
+ * ```kotlin
+ * install(GraphPlugin) {
+ *     neo4j {
+ *         uri = "bolt://localhost:7687"
+ *         username = "neo4j"
+ *         password = "secret"
+ *     }
+ * }
+ * ```
+ */
+class ManagedNeo4jGraphPluginConfig {
+    var uri: String = "bolt://localhost:7687"
+    var username: String = ""
+    var password: String = ""
+    var database: String = "neo4j"
+}
+
+/**
+ * Configures [GraphPlugin] with a plugin-owned Neo4j driver.
+ */
+fun GraphPluginConfig.neo4j(
+    configure: ManagedNeo4jGraphPluginConfig.() -> Unit,
+): GraphPluginConfig = apply {
+    val props = ManagedNeo4jGraphPluginConfig().apply(configure)
+    props.uri.requireNotBlank("uri")
+    props.database.requireNotBlank("database")
+
+    val authToken = if (props.username.isBlank()) {
+        AuthTokens.none()
+    } else {
+        AuthTokens.basic(props.username, props.password)
+    }
+    val driver = GraphDatabase.driver(props.uri, authToken)
+    val graphOperations = Neo4jGraphOperations(driver, props.database)
+    val graphSuspendOperations = Neo4jGraphSuspendOperations(driver, props.database)
+
+    configure(
+        backendName = "managedNeo4j",
+        graphOperationsFactory = { graphOperations },
+        graphSuspendOperationsFactory = { graphSuspendOperations },
+        closeActions = listOf(
+            GraphPluginCloseAction("Neo4jGraphOperations") {
+                graphOperations.close()
+            },
+            GraphPluginCloseAction("Neo4jGraphSuspendOperations") {
+                graphSuspendOperations.close()
+            },
+            GraphPluginCloseAction("Neo4jDriver") {
+                driver.close()
+            },
+        ),
+    )
+}

--- a/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/BackendGraphPluginRuntimeTest.kt
+++ b/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/BackendGraphPluginRuntimeTest.kt
@@ -6,8 +6,6 @@ import com.zaxxer.hikari.HikariDataSource
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.graph.age.AgeGraphOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
-import io.bluetape4k.graph.memgraph.MemgraphGraphOperations
-import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
@@ -31,30 +29,32 @@ import java.util.UUID
 class BackendGraphPluginRuntimeTest {
 
     @Test
-    fun `Neo4j helper 는 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
-        val driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
-
+    fun `managed Neo4j DSL 은 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
         try {
             backendSmoke(graphName = "default") {
-                neo4j(driver)
+                neo4j {
+                    uri = Neo4jServer.Launcher.neo4j.boltUrl
+                }
             }
         } finally {
-            runCatching { Neo4jGraphOperations(driver).dropGraph("default") }
-            driver.close()
+            GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none()).use { driver ->
+                runCatching { driver.session().use { session -> session.run("MATCH (n) DETACH DELETE n").consume() } }
+            }
         }
     }
 
     @Test
-    fun `Memgraph helper 는 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
-        val driver = GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none())
-
+    fun `managed Memgraph DSL 은 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
         try {
             backendSmoke(graphName = "default") {
-                memgraph(driver)
+                memgraph {
+                    uri = MemgraphServer.Launcher.memgraph.boltUrl
+                }
             }
         } finally {
-            runCatching { MemgraphGraphOperations(driver).dropGraph("default") }
-            driver.close()
+            GraphDatabase.driver(MemgraphServer.Launcher.memgraph.boltUrl, AuthTokens.none()).use { driver ->
+                runCatching { driver.session().use { session -> session.run("MATCH (n) DETACH DELETE n").consume() } }
+            }
         }
     }
 
@@ -88,18 +88,22 @@ class BackendGraphPluginRuntimeTest {
     }
 
     @Test
-    fun `FalkorDB helper 는 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
+    fun `managed FalkorDB DSL 은 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
         val graphName = randomGraphName("ktor_falkor")
         val server = FalkorDBServer.Launcher.falkordb
-        val driver = FalkorDB.driver(server.host, server.port)
 
         try {
             backendSmoke(graphName = graphName) {
-                falkorDB(driver, graphName)
+                falkorDB {
+                    host = server.host
+                    port = server.port
+                    this.graphName = graphName
+                }
             }
         } finally {
-            runCatching { driver.graph(graphName).use { graph -> graph.deleteGraph() } }
-            driver.close()
+            FalkorDB.driver(server.host, server.port).use { driver ->
+                runCatching { driver.graph(graphName).use { graph -> graph.deleteGraph() } }
+            }
         }
     }
 

--- a/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
+++ b/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
@@ -134,6 +134,33 @@ class GraphPluginTest {
         }
     }
 
+    @Test
+    fun `managed backend DSL 은 잘못된 property 를 fail fast 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().neo4j {
+                uri = " "
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().memgraph {
+                database = " "
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().falkorDB {
+                host = " "
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().falkorDB {
+                port = 0
+            }
+        }
+    }
+
     private class ThrowingGraphOperations(
         private val delegate: GraphOperations,
         private val closed: AtomicBoolean,


### PR DESCRIPTION
## Summary

Adds managed-driver property DSLs to `graph-ktor` so small Ktor services can let `GraphPlugin` create and own backend drivers directly.

Closes #232.

## DoD Checklist

- [x] Add `neo4j { uri; username; password; database }` managed-driver DSL.
- [x] Add `memgraph { uri; username; password; database }` managed-driver DSL.
- [x] Add `falkorDB { host; port; username; password; graphName }` managed-driver DSL.
- [x] Preserve caller-owned helpers: `neo4j(driver)`, `memgraph(driver)`, `falkorDB(driver)`, and `age(graphName)`.
- [x] Keep coroutine-first `GraphSuspendOperations` access intact through `ApplicationCall.graphSuspendOperations()`.
- [x] Document lifecycle ownership in `README.md` and `README.ko.md`.
- [x] Split Apache AGE managed `DataSource` ownership into follow-up #254.
- [x] Add lesson guard so future example issues #247-#252 prefer the latest Ktor managed DSL when the example owns the backend connection.

## Changed Files

- `ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedNeo4jGraphPluginConfig.kt`
- `ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedMemgraphGraphPluginConfig.kt`
- `ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedFalkorDBGraphPluginConfig.kt`
- `ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/BackendGraphPluginRuntimeTest.kt`
- `ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt`
- `ktor/graph-ktor/README.md`
- `ktor/graph-ktor/README.ko.md`
- `CHANGELOG.md`
- `docs/superpowers/specs/2026-05-28-issue-232-ktor-managed-backend-dsl-design.md`
- `docs/superpowers/plans/2026-05-28-issue-232-ktor-managed-backend-dsl-plan.md`
- `docs/lessons/2026-05-28-issue-232-ktor-managed-backend-dsl.md`

## Verification

- [x] `./gradlew projects --no-daemon | rg 'graph-ktor|ktor-graph-examples'`
- [x] `./gradlew :bluetape4k-graph-ktor:compileKotlin :bluetape4k-graph-ktor:compileTestKotlin --no-daemon`
- [x] `./gradlew :bluetape4k-graph-ktor:test --no-daemon` — 11 tests passing
- [x] `git diff --check`
- [x] untracked-file trailing whitespace check

## Review Gate

Local 7-tier review: P0=0 P1=0.

| Tier | Status | Notes |
|---|---|---|
| Security | Pass | No credential logging added; README uses placeholder credentials. |
| Ops/SRE | Pass | Managed drivers close through existing isolated close-action path. |
| Structural impact | Pass | Existing caller-owned overloads stay source-compatible. |
| Kotlin quality | Pass | DSL config classes use simple mutable Ktor-style properties and bluetape4k validation helpers. |
| Tests/types | Pass | Managed Neo4j, Memgraph, and FalkorDB runtime route smoke tests pass. |
| Performance/stability | Pass | No extra backend is created unless explicitly selected. |
| Docs/evidence | Pass | README pair, CHANGELOG, spec, plan, and lesson updated. |

## Follow-up / Known Gaps

- #254 tracks managed Apache AGE `DataSource` DSL because Exposed transaction-manager and pool ownership need a separate contract.
- IDE diagnostics MCP was unavailable in this session; Gradle compile/test and diff checks were used as fallback evidence.
