### PR TITLE
feat: add graph-ktor AGE DataSource DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Memgraph, and FalkorDB drivers through `neo4j { ... }`, `memgraph { ... }`,
   and `falkorDB { ... }`, while preserving caller-owned helper overloads
   ([#232](https://github.com/bluetape4k/bluetape4k-graph/issues/232)).
+- **Ktor managed Apache AGE DataSource DSL**: `graph-ktor` can now create a
+  Hikari-backed AGE pool through `ageDataSource { ... }`, connect it through
+  Exposed `Database.connect(...)`, and close only the plugin-owned pool on Ktor
+  shutdown ([#254](https://github.com/bluetape4k/bluetape4k-graph/issues/254)).
 
 ### Changed
 

--- a/docs/lessons/2026-05-28-issue-254-ktor-age-datasource-dsl.md
+++ b/docs/lessons/2026-05-28-issue-254-ktor-age-datasource-dsl.md
@@ -1,0 +1,21 @@
+# Issue 254 - Managed AGE DataSource DSL
+
+## Context
+
+`graph-ktor` gained managed backend setup for driver-style backends in #232. AGE needed a separate slice because Exposed owns a process-wide JDBC transaction manager and the pool lifecycle must be explicit.
+
+## Decision
+
+Add `ageDataSource { ... }` as a managed, Hikari-backed convenience path while keeping `age(graphName)` as the caller-owned Exposed setup path.
+
+## Outcome
+
+The managed helper creates the pool, calls `Database.connect(dataSource)`, wires sync and suspend AGE operations, and closes only the plugin-created pool on Ktor shutdown.
+
+## Verification
+
+Run focused `graph-ktor` compile and test checks before merging.
+
+## Future Guidance
+
+Use `ageDataSource { ... }` for small Ktor services and examples that do not already have DI-managed Exposed infrastructure. Use `age(graphName)` when the application owns `Database.connect(...)` and the pool.

--- a/docs/superpowers/plans/2026-05-28-issue-254-ktor-age-datasource-dsl-plan.md
+++ b/docs/superpowers/plans/2026-05-28-issue-254-ktor-age-datasource-dsl-plan.md
@@ -1,0 +1,22 @@
+# Issue 254 - graph-ktor Managed AGE DataSource DSL Plan
+
+## DoD
+
+- Add `ageDataSource { ... }` with property validation.
+- Create a Hikari pool, call `Database.connect(dataSource)`, and wire sync/suspend AGE operations.
+- Close plugin-owned AGE operations and the plugin-created Hikari pool on Ktor stop.
+- Preserve the existing caller-owned `age(graphName)` helper.
+- Add validation tests for invalid properties.
+- Add Ktor `testApplication` smoke coverage with PostgreSQL AGE Testcontainers.
+- Update English and Korean `graph-ktor` README files.
+- Update changelog and lesson note.
+- Verify compile, test, and whitespace checks.
+
+## Implementation Steps
+
+1. Add `ManagedAgeDataSourceGraphPluginConfig` and `GraphPluginConfig.ageDataSource`.
+2. Add HikariCP as a compile-only dependency for the optional DSL implementation.
+3. Convert the AGE Ktor runtime smoke to use managed setup.
+4. Add invalid property fail-fast tests.
+5. Document lifecycle ownership and optional Hikari dependency.
+6. Run focused `graph-ktor` compile/test checks.

--- a/docs/superpowers/specs/2026-05-28-issue-254-ktor-age-datasource-dsl-design.md
+++ b/docs/superpowers/specs/2026-05-28-issue-254-ktor-age-datasource-dsl-design.md
@@ -1,0 +1,34 @@
+# Issue 254 - graph-ktor Managed AGE DataSource DSL Design
+
+## Context
+
+Issue #232 added managed-driver DSLs for Neo4j, Memgraph, and FalkorDB. Apache AGE was split out because it uses Exposed's global JDBC transaction manager and a JDBC `DataSource`, not a backend-local driver object.
+
+## Decision
+
+Add a dedicated `ageDataSource { ... }` DSL in `graph-ktor`.
+
+- It creates a plugin-owned Hikari pool from simple properties.
+- It calls Exposed `Database.connect(dataSource)` before constructing AGE operations.
+- It wires `AgeGraphOperations` and `AgeGraphSuspendOperations` into `GraphPlugin`.
+- It closes only the Hikari pool created by the DSL on `ApplicationStopped`.
+- It leaves the existing `age(graphName)` helper as caller-owned for DI-managed Exposed setups.
+
+## Dependency Boundary
+
+`graph-ktor` keeps backend helpers compile-only. HikariCP follows the same optional runtime boundary: the DSL implementation compiles against Hikari, and applications using `ageDataSource { ... }` must include HikariCP with `graph-age`.
+
+## Defaults
+
+- `jdbcUrl`: `jdbc:postgresql://localhost:5432/postgres`
+- `username`: `postgres`
+- `graphName`: `default`
+- `connectionInitSql`: `LOAD 'age'; SET search_path = ag_catalog, "$user", public;`
+- `driverClassName`: `org.postgresql.Driver`
+- `maximumPoolSize`: `4`
+
+## Non-Goals
+
+- Do not replace Exposed's global transaction manager.
+- Do not close caller-owned `Database` or `DataSource` instances.
+- Do not change existing `age(graphName)` behavior.

--- a/ktor/graph-ktor/README.ko.md
+++ b/ktor/graph-ktor/README.ko.md
@@ -16,7 +16,7 @@
 - `Application.graphOperations()` / `Application.graphSuspendOperations()`.
 - Route handler용 `ApplicationCall.graphOperations()` / `ApplicationCall.graphSuspendOperations()`.
 - TinkerGraph, Neo4j, Memgraph, Apache AGE, FalkorDB backend helper.
-- Neo4j, Memgraph, FalkorDB용 managed-driver property DSL.
+- Neo4j, Memgraph, FalkorDB, Apache AGE용 managed property DSL.
 - Plugin-owned resource lifecycle cleanup.
 
 ## 의존성
@@ -28,6 +28,7 @@ dependencies {
     implementation("io.github.bluetape4k.graph:bluetape4k-graph-ktor")
     implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop") // 또는 graph-neo4j, graph-age, ...
     implementation("io.ktor:ktor-server-core")
+    implementation("com.zaxxer:HikariCP") // ageDataSource { ... } 사용 시 필요
 }
 ```
 
@@ -87,6 +88,27 @@ fun Application.module() {
 같은 managed-driver pattern은 `memgraph { ... }`, `falkorDB { ... }`에서도 사용할 수 있습니다.
 Application은 여전히 실제 사용할 backend module dependency를 직접 선언해야 합니다.
 
+### Managed Apache AGE DataSource
+
+```kotlin
+fun Application.module() {
+    install(GraphPlugin) {
+        ageDataSource {
+            jdbcUrl = "jdbc:postgresql://localhost:5432/postgres"
+            username = "postgres"
+            password = "secret"
+            graphName = "social"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, public;"
+        }
+    }
+}
+```
+
+`ageDataSource { ... }`는 Hikari 기반 pool을 생성하고 Exposed
+`Database.connect(dataSource)`를 호출한 뒤, application stop 시 plugin이 생성한 pool만 닫습니다.
+외부 DI container가 Exposed `Database`, `DataSource`, transaction manager lifecycle을 이미 소유한다면
+기존 `age(graphName)` helper를 사용합니다.
+
 ## Backend 참고
 
 | Backend | Helper | Lifecycle |
@@ -97,11 +119,9 @@ Application은 여전히 실제 사용할 backend module dependency를 직접 �
 | Memgraph | `memgraph(driver, database)` | Driver는 caller-owned이며 plugin이 닫지 않습니다. |
 | Memgraph | `memgraph { uri; username; password; database }` | Plugin이 driver를 생성하고 닫습니다. |
 | Apache AGE | `age(graphName)` | Graph 사용 전에 caller가 Exposed `Database.connect(...)`를 호출해야 합니다. |
+| Apache AGE | `ageDataSource { jdbcUrl; username; password; graphName; connectionInitSql }` | Plugin이 Hikari pool을 생성하고 Exposed를 연결한 뒤 생성한 pool만 닫습니다. |
 | FalkorDB | `falkorDB(driver, graphName)` | Driver는 caller-owned이며 plugin이 닫지 않습니다. |
 | FalkorDB | `falkorDB { host; port; username; password; graphName }` | Plugin이 driver를 생성하고 닫습니다. |
-
-Apache AGE managed `DataSource` 생성은 Exposed transaction manager와 pool ownership 계약이 필요하므로
-[#254](https://github.com/bluetape4k/bluetape4k-graph/issues/254)에서 별도로 다룹니다.
 
 ## 테스트
 

--- a/ktor/graph-ktor/README.md
+++ b/ktor/graph-ktor/README.md
@@ -15,7 +15,7 @@ Ktor 3.x plugin integration for `bluetape4k-graph`. It exposes `GraphOperations`
 - `Application.graphOperations()` / `Application.graphSuspendOperations()`.
 - `ApplicationCall.graphOperations()` / `ApplicationCall.graphSuspendOperations()` for route handlers.
 - Backend helper functions for TinkerGraph, Neo4j, Memgraph, Apache AGE, and FalkorDB.
-- Managed-driver property DSLs for Neo4j, Memgraph, and FalkorDB.
+- Managed-driver property DSLs for Neo4j, Memgraph, FalkorDB, and Apache AGE.
 - Lifecycle cleanup for plugin-owned resources.
 
 ## Dependencies
@@ -27,6 +27,7 @@ dependencies {
     implementation("io.github.bluetape4k.graph:bluetape4k-graph-ktor")
     implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop") // or graph-neo4j, graph-age, ...
     implementation("io.ktor:ktor-server-core")
+    implementation("com.zaxxer:HikariCP") // required when using ageDataSource { ... }
 }
 ```
 
@@ -86,6 +87,27 @@ fun Application.module() {
 The same managed-driver pattern is available through `memgraph { ... }` and
 `falkorDB { ... }`. Applications still declare the concrete backend module as a dependency.
 
+### Managed Apache AGE DataSource
+
+```kotlin
+fun Application.module() {
+    install(GraphPlugin) {
+        ageDataSource {
+            jdbcUrl = "jdbc:postgresql://localhost:5432/postgres"
+            username = "postgres"
+            password = "secret"
+            graphName = "social"
+            connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, public;"
+        }
+    }
+}
+```
+
+`ageDataSource { ... }` creates a Hikari-backed pool, calls Exposed
+`Database.connect(dataSource)`, and closes only that plugin-owned pool on
+application stop. Use `age(graphName)` when an external DI container already owns
+the Exposed `Database`, `DataSource`, or transaction-manager lifecycle.
+
 ## Backend Notes
 
 | Backend | Helper | Lifecycle |
@@ -96,12 +118,9 @@ The same managed-driver pattern is available through `memgraph { ... }` and
 | Memgraph | `memgraph(driver, database)` | Driver is caller-owned and is not closed by the plugin. |
 | Memgraph | `memgraph { uri; username; password; database }` | Plugin creates and closes the driver. |
 | Apache AGE | `age(graphName)` | Caller must call Exposed `Database.connect(...)` before graph use. |
+| Apache AGE | `ageDataSource { jdbcUrl; username; password; graphName; connectionInitSql }` | Plugin creates the Hikari pool, connects Exposed, and closes only the pool it created. |
 | FalkorDB | `falkorDB(driver, graphName)` | Driver is caller-owned and is not closed by the plugin. |
 | FalkorDB | `falkorDB { host; port; username; password; graphName }` | Plugin creates and closes the driver. |
-
-Managed Apache AGE `DataSource` creation is intentionally tracked separately in
-[#254](https://github.com/bluetape4k/bluetape4k-graph/issues/254) because Exposed
-transaction-manager and pool ownership need a dedicated contract.
 
 ## Testing
 

--- a/ktor/graph-ktor/build.gradle.kts
+++ b/ktor/graph-ktor/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     compileOnly(project(":bluetape4k-graph-memgraph"))
     compileOnly(project(":bluetape4k-graph-age"))
     compileOnly(project(":bluetape4k-graph-falkordb"))
+    compileOnly(libs.hikaricp)
 
     // Logging
     implementation(libs.bluetape4k.logging)

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedAgeDataSourceGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedAgeDataSourceGraphPluginConfig.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.graph.ktor
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.graph.age.AgeGraphOperations
+import io.bluetape4k.graph.age.AgeGraphSuspendOperations
+import io.bluetape4k.graph.age.sql.AgeSql
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * Ktor DSL for creating an Apache AGE JDBC pool owned by [GraphPlugin].
+ *
+ * ## Behavior / Contract
+ * - [jdbcUrl], [username], [graphName], [connectionInitSql], and [driverClassName] must not be blank.
+ * - [maximumPoolSize] must be positive.
+ * - The managed pool is connected to Exposed through `Database.connect(dataSource)` before AGE operations are created.
+ * - The Hikari pool created by this DSL is plugin-owned and is closed on `ApplicationStopped`.
+ * - The existing `age(graphName)` helper keeps its caller-owned `Database` / `DataSource` contract.
+ *
+ * ```kotlin
+ * install(GraphPlugin) {
+ *     ageDataSource {
+ *         jdbcUrl = "jdbc:postgresql://localhost:5432/postgres"
+ *         username = "postgres"
+ *         password = "secret"
+ *         graphName = "social"
+ *     }
+ * }
+ * ```
+ */
+class ManagedAgeDataSourceGraphPluginConfig {
+    var jdbcUrl: String = "jdbc:postgresql://localhost:5432/postgres"
+    var username: String = "postgres"
+    var password: String = ""
+    var graphName: String = "default"
+    var connectionInitSql: String = "${AgeSql.loadAge()}; ${AgeSql.setSearchPath()};"
+    var driverClassName: String = "org.postgresql.Driver"
+    var maximumPoolSize: Int = 4
+}
+
+/**
+ * Configures [GraphPlugin] with a plugin-owned Apache AGE JDBC pool.
+ */
+fun GraphPluginConfig.ageDataSource(
+    configure: ManagedAgeDataSourceGraphPluginConfig.() -> Unit,
+): GraphPluginConfig = apply {
+    val props = ManagedAgeDataSourceGraphPluginConfig().apply(configure)
+    props.jdbcUrl.requireNotBlank("jdbcUrl")
+    props.username.requireNotBlank("username")
+    props.graphName.requireNotBlank("graphName")
+    props.connectionInitSql.requireNotBlank("connectionInitSql")
+    props.driverClassName.requireNotBlank("driverClassName")
+    props.maximumPoolSize.requirePositiveNumber("maximumPoolSize")
+
+    val dataSource = HikariDataSource(HikariConfig().apply {
+        jdbcUrl = props.jdbcUrl
+        username = props.username
+        password = props.password
+        driverClassName = props.driverClassName
+        connectionInitSql = props.connectionInitSql
+        maximumPoolSize = props.maximumPoolSize
+    })
+
+    try {
+        Database.connect(dataSource)
+
+        val graphOperations = AgeGraphOperations(props.graphName)
+        val graphSuspendOperations = AgeGraphSuspendOperations(props.graphName)
+
+        configure(
+            backendName = "managedAgeDataSource",
+            graphOperationsFactory = { graphOperations },
+            graphSuspendOperationsFactory = { graphSuspendOperations },
+            closeActions = listOf(
+                GraphPluginCloseAction("AgeGraphOperations") {
+                    graphOperations.close()
+                },
+                GraphPluginCloseAction("AgeGraphSuspendOperations") {
+                    graphSuspendOperations.close()
+                },
+                GraphPluginCloseAction("AgeDataSource") {
+                    dataSource.close()
+                },
+            ),
+        )
+    } catch (e: IllegalArgumentException) {
+        dataSource.close()
+        throw e
+    }
+}

--- a/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/BackendGraphPluginRuntimeTest.kt
+++ b/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/BackendGraphPluginRuntimeTest.kt
@@ -59,13 +59,53 @@ class BackendGraphPluginRuntimeTest {
     }
 
     @Test
-    fun `Apache AGE helper 는 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
+    fun `managed Apache AGE DataSource DSL 은 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
         val graphName = randomGraphName("ktor_age")
         val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        val username = requireNotNull(server.username) { "PostgreSQL AGE username must be available" }
+        val password = requireNotNull(server.password) { "PostgreSQL AGE password must be available" }
+
+        try {
+            backendSmoke(graphName = graphName) {
+                ageDataSource {
+                    jdbcUrl = server.jdbcUrl
+                    this.username = username
+                    this.password = password
+                    this.graphName = graphName
+                    connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+                    maximumPoolSize = 2
+                }
+            }
+        } finally {
+            HikariDataSource(HikariConfig().apply {
+                jdbcUrl = server.jdbcUrl
+                this.username = username
+                this.password = password
+                driverClassName = "org.postgresql.Driver"
+                connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
+                maximumPoolSize = 1
+            }).use { cleanupDataSource ->
+                Database.connect(cleanupDataSource)
+                runCatching {
+                    val ops = AgeGraphOperations(graphName)
+                    if (ops.graphExists(graphName)) {
+                        ops.dropGraph(graphName)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `caller-owned Apache AGE helper 는 Ktor route 에서 sync suspend operations 를 연결한다`() = runSuspendIO {
+        val graphName = randomGraphName("ktor_age")
+        val server = PostgreSQLAgeServer.Launcher.postgresqlAge
+        val username = requireNotNull(server.username) { "PostgreSQL AGE username must be available" }
+        val password = requireNotNull(server.password) { "PostgreSQL AGE password must be available" }
         val dataSource = HikariDataSource(HikariConfig().apply {
             jdbcUrl = server.jdbcUrl
-            username = server.username
-            password = server.password
+            this.username = username
+            this.password = password
             driverClassName = "org.postgresql.Driver"
             connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public;"
             maximumPoolSize = 2

--- a/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
+++ b/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
@@ -159,6 +159,24 @@ class GraphPluginTest {
                 port = 0
             }
         }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().ageDataSource {
+                jdbcUrl = " "
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().ageDataSource {
+                graphName = " "
+            }
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphPluginConfig().ageDataSource {
+                maximumPoolSize = 0
+            }
+        }
     }
 
     private class ThrowingGraphOperations(


### PR DESCRIPTION
## Summary

Adds a managed Apache AGE DataSource DSL for `graph-ktor` while preserving the existing caller-owned `age(graphName)` helper.

Closes #254.

## DoD Checklist

- [x] Add `ageDataSource { ... }` for plugin-owned AGE setup.
- [x] Create a Hikari-backed pool from Ktor DSL properties.
- [x] Call Exposed `Database.connect(dataSource)` before creating AGE operations.
- [x] Close only the plugin-owned Hikari pool on Ktor shutdown.
- [x] Keep `age(graphName)` caller-owned behavior intact.
- [x] Keep coroutine-first `GraphSuspendOperations` route access unchanged.
- [x] Document lifecycle and dependency requirements in `README.md` and `README.ko.md`.
- [x] Add PostgreSQL AGE Testcontainers coverage for managed setup.
- [x] Preserve caller-owned AGE runtime smoke coverage.
- [x] Add invalid property fail-fast tests.

## Changed Files

- `ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/ManagedAgeDataSourceGraphPluginConfig.kt`
- `ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/BackendGraphPluginRuntimeTest.kt`
- `ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt`
- `ktor/graph-ktor/README.md`
- `ktor/graph-ktor/README.ko.md`
- `CHANGELOG.md`
- `docs/superpowers/specs/2026-05-28-issue-254-ktor-age-datasource-dsl-design.md`
- `docs/superpowers/plans/2026-05-28-issue-254-ktor-age-datasource-dsl-plan.md`
- `docs/lessons/2026-05-28-issue-254-ktor-age-datasource-dsl.md`

## Verification

- [x] `./gradlew :bluetape4k-graph-ktor:compileKotlin :bluetape4k-graph-ktor:compileTestKotlin --no-daemon`
- [x] `./gradlew :bluetape4k-graph-ktor:compileKotlin :bluetape4k-graph-ktor:compileTestKotlin :bluetape4k-graph-ktor:test --no-daemon`
- [x] `git diff --check`

## Review Gate

- P0=0 P1=0
- Known gap: IDE diagnostics were not available in this Codex session; Gradle compile/test covered the touched Kotlin module.
