### PR TITLE
build: consume projects 1.10.0 BOM

### DIFF
--- a/docs/lessons/2026-06-01-projects-1-10-0-bom-handoff.md
+++ b/docs/lessons/2026-06-01-projects-1-10-0-bom-handoff.md
@@ -1,0 +1,21 @@
+# Projects 1.10.0 BOM handoff
+
+## Context
+
+`bluetape4k-projects` 1.10.0 was released and `bluetape4k-bom:1.10.0` is visible
+from Maven Central.
+
+## Decision
+
+Update the local catalog's projects BOM version from 1.9.2 to 1.10.0 while
+leaving this repository's own release line unchanged.
+
+## Outcome
+
+Graph builds now consume the stable projects 1.10.0 BOM for shared bluetape4k
+module versions.
+
+## Verification
+
+- Maven Central HTTP 200 for `bluetape4k-bom:1.10.0`.
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.9.2"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.10.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- bump the local bluetape4k projects BOM reference from 1.9.2 to 1.10.0
- record the projects 1.10.0 BOM handoff lesson
- leave independent repository BOM lines unchanged

## Verification
- Maven Central HTTP 200 for `io.github.bluetape4k:bluetape4k-bom:1.10.0`
- `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache`
