### PR TITLE
perf: stabilize AGE and Neo4j benchmark summaries

### DIFF
--- a/benchmark/README.ko.md
+++ b/benchmark/README.ko.md
@@ -28,6 +28,62 @@
 - `docs/benchmark/2026-05-21-api-model-jmh.json`
 - `docs/benchmark/2026-04-18-graph-io-bulk-results.md`
 
+## AGE + Neo4j Summary Wrapper
+
+standalone AGE와 Neo4j benchmark module의 결과를 자동화에서 하나의 machine-readable summary로 읽어야 할 때 `scripts/benchmark-neo4j-age.sh`를 사용합니다.
+
+```bash
+scripts/benchmark-neo4j-age.sh
+```
+
+wrapper는 `:graph-age-benchmark:benchmark`와 `:graph-neo4j-benchmark:benchmark`를 실행하고, 생성된 kotlinx-benchmark/JMH JSON report를 읽은 뒤 마지막 stdout line에 JSON object 하나만 출력합니다. Gradle benchmark log는 stderr로 흘려 stdout parser가 summary만 읽을 수 있게 합니다.
+
+안정 summary schema:
+
+```json
+{
+  "schema": "bluetape4k.graph.backend-benchmark-summary.v1",
+  "primary": 1500.0,
+  "unit": "us/op",
+  "direction": "lower_is_better",
+  "sources": {
+    "age": "benchmark/graph-age-benchmark/build/reports/benchmarks/main/main.json",
+    "neo4j": "benchmark/graph-neo4j-benchmark/build/reports/benchmarks/main/main.json"
+  },
+  "sub_scores": {
+    "age_createVertex": 1000.0,
+    "neo4j_createVertex": 2000.0
+  },
+  "benchmarks": [
+    {
+      "backend": "age",
+      "key": "age_createVertex",
+      "benchmark": "pkg.CreateVertexBenchmark.createVertex",
+      "operation": "createVertex",
+      "params": {},
+      "score": 1000.0,
+      "unit": "us/op",
+      "sourceScore": 1.0,
+      "sourceUnit": "ms/op",
+      "source": "benchmark/graph-age-benchmark/build/reports/benchmarks/main/main.json"
+    }
+  ]
+}
+```
+
+`primary`와 모든 `sub_scores` 값은 `us/op`로 정규화되며 낮을수록 좋습니다. `sub_scores`는 ranking script가 쓰는 compact contract이고, `benchmarks`는 source path, original unit, parameter를 담아 진단에 사용합니다.
+
+contract test나 report-only parsing에서는 Gradle 실행을 건너뛰고 기존 report root를 지정할 수 있습니다.
+
+```bash
+BENCHMARK_SKIP_RUN=true \
+BENCHMARK_AGE_REPORT_ROOT=benchmark/graph-age-benchmark/build/reports/benchmarks/main \
+BENCHMARK_NEO4J_REPORT_ROOT=benchmark/graph-neo4j-benchmark/build/reports/benchmarks/main \
+scripts/benchmark-neo4j-age.sh
+```
+
+report 생성에 실패하면 wrapper는 non-zero로 종료하고 검색한 root, 기대하는 file shape, 복구 hint를 stderr에 씁니다. malformed JMH JSON도 backend name과 file path를 포함해 실패합니다.
+
 ## Medium Backend 결과
 
 ![Graph DB medium Testcontainers benchmark](../docs/images/readme-charts/graph-db-medium-testcontainers-latency-chart-01.png)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,6 +28,62 @@ Latest raw artifacts:
 - `docs/benchmark/2026-05-21-api-model-jmh.json`
 - `docs/benchmark/2026-04-18-graph-io-bulk-results.md`
 
+## AGE + Neo4j Summary Wrapper
+
+Use `scripts/benchmark-neo4j-age.sh` when an automation lane needs one machine-readable summary for the standalone AGE and Neo4j benchmark modules:
+
+```bash
+scripts/benchmark-neo4j-age.sh
+```
+
+The wrapper runs `:graph-age-benchmark:benchmark` and `:graph-neo4j-benchmark:benchmark`, reads the generated kotlinx-benchmark/JMH JSON reports, and emits exactly one JSON object on the last stdout line. Gradle benchmark logs are streamed to stderr so callers can safely parse stdout.
+
+Stable summary schema:
+
+```json
+{
+  "schema": "bluetape4k.graph.backend-benchmark-summary.v1",
+  "primary": 1500.0,
+  "unit": "us/op",
+  "direction": "lower_is_better",
+  "sources": {
+    "age": "benchmark/graph-age-benchmark/build/reports/benchmarks/main/main.json",
+    "neo4j": "benchmark/graph-neo4j-benchmark/build/reports/benchmarks/main/main.json"
+  },
+  "sub_scores": {
+    "age_createVertex": 1000.0,
+    "neo4j_createVertex": 2000.0
+  },
+  "benchmarks": [
+    {
+      "backend": "age",
+      "key": "age_createVertex",
+      "benchmark": "pkg.CreateVertexBenchmark.createVertex",
+      "operation": "createVertex",
+      "params": {},
+      "score": 1000.0,
+      "unit": "us/op",
+      "sourceScore": 1.0,
+      "sourceUnit": "ms/op",
+      "source": "benchmark/graph-age-benchmark/build/reports/benchmarks/main/main.json"
+    }
+  ]
+}
+```
+
+`primary` and every `sub_scores` value are normalized to `us/op`; lower is better. `sub_scores` keeps the compact contract used by ranking scripts, while `benchmarks` carries source paths, original units, and parameters for diagnostics.
+
+For contract tests or report-only parsing, skip Gradle execution and point the wrapper at existing report roots:
+
+```bash
+BENCHMARK_SKIP_RUN=true \
+BENCHMARK_AGE_REPORT_ROOT=benchmark/graph-age-benchmark/build/reports/benchmarks/main \
+BENCHMARK_NEO4J_REPORT_ROOT=benchmark/graph-neo4j-benchmark/build/reports/benchmarks/main \
+scripts/benchmark-neo4j-age.sh
+```
+
+If report generation fails, the wrapper exits non-zero and writes the searched root, expected file shape, and recovery hint to stderr. Malformed JMH JSON also fails with the backend name and file path.
+
 ## Medium Backend Result
 
 ![Graph DB medium Testcontainers benchmark](../docs/images/readme-charts/graph-db-medium-testcontainers-latency-chart-01.png)

--- a/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkScriptContractTest.kt
+++ b/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkScriptContractTest.kt
@@ -68,6 +68,10 @@ class BenchmarkScriptContractTest {
 
         result.exitCode shouldBeEqualTo 0
         result.stdoutLines shouldHaveSingleLineContaining "\"primary\": 1500"
+        result.stdoutLines.single() shouldContain "\"schema\": \"bluetape4k.graph.backend-benchmark-summary.v1\""
+        result.stdoutLines.single() shouldContain "\"unit\": \"us/op\""
+        result.stdoutLines.single() shouldContain "\"direction\": \"lower_is_better\""
+        result.stdoutLines.single() shouldContain "\"benchmarks\""
         result.stdoutLines.single() shouldContain "\"age_createVertex\": 1000"
         result.stdoutLines.single() shouldContain "\"neo4j_createVertex\": 2000"
         assertJson(result.stdoutLines.single())
@@ -85,6 +89,32 @@ class BenchmarkScriptContractTest {
 
         (result.exitCode != 0).shouldBeTrue()
         result.stderr shouldContain "ERROR: benchmark JSON report not found"
+        result.stdoutLines shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun `neo4j age benchmark wrapper explains malformed reports`(@TempDir dir: Path) {
+        val ageRoot = jmhReportRoot(dir, "age")
+        val neo4jRoot = jmhReportRoot(dir, "neo4j")
+        writeJmhReport(
+            ageRoot.resolve("main.json"),
+            """
+            [
+              {"benchmark": "pkg.CreateVertexBenchmark.createVertex", "primaryMetric": {"score": 1.0, "scoreUnit": "ms/op"}}
+            ]
+            """.trimIndent(),
+        )
+        writeJmhReport(neo4jRoot.resolve("main.json"), """{"not": "a JMH list"}""")
+
+        val result = runScript(
+            "benchmark-neo4j-age.sh",
+            "BENCHMARK_SKIP_RUN" to "true",
+            "BENCHMARK_AGE_REPORT_ROOT" to ageRoot.parent.toString(),
+            "BENCHMARK_NEO4J_REPORT_ROOT" to neo4jRoot.parent.toString(),
+        )
+
+        (result.exitCode != 0).shouldBeTrue()
+        result.stderr shouldContain "ERROR: Expected JMH result list for neo4j report"
         result.stdoutLines shouldBeEqualTo emptyList()
     }
 

--- a/docs/lessons/2026-06-01-issue-216-benchmark-summary-schema.md
+++ b/docs/lessons/2026-06-01-issue-216-benchmark-summary-schema.md
@@ -1,0 +1,23 @@
+# Issue 216 benchmark summary schema
+
+## Context
+
+Issue #216 required the standalone AGE and Neo4j benchmark wrapper to expose a documented shared report shape while keeping existing benchmark commands usable.
+
+## Decision
+
+`scripts/benchmark-neo4j-age.sh` now keeps the compact `primary` and `sub_scores` contract, then adds `schema`, `unit`, `direction`, `sources`, and detailed `benchmarks` rows. The wrapper normalizes all latency values to `us/op` and fails early on missing, malformed, empty, non-finite, or unsupported JMH result data.
+
+## Outcome
+
+The benchmark guide documents the wrapper command, report roots, stable JSON schema, metric direction, and failure behavior in both English and Korean.
+
+## Verification
+
+- `bash -n scripts/benchmark-neo4j-age.sh`
+- `git diff --check`
+- `./gradlew :graph-benchmark:test --tests 'io.bluetape4k.graph.benchmark.BenchmarkScriptContractTest' --no-daemon`
+
+## Future note
+
+Keep wrapper stdout parseable as exactly one final JSON line. Send Gradle logs and diagnostics to stderr so ranking automation can read stdout without filtering.

--- a/scripts/benchmark-neo4j-age.sh
+++ b/scripts/benchmark-neo4j-age.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Wrapper: run AGE + Neo4j kotlinx-benchmarks and emit combined JSON summary on the last stdout line.
-# Output shape:
-#   {"primary": <combined_mean_us>,
-#    "sub_scores": {"age_<bench>": X, ..., "neo4j_<bench>": Y, ...}}
+# Wrapper: run AGE + Neo4j kotlinx-benchmarks and emit a combined JSON summary
+# on the last stdout line.
+#
+# Stable output schema: bluetape4k.graph.backend-benchmark-summary.v1
+# - primary: arithmetic mean of all AGE + Neo4j benchmark scores in us/op.
+# - sub_scores: backend-prefixed operation scores in us/op.
+# - benchmarks: per-result rows with backend, benchmark, operation, params, and units.
+# Lower values are better for this wrapper.
 
 set -euo pipefail
 
@@ -27,35 +31,56 @@ fi
 pick_report() {
     local root="$1"
     local file
-    file="$(fd --type f --extension json . "$root" 2>/dev/null | head -n1 || true)"
-    if [[ -z "${file}" ]]; then
-        shopt -s nullglob
-        local candidates=("$root"/*/*.json)
-        shopt -u nullglob
-        if ((${#candidates[@]} > 0)); then
-            file="${candidates[-1]}"
-        fi
-    fi
+    file="$(find "$root" -type f -name '*.json' -print 2>/dev/null | sort | tail -n1 || true)"
     echo "$file"
+}
+
+report_missing() {
+    local backend="$1"
+    local root="$2"
+    local module="$3"
+    local env_name="$4"
+
+    echo "ERROR: ${backend} benchmark JSON report not found." 1>&2
+    echo "  searched: ${root}" 1>&2
+    echo "  expected: a kotlinx-benchmark/JMH JSON file under the report root" 1>&2
+    if [[ "${BENCHMARK_SKIP_RUN:-false}" == "true" ]]; then
+        echo "  hint: unset BENCHMARK_SKIP_RUN or set ${env_name} to an existing report root" 1>&2
+    else
+        echo "  hint: run ./gradlew ${module}:benchmark and check the benchmark task output" 1>&2
+    fi
 }
 
 AGE_REPORT_FILE="$(pick_report "$AGE_REPORT_ROOT")"
 NEO4J_REPORT_FILE="$(pick_report "$NEO4J_REPORT_ROOT")"
 
 if [[ -z "${AGE_REPORT_FILE}" || ! -f "${AGE_REPORT_FILE}" ]]; then
-    echo "ERROR: AGE benchmark JSON report not found under $AGE_REPORT_ROOT" 1>&2
+    report_missing "AGE" "$AGE_REPORT_ROOT" "$AGE_MODULE" "BENCHMARK_AGE_REPORT_ROOT"
     exit 1
 fi
 if [[ -z "${NEO4J_REPORT_FILE}" || ! -f "${NEO4J_REPORT_FILE}" ]]; then
-    echo "ERROR: Neo4j benchmark JSON report not found under $NEO4J_REPORT_ROOT" 1>&2
+    report_missing "Neo4j" "$NEO4J_REPORT_ROOT" "$NEO4J_MODULE" "BENCHMARK_NEO4J_REPORT_ROOT"
     exit 1
 fi
 
 # Parse JSON with python3 (always available on macOS + CI).
 python3 - "$AGE_REPORT_FILE" "$NEO4J_REPORT_FILE" <<'PY'
-import json, sys
+import json
+import math
+import sys
 
 age_path, neo4j_path = sys.argv[1], sys.argv[2]
+schema = "bluetape4k.graph.backend-benchmark-summary.v1"
+
+
+class BenchmarkReportError(Exception):
+    pass
+
+
+def fail(message):
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
 
 def to_us(score, unit):
     unit = unit.lower()
@@ -67,34 +92,93 @@ def to_us(score, unit):
         return score * 1000.0
     if unit.startswith("s/op"):
         return score * 1_000_000.0
-    return score  # unknown -> pass through
+    raise BenchmarkReportError(f"unsupported scoreUnit '{unit}'; expected ns/op, us/op, ms/op, or s/op")
 
 def load(path, prefix):
-    with open(path) as fh:
-        data = json.load(fh)
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except OSError as exc:
+        raise BenchmarkReportError(f"cannot read {prefix} report {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkReportError(f"cannot parse {prefix} report {path}: {exc}") from exc
+
+    if not isinstance(data, list):
+        raise BenchmarkReportError(f"Expected JMH result list for {prefix} report: {path}")
+    if not data:
+        raise BenchmarkReportError(f"Empty JMH result list for {prefix} report: {path}")
+
     all_us = []
     sub = {}
-    for item in data:
+    rows = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise BenchmarkReportError(f"Expected object at {prefix} report row {index}: {path}")
         name = item.get("benchmark", "")
+        if not name:
+            raise BenchmarkReportError(f"Missing benchmark name at {prefix} report row {index}: {path}")
         prim = item.get("primaryMetric", {})
-        score = float(prim.get("score", 0.0))
+        if not isinstance(prim, dict):
+            raise BenchmarkReportError(f"Missing primaryMetric object for {name} in {path}")
+        try:
+            score = float(prim["score"])
+        except KeyError as exc:
+            raise BenchmarkReportError(f"Missing primaryMetric.score for {name} in {path}") from exc
+        except (TypeError, ValueError) as exc:
+            raise BenchmarkReportError(f"Invalid primaryMetric.score for {name} in {path}: {prim.get('score')}") from exc
+        if not math.isfinite(score):
+            raise BenchmarkReportError(f"Non-finite primaryMetric.score for {name} in {path}: {prim.get('score')}")
         unit = str(prim.get("scoreUnit", "us/op"))
         us = to_us(score, unit)
         all_us.append(us)
         short = name.rsplit(".", 1)[-1]
-        sub[f"{prefix}_{short}"] = round(us, 3)
-    return all_us, sub
+        params = {str(k): str(v) for k, v in item.get("params", {}).items()}
+        param_suffix = ""
+        if params:
+            param_suffix = "[" + ",".join(f"{key}={value}" for key, value in sorted(params.items())) + "]"
+        key = f"{prefix}_{short}{param_suffix}"
+        rounded = round(us, 3)
+        sub[key] = rounded
+        rows.append(
+            {
+                "backend": prefix,
+                "key": key,
+                "benchmark": name,
+                "operation": short,
+                "params": params,
+                "score": rounded,
+                "unit": "us/op",
+                "sourceScore": score,
+                "sourceUnit": unit,
+                "source": path,
+            }
+        )
+    return all_us, sub, rows
 
-age_scores, age_sub = load(age_path, "age")
-neo4j_scores, neo4j_sub = load(neo4j_path, "neo4j")
+try:
+    age_scores, age_sub, age_rows = load(age_path, "age")
+    neo4j_scores, neo4j_sub, neo4j_rows = load(neo4j_path, "neo4j")
+except BenchmarkReportError as exc:
+    fail(str(exc))
 
 combined = age_scores + neo4j_scores
-primary = round(sum(combined) / len(combined), 3) if combined else 0.0
+primary = round(sum(combined) / len(combined), 3)
 
 sub = {}
 sub.update(age_sub)
 sub.update(neo4j_sub)
 
 # Emit exactly one JSON line on stdout (the last line of stdout, per contract).
-print(json.dumps({"primary": primary, "sub_scores": sub}))
+print(json.dumps({
+    "schema": schema,
+    "primary": primary,
+    "unit": "us/op",
+    "direction": "lower_is_better",
+    "sources": {
+        "age": age_path,
+        "neo4j": neo4j_path,
+    },
+    "sub_scores": sub,
+    "benchmarks": age_rows + neo4j_rows,
+}))
 PY


### PR DESCRIPTION
## Summary
- Document the shared AGE + Neo4j benchmark summary schema in the benchmark guide.
- Extend scripts/benchmark-neo4j-age.sh with schema metadata, per-row diagnostics, and stricter JMH JSON validation.
- Strengthen BenchmarkScriptContractTest coverage for schema fields and malformed report failures.

## Verification
- bash -n scripts/benchmark-neo4j-age.sh
- git diff --check
- ./gradlew :graph-benchmark:test --tests 'io.bluetape4k.graph.benchmark.BenchmarkScriptContractTest' --no-daemon

Closes #216