### PR TITLE
docs: define GraphML compatibility boundaries

### DIFF
--- a/docs/lessons/2026-06-01-issue-235-graphml-compatibility-contract.md
+++ b/docs/lessons/2026-06-01-issue-235-graphml-compatibility-contract.md
@@ -1,0 +1,23 @@
+# Issue 235 GraphML compatibility contract
+
+## Context
+
+GraphML supports undirected graphs, nested graphs, ports, hyperedges, and XML extension payloads. The current graph IO model is a backend-neutral property graph with directed `GraphEdge` records, so the next compatibility slice needed an explicit support matrix before broadening import behavior.
+
+## Decision
+
+Keep the implemented GraphML subset focused on directed property graphs with scalar keys and data. Treat undirected graph defaults, edge-level undirected flags, ports, nested graphs, hyperedges, and extension payloads as explicit unsupported constructs with documented `SKIP` and `FAIL` behavior.
+
+## Outcome
+
+Representative GraphML fixtures now lock the supported property-graph subset and the unsupported-construct policy. README files document the compatibility matrix, and the design note records why undirected and nested graph support should wait for explicit mapping rules.
+
+## Verification
+
+- `./gradlew :bluetape4k-graph-io-graphml:test --tests 'io.bluetape4k.graph.io.graphml.internal.StaxGraphMlReaderWriterTest' --no-daemon`
+- `./gradlew :bluetape4k-graph-io-graphml:test --no-daemon`
+- `./gradlew :bluetape4k-graph-io-graphml:detekt --no-daemon`
+
+## Future note
+
+Do not silently flatten nested GraphML or auto-create reverse edges for undirected input. Choose a named mapping policy first, then add round-trip fixtures before changing importer behavior.

--- a/docs/superpowers/specs/2026-06-01-issue-235-graphml-compatibility-slice.md
+++ b/docs/superpowers/specs/2026-06-01-issue-235-graphml-compatibility-slice.md
@@ -1,0 +1,39 @@
+# Issue 235 GraphML compatibility slice
+
+## Context
+
+The first GraphML importer/exporter is intentionally a backend-neutral property-graph subset. Full GraphML includes constructs that do not map cleanly to `GraphVertex`, directed `GraphEdge`, and backend-neutral `GraphOperations`.
+
+## Compatibility decision matrix
+
+| GraphML construct | Decision | Current behavior | Rationale |
+|---|---|---|---|
+| Directed `<graph>` with `<node>`, `<edge>`, scalar `<data>` | Implement | Imported/exported | Directly maps to vertices, directed edges, labels, and scalar properties. |
+| `key` definitions with scalar `attr.type` | Implement | Imported/exported | Provides stable property names and primitive coercion without backend-specific schema assumptions. |
+| Graph-level `edgedefault="undirected"` | Defer | `SKIP` records `WARN`; `FAIL` returns failed report before writes | `GraphEdge` is directed. Auto-duplicating reverse edges would change edge counts and traversal semantics. |
+| Edge-level `directed="false"` | Defer | `SKIP` records `WARN` and keeps the source-to-target projection; `FAIL` returns failed report before writes | A source-to-target projection is useful for inspection, but it is not a faithful undirected edge contract. |
+| Nested `<graph>` inside a node | Reject for this slice | `SKIP` records `WARN` and skips the nested subgraph; `FAIL` returns failed report before writes | `GraphVertex` has no child graph scope. Flattening needs a separate external-id and ownership mapping design. |
+| `<hyperedge>` | Reject | `SKIP` records `WARN`; `FAIL` returns failed report before writes | `GraphEdge` has exactly one source and one target. Hyperedge lowering requires a reification node policy. |
+| `<port>` | Defer | `SKIP` records `WARN`; `FAIL` returns failed report before writes | Ports are endpoint metadata, but current edge endpoints target vertices only. |
+| XML extension payloads such as yFiles graphics | Defer | Outside the contract | Visual metadata should be preserved only after a namespaced extension-property policy exists. |
+
+## Undirected and nested graph mapping
+
+Undirected GraphML is not implemented as true undirected storage in this slice. Under `UnsupportedGraphMlElementPolicy.SKIP`, the reader reports a warning and can keep the explicit `source` to `target` edge projection for diagnostic imports. Under `FAIL`, the bulk importer returns `GraphIoStatus.FAILED` before vertex or edge writes.
+
+Nested graphs remain rejected for import because the current backend-neutral operations model has no graph containment boundary. Future support should choose one of these explicit policies before implementation:
+
+- Flatten nested vertices into the parent graph with a reserved containment property.
+- Reify the nested graph as a vertex and connect contained vertices with ownership edges.
+- Add a graph-scope abstraction to `graph-core`.
+
+The first two policies can be implemented in `graph-io-graphml` only after the property names, collision rules, and round-trip export contract are defined. The third is a larger `graph-core` design change.
+
+## Compatibility fixtures
+
+Representative fixtures live under `graph-io/graphml/src/test/resources/fixtures/graphml/`:
+
+- `property-graph-basic.graphml`: directed property graph fixture for the implemented subset.
+- `unsupported-constructs.graphml`: undirected graph default, nested graph, port, hyperedge, and undirected edge fixture.
+
+The reader tests verify `SKIP` warning behavior and `FAIL` strict behavior. The bulk importer test verifies strict unsupported input fails before any graph writes.

--- a/graph-io/graphml/README.ko.md
+++ b/graph-io/graphml/README.ko.md
@@ -165,6 +165,20 @@ data class GraphMlImportOptions(
 - `UnsupportedGraphMlElementPolicy.SKIP`은 `WARN` failure를 기록하고 지원되는 subset 처리를 계속합니다.
 - `UnsupportedGraphMlElementPolicy.FAIL`은 `ERROR` failure를 기록하며 bulk importer는 graph element를 생성하지 않고 `FAILED`를 반환합니다.
 
+### Property-graph subset 이후의 compatibility contract
+
+| GraphML construct | 결정 | Import 동작 | 근거 |
+|---|---|---|---|
+| node, edge, scalar data, scalar key를 가진 directed graph | 구현됨 | Import/export 지원 | `GraphVertex`, directed `GraphEdge`, scalar property에 직접 대응됩니다. |
+| Graph-level `edgedefault="undirected"` | 보류 | `SKIP`은 `WARN` 기록, `FAIL`은 write 전 `FAILED` 반환 | `GraphEdge`는 directed입니다. reverse edge를 자동 생성하면 edge 수와 traversal 의미가 바뀝니다. |
+| Edge-level `directed="false"` | 보류 | `SKIP`은 `WARN` 기록 후 source-to-target projection 유지, `FAIL`은 write 전 `FAILED` 반환 | projection은 진단용 import에는 유용하지만 충실한 undirected-edge contract는 아닙니다. |
+| Nested `<graph>` | 이번 slice에서는 거부 | `SKIP`은 `WARN` 기록 후 nested content skip, `FAIL`은 write 전 `FAILED` 반환 | `GraphVertex`에는 child graph scope가 없습니다. Flattening에는 명시적 ownership mapping 설계가 필요합니다. |
+| `<hyperedge>` | 거부 | `SKIP`은 `WARN` 기록, `FAIL`은 write 전 `FAILED` 반환 | `GraphEdge`는 source 하나와 target 하나만 가집니다. Hyperedge 지원에는 reification node 정책이 필요합니다. |
+| `<port>` | 보류 | `SKIP`은 `WARN` 기록, `FAIL`은 write 전 `FAILED` 반환 | port는 endpoint metadata이지만 현재 backend-neutral endpoint는 vertex만 가리킵니다. |
+| yFiles graphics 같은 XML extension payload | 보류 | 지원 contract 밖 | 시각 metadata를 보존하려면 namespaced extension-property 정책이 먼저 필요합니다. |
+
+`src/test/resources/fixtures/graphml/`의 대표 fixture가 permissive/strict import policy 양쪽의 contract를 고정합니다.
+
 ### 익스포트 옵션
 
 `GraphMlExportOptions`는 현재 비어 있지만 향후 기능 확장을 위한 확장 포인트를 제공합니다:

--- a/graph-io/graphml/README.md
+++ b/graph-io/graphml/README.md
@@ -165,6 +165,20 @@ Supported import subset:
 - `UnsupportedGraphMlElementPolicy.SKIP` records `WARN` failures and continues with the supported subset.
 - `UnsupportedGraphMlElementPolicy.FAIL` records `ERROR` failures and the bulk importer returns `FAILED` without creating graph elements.
 
+### Compatibility Contract Beyond the Property-Graph Subset
+
+| GraphML construct | Decision | Import behavior | Rationale |
+|---|---|---|---|
+| Directed graph with nodes, edges, scalar data, and scalar keys | Implemented | Imported/exported | Directly maps to `GraphVertex`, directed `GraphEdge`, and scalar properties. |
+| Graph-level `edgedefault="undirected"` | Deferred | `SKIP` records `WARN`; `FAIL` returns `FAILED` before writes | `GraphEdge` is directed; auto-creating reverse edges would change edge counts and traversal semantics. |
+| Edge-level `directed="false"` | Deferred | `SKIP` records `WARN` and keeps the source-to-target projection; `FAIL` returns `FAILED` before writes | The projection is useful for diagnostic imports but is not a faithful undirected-edge contract. |
+| Nested `<graph>` | Rejected for this slice | `SKIP` records `WARN` and skips nested content; `FAIL` returns `FAILED` before writes | `GraphVertex` has no child graph scope. Flattening needs an explicit ownership mapping design. |
+| `<hyperedge>` | Rejected | `SKIP` records `WARN`; `FAIL` returns `FAILED` before writes | `GraphEdge` has exactly one source and one target. Hyperedge support needs a reification-node policy. |
+| `<port>` | Deferred | `SKIP` records `WARN`; `FAIL` returns `FAILED` before writes | Ports describe endpoint metadata, while current backend-neutral endpoints target vertices only. |
+| XML extension payloads such as yFiles graphics | Deferred | Outside the supported contract | Visual metadata needs a namespaced extension-property policy before preservation. |
+
+Representative fixtures under `src/test/resources/fixtures/graphml/` lock this contract for both permissive and strict import policies.
+
 ### Export Options
 
 `GraphMlExportOptions` is currently empty but provides extension point for future features:

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
@@ -1,11 +1,16 @@
 package io.bluetape4k.graph.io.graphml.internal
 
 import io.bluetape4k.graph.io.graphml.GraphMlExportOptions
+import io.bluetape4k.graph.io.graphml.GraphMlBulkImporter
 import io.bluetape4k.graph.io.graphml.GraphMlImportOptions
 import io.bluetape4k.graph.io.graphml.UnsupportedGraphMlElementPolicy
 import io.bluetape4k.graph.io.model.GraphIoEdgeRecord
 import io.bluetape4k.graph.io.model.GraphIoVertexRecord
+import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoFailureSeverity
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
@@ -13,6 +18,7 @@ import io.bluetape4k.assertions.shouldHaveSize
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.InputStream
 
 class StaxGraphMlReaderWriterTest {
 
@@ -106,6 +112,22 @@ class StaxGraphMlReaderWriterTest {
     }
 
     @Test
+    fun `reader imports representative property graph fixture`() {
+        val result = fixture("property-graph-basic.graphml").use { reader.read(it) }
+
+        result.failures shouldHaveSize 0
+        result.vertices shouldHaveSize 2
+        result.edges shouldHaveSize 1
+        result.vertices[0].externalId shouldBeEqualTo "n1"
+        result.vertices[0].label shouldBeEqualTo "Person"
+        result.vertices[0].properties["name"] shouldBeEqualTo "Alice"
+        result.vertices[0].properties["age"] shouldBeEqualTo 31
+        result.edges[0].externalId shouldBeEqualTo "e1"
+        result.edges[0].label shouldBeEqualTo "KNOWS"
+        result.edges[0].properties["score"] shouldBeEqualTo 0.75
+    }
+
+    @Test
     fun `reader records failure for edge missing source`() {
         val xml = """<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/graphml">
@@ -119,21 +141,8 @@ class StaxGraphMlReaderWriterTest {
     }
 
     @Test
-    fun `reader records warnings for unsupported graphml elements with SKIP policy`() {
-        val xml = """<?xml version="1.0" encoding="UTF-8"?>
-<graphml xmlns="http://graphml.graphdrawing.org/graphml">
-  <graph id="G" edgedefault="undirected">
-    <node id="n1">
-      <port name="p1"/>
-      <graph id="nested" edgedefault="directed">
-        <node id="n2"/>
-      </graph>
-    </node>
-    <hyperedge id="h1"/>
-    <edge id="e1" source="n1" target="n1" directed="false"/>
-  </graph>
-</graphml>"""
-        val result = reader.read(ByteArrayInputStream(xml.toByteArray()))
+    fun `reader records warnings for unsupported graphml fixture with SKIP policy`() {
+        val result = fixture("unsupported-constructs.graphml").use { reader.read(it) }
 
         result.vertices shouldHaveSize 1
         result.edges shouldHaveSize 1
@@ -147,7 +156,44 @@ class StaxGraphMlReaderWriterTest {
     }
 
     @Test
-    fun `reader records errors for unsupported graphml elements with FAIL policy`() {
+    fun `reader records errors for unsupported graphml fixture with FAIL policy`() {
+        val result = fixture("unsupported-constructs.graphml").use {
+            reader.read(
+                it,
+                GraphMlImportOptions(unsupportedElementPolicy = UnsupportedGraphMlElementPolicy.FAIL),
+            )
+        }
+
+        result.vertices shouldHaveSize 1
+        result.edges shouldHaveSize 1
+        result.failures shouldHaveSize 5
+        result.failures.map { it.severity }.toSet() shouldBeEqualTo setOf(GraphIoFailureSeverity.ERROR)
+        result.failures.map { it.message } shouldContain "GraphML undirected graphs are not supported"
+        result.failures.map { it.message } shouldContain "Nested GraphML graphs are not supported"
+        result.failures.map { it.message } shouldContain "GraphML undirected edges are not supported"
+    }
+
+    @Test
+    fun `bulk importer fails before writes for strict unsupported graphml fixture`() {
+        val report = GraphMlBulkImporter().importGraph(
+            GraphImportSource.InputStreamSource(fixture("unsupported-constructs.graphml"), closeInput = true),
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+            GraphMlImportOptions(unsupportedElementPolicy = UnsupportedGraphMlElementPolicy.FAIL),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.verticesRead shouldBeEqualTo 1L
+        report.verticesCreated shouldBeEqualTo 0L
+        report.edgesRead shouldBeEqualTo 1L
+        report.edgesCreated shouldBeEqualTo 0L
+        report.failures shouldHaveSize 5
+        report.failures.singleOrNull { it.message.contains("hyperedge") }?.severity shouldBeEqualTo
+            GraphIoFailureSeverity.ERROR
+    }
+
+    @Test
+    fun `reader records one error for undirected graph default`() {
         val xml = """<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/graphml">
   <graph id="G" edgedefault="undirected">
@@ -178,4 +224,9 @@ class StaxGraphMlReaderWriterTest {
         result.vertices shouldHaveSize 1
         result.vertices[0].label shouldBeEqualTo "Item"
     }
+
+    private fun fixture(name: String): InputStream =
+        requireNotNull(javaClass.getResourceAsStream("/fixtures/graphml/$name")) {
+            "GraphML fixture not found: $name"
+        }
 }

--- a/graph-io/graphml/src/test/resources/fixtures/graphml/property-graph-basic.graphml
+++ b/graph-io/graphml/src/test/resources/fixtures/graphml/property-graph-basic.graphml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <key id="label" for="all" attr.name="label" attr.type="string"/>
+  <key id="name" for="node" attr.name="name" attr.type="string"/>
+  <key id="age" for="node" attr.name="age" attr.type="int"/>
+  <key id="score" for="edge" attr.name="score" attr.type="double"/>
+  <graph id="G" edgedefault="directed">
+    <node id="n1">
+      <data key="label">Person</data>
+      <data key="name">Alice</data>
+      <data key="age">31</data>
+    </node>
+    <node id="n2">
+      <data key="label">Person</data>
+      <data key="name">Bob</data>
+      <data key="age">29</data>
+    </node>
+    <edge id="e1" source="n1" target="n2">
+      <data key="label">KNOWS</data>
+      <data key="score">0.75</data>
+    </edge>
+  </graph>
+</graphml>

--- a/graph-io/graphml/src/test/resources/fixtures/graphml/unsupported-constructs.graphml
+++ b/graph-io/graphml/src/test/resources/fixtures/graphml/unsupported-constructs.graphml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <key id="label" for="all" attr.name="label" attr.type="string"/>
+  <graph id="G" edgedefault="undirected">
+    <node id="n1">
+      <data key="label">Router</data>
+      <port name="eth0"/>
+      <graph id="nested" edgedefault="directed">
+        <node id="n2">
+          <data key="label">NestedDevice</data>
+        </node>
+      </graph>
+    </node>
+    <hyperedge id="h1">
+      <endpoint node="n1"/>
+      <endpoint node="n2"/>
+      <endpoint node="n3"/>
+    </hyperedge>
+    <edge id="e1" source="n1" target="n1" directed="false">
+      <data key="label">LINK</data>
+    </edge>
+  </graph>
+</graphml>


### PR DESCRIPTION
## Summary
- document the GraphML compatibility matrix beyond the current property-graph subset
- add representative GraphML fixtures for supported directed property graphs and unsupported constructs
- lock permissive SKIP and strict FAIL behavior with reader and bulk importer tests

Closes #235

## Verification
- ./gradlew :bluetape4k-graph-io-graphml:test --tests 'io.bluetape4k.graph.io.graphml.internal.StaxGraphMlReaderWriterTest' --no-daemon\n- ./gradlew :bluetape4k-graph-io-graphml:test --no-daemon\n- ./gradlew :bluetape4k-graph-io-graphml:detekt --no-daemon\n- git diff --check