### PR TITLE
feat: add security attack-path graph examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -96,6 +96,7 @@ jobs:
               :supply-chain-graph-examples:build \
               :data-lineage-examples:build \
               :network-topology-examples:build \
+              :security-attack-path-examples:build \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ examples/
   supply-chain-graph-examples/
   data-lineage-examples/
   network-topology-examples/
+  security-attack-path-examples/
   ktor-graph-examples/
 ```
 
@@ -71,6 +72,7 @@ examples/
 ./gradlew :supply-chain-graph-examples:test
 ./gradlew :data-lineage-examples:test
 ./gradlew :network-topology-examples:test
+./gradlew :security-attack-path-examples:test
 ./gradlew :bluetape4k-graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
 ./gradlew publishBluetapeGraphPublicationToMavenLocalRepository
 ./gradlew publishAggregationToCentralPortal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure-impact checks, isolated segment detection, redundant route discovery,
   and sync/suspend TinkerGraph tests
   ([#251](https://github.com/bluetape4k/bluetape4k-graph/issues/251)).
+- **Security attack-path graph example**: Added a
+  `security-attack-path-examples` module with graph-io CSV fixtures, shortest
+  attack-path queries, risk-ranked path enumeration, credential-based privilege
+  escalation, remediation-impact checks, and sync/suspend TinkerGraph tests
+  ([#252](https://github.com/bluetape4k/bluetape4k-graph/issues/252)).
 
 ### Changed
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -21,7 +21,7 @@ bluetape4k 생태계의 그래프 데이터베이스 통합 라이브러리. Apa
 - blocking API와 coroutine API를 함께 제공하고, blocking 백엔드에 virtual-thread adapter를 붙이고 싶을 때
 - batch insert, schema/index 관리, merge/upsert, transaction block, weighted path, graph algorithm 같은 공통 기능이 필요할 때
 - CSV, NDJSON, GraphML, OkIO stream 기반의 이식 가능한 그래프 벌크 I/O가 필요할 때
-- code graph, social graph, fraud detection, recommendation, knowledge graph, observability incident, IAM access path, supply-chain impact analysis, data lineage, network topology, Ktor integration 예제를 바로 실행해 보고 싶을 때
+- code graph, social graph, fraud detection, recommendation, knowledge graph, observability incident, IAM access path, supply-chain impact analysis, data lineage, network topology, security attack path, Ktor integration 예제를 바로 실행해 보고 싶을 때
 
 <!-- README_VISUAL_OVERVIEW:START -->
 ## Overview Diagram
@@ -89,6 +89,7 @@ examples/
   supply-chain-graph-examples # supply-chain impact, alternate-route graph 예시
   data-lineage-examples # data lineage, dashboard impact graph 예시
   network-topology-examples # network topology path, failure-impact graph 예시
+  security-attack-path-examples # security attack-path, remediation-impact graph 예시
   ktor-graph-examples     # TinkerGraph 기반 Ktor GraphPlugin 예시
 ```
 
@@ -339,6 +340,7 @@ driver.close()
 ./gradlew :supply-chain-graph-examples:test
 ./gradlew :data-lineage-examples:test
 ./gradlew :network-topology-examples:test
+./gradlew :security-attack-path-examples:test
 
 # 특정 클래스
 ./gradlew :graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
@@ -369,6 +371,8 @@ GitHub Actions는 전용 `Examples` workflow도 실행한다. 이 workflow는 �
 | `AbstractDataLineageImpactSuspendTest` | coroutine data lineage impact 예시 |
 | `AbstractNetworkTopologyImpactTest` | device path, service impact, isolated segment, redundant route 예시 |
 | `AbstractNetworkTopologyImpactSuspendTest` | coroutine network topology impact 예시 |
+| `AbstractSecurityAttackPathTest` | attack path, privilege escalation, remediation impact, unreachable crown-jewel 예시 |
+| `AbstractSecurityAttackPathSuspendTest` | coroutine security attack-path 예시 |
 | `KtorGraphAppTest` | TinkerGraph 기반 Ktor `GraphPlugin` smoke 예시 |
 | `FalkorDBKtorGraphAppTest` | FalkorDB 기반 Ktor `GraphPlugin` smoke 예시 |
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use this project when you need:
 - paired blocking and coroutine APIs, with virtual-thread adapters for blocking backends
 - common graph capabilities such as batch insert, schema/index management, merge/upsert, transaction blocks, weighted paths, and graph algorithms
 - portable graph bulk I/O in CSV, NDJSON, GraphML, and OkIO streams
-- ready-to-run domain examples for code graphs, social graphs, fraud detection, recommendations, knowledge graphs, observability incidents, IAM access paths, supply-chain impact analysis, data lineage, network topology, and Ktor integration
+- ready-to-run domain examples for code graphs, social graphs, fraud detection, recommendations, knowledge graphs, observability incidents, IAM access paths, supply-chain impact analysis, data lineage, network topology, security attack paths, and Ktor integration
 
 <!-- README_VISUAL_OVERVIEW:START -->
 ## Overview Diagram
@@ -89,6 +89,7 @@ examples/
   supply-chain-graph-examples # Supply-chain impact and alternate-route graph examples
   data-lineage-examples # Data lineage and dashboard impact examples
   network-topology-examples # Network topology path and failure-impact examples
+  security-attack-path-examples # Security attack-path and remediation-impact examples
   ktor-graph-examples     # Ktor GraphPlugin example using TinkerGraph
 ```
 
@@ -339,6 +340,7 @@ Tests automatically launch Docker containers via Testcontainers. Docker is requi
 ./gradlew :supply-chain-graph-examples:test
 ./gradlew :data-lineage-examples:test
 ./gradlew :network-topology-examples:test
+./gradlew :security-attack-path-examples:test
 
 # Specific class
 ./gradlew :graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
@@ -369,6 +371,8 @@ Each example module uses the **abstract test class pattern**. Common test logic 
 | `AbstractDataLineageImpactSuspendTest` | Coroutine data lineage impact examples |
 | `AbstractNetworkTopologyImpactTest` | Device path, service impact, isolated segment, and redundant route examples |
 | `AbstractNetworkTopologyImpactSuspendTest` | Coroutine network topology impact examples |
+| `AbstractSecurityAttackPathTest` | Attack path, privilege escalation, remediation impact, and unreachable crown-jewel examples |
+| `AbstractSecurityAttackPathSuspendTest` | Coroutine security attack-path examples |
 | `KtorGraphAppTest` | TinkerGraph-backed Ktor `GraphPlugin` smoke example |
 | `FalkorDBKtorGraphAppTest` | FalkorDB-backed Ktor `GraphPlugin` smoke example |
 

--- a/docs/lessons/2026-06-01-issue-252-security-attack-path-example.md
+++ b/docs/lessons/2026-06-01-issue-252-security-attack-path-example.md
@@ -1,0 +1,32 @@
+# Issue 252 Security Attack-Path Example
+
+## Context
+
+Issue #252 asked for a bounded educational security attack-path graph example for the 0.5.0 milestone.
+
+## Decision
+
+Add `security-attack-path-examples` as a graph-io CSV-backed TinkerGraph example with sync and coroutine services.
+The model covers entry assets, hosts, principals, credentials, vulnerabilities, permissions, and crown-jewel hosts.
+It explicitly documents that the module is not a scanner.
+
+## Outcome
+
+The first slice demonstrates shortest attack paths, risk-ranked path enumeration, credential-based privilege escalation,
+unreachable crown-jewel detection, and remediation impact by cutting one edge.
+
+## Verification
+
+Run the module tests and Examples workflow before merging. The expected local commands are:
+
+```bash
+./gradlew :security-attack-path-examples:test --no-daemon
+./gradlew :security-attack-path-examples:build --no-daemon
+./gradlew projects --no-daemon
+git diff --check
+```
+
+## Future Notes
+
+Keep future security-domain examples educational and deterministic. Do not add vulnerability feeds, scanners, or external
+security dependencies without a separate design issue.

--- a/examples/security-attack-path-examples/README.ko.md
+++ b/examples/security-attack-path-examples/README.ko.md
@@ -1,0 +1,73 @@
+# security-attack-path-examples
+
+> 🇺🇸 [English](README.md)
+
+Entry asset, host, principal, credential, vulnerability, permission, crown-jewel system을 작은 security attack-path
+graph로 모델링하는 예제입니다. path explanation, privilege escalation, risk ranking, remediation impact에 필요한
+backend-independent traversal을 보여줍니다.
+
+> 이 모듈은 교육용 graph-modeling 예제이며 security scanner가 아닙니다. vulnerability feed 수집, probe 실행,
+> exploitability 검증, production security decision을 수행하지 않습니다.
+
+## 예제 시나리오
+
+샘플 그래프는 internet-facing entry asset에서 public web host로 진입한 뒤 exploit을 통해 service account로
+pivot하고, admin credential을 발견해 customer database에 도달하는 흐름을 모델링합니다. backup vault는 도달할 수
+없는 crown jewel로 둬서 reachable/unreachable target을 테스트합니다.
+
+## Graph Model
+
+| 요소 | Label | 주요 속성 | 목적 |
+|---|---|---|---|
+| Entry asset | `EntryAsset` | `assetId`, `exposure`, `status` | 외부 또는 내부 시작점입니다. |
+| Host | `Host` | `hostId`, `exposure`, `criticality`, `status` | workload, data store, protected system입니다. |
+| Principal | `Principal` | `principalId`, `kind`, `privilege`, `status` | human, service, assumed identity입니다. |
+| Credential | `Credential` | `credentialId`, `kind`, `status` | pivot에 사용되는 token 또는 credential material입니다. |
+| Vulnerability | `Vulnerability` | `vulnerabilityId`, `severity`, `status` | path ranking에 쓰는 교육용 risk signal입니다. |
+| Permission | `Permission` | `permissionId`, `privilege`, `status` | protected host를 control할 수 있는 capability입니다. |
+
+## Traversal Goals
+
+| 질문 | API |
+|---|---|
+| entry asset에서 crown jewel까지의 최단 active path는 무엇인가? | `shortestAttackPath(sourceAssetId, targetHostId)` |
+| risk signal이 큰 attack path는 무엇인가? | `rankedAttackPaths(sourceAssetId, targetHostId)` |
+| 낮은 권한의 service account가 admin privilege에 어떻게 도달하는가? | `privilegeEscalationPaths(startPrincipalId)` |
+| source에서 도달할 수 없는 crown jewel은 무엇인가? | `unreachableCrownJewels(sourceAssetId)` |
+| 특정 edge를 끊으면 어떤 crown jewel이 unreachable이 되는가? | `remediationImpact(blockedEdgeId)` |
+
+## Sample Dataset
+
+모듈은 `src/main/resources/sample-data/security-attack-path/` 아래에 graph-io CSV fixture를 포함합니다.
+
+| 파일 | 내용 |
+|---|---|
+| `vertices.csv` | entry asset, host, principal, credential, vulnerability, permission. |
+| `edges.csv` | reachability, exploit, compromise, credential, permission, asset-control edge. |
+
+```kotlin
+val ops = TinkerGraphOperations()
+val service = SecurityAttackPathService(ops)
+service.initialize()
+
+SecurityAttackPathSampleDatasetLoader.importCsv(ops)
+val path = service.shortestAttackPath("internet", "customer-db")
+val blocked = service.remediationImpact("edge-credential-admin")
+```
+
+## Expected Output
+
+| Query | Expected IDs |
+|---|---|
+| `shortestAttackPath("internet", "customer-db")` | `internet`, `web-edge`, `vuln-web-rce`, `web-service`, `ci-admin-token`, `domain-admin`, `db-admin`, `customer-db` |
+| `privilegeEscalationPaths("web-service")` | `web-service`, `ci-admin-token`, `domain-admin` |
+| `unreachableCrownJewels("internet")` | `backup-vault` |
+| `remediationImpact("edge-credential-admin")` | `customer-db` |
+
+## 테스트 실행
+
+```bash
+./gradlew :security-attack-path-examples:test
+```
+
+첫 slice는 TinkerGraph smoke coverage와 graph-io CSV loader test를 사용합니다.

--- a/examples/security-attack-path-examples/README.md
+++ b/examples/security-attack-path-examples/README.md
@@ -1,0 +1,73 @@
+# security-attack-path-examples
+
+> 🇰🇷 [한국어 문서](README.ko.md)
+
+This example models a compact security attack-path graph for entry assets, hosts, principals, credentials,
+vulnerabilities, permissions, and crown-jewel systems. It demonstrates backend-independent traversal for path
+explanation, privilege escalation, risk ranking, and remediation impact.
+
+> This is an educational graph-modeling example, not a security scanner. It does not ingest vulnerability feeds, run
+> probes, validate exploitability, or make production security decisions.
+
+## Scenario
+
+The sample graph starts from an internet-facing entry asset, reaches a public web host, pivots through an exploit into a
+service account, discovers an admin credential, and reaches a customer database through an admin permission. A backup
+vault is modeled as an unreachable crown jewel so tests can distinguish reachable and unreachable targets.
+
+## Graph Model
+
+| Element | Label | Key properties | Purpose |
+|---|---|---|---|
+| Entry asset | `EntryAsset` | `assetId`, `exposure`, `status` | External or internal starting point. |
+| Host | `Host` | `hostId`, `exposure`, `criticality`, `status` | Workload, data store, or protected system. |
+| Principal | `Principal` | `principalId`, `kind`, `privilege`, `status` | Human, service, or assumed identity. |
+| Credential | `Credential` | `credentialId`, `kind`, `status` | Token or credential material used for pivots. |
+| Vulnerability | `Vulnerability` | `vulnerabilityId`, `severity`, `status` | Educational risk signal for path ranking. |
+| Permission | `Permission` | `permissionId`, `privilege`, `status` | Capability that can control a protected host. |
+
+## Traversal Goals
+
+| Question | API |
+|---|---|
+| What is the shortest active path from an entry asset to a crown jewel? | `shortestAttackPath(sourceAssetId, targetHostId)` |
+| Which attack paths have the strongest risk signals? | `rankedAttackPaths(sourceAssetId, targetHostId)` |
+| How can a low-privilege service account reach admin privilege? | `privilegeEscalationPaths(startPrincipalId)` |
+| Which crown jewels are unreachable from a source? | `unreachableCrownJewels(sourceAssetId)` |
+| Which crown jewels become unreachable after cutting one edge? | `remediationImpact(blockedEdgeId)` |
+
+## Sample Dataset
+
+The module bundles graph-io CSV fixtures under `src/main/resources/sample-data/security-attack-path/`.
+
+| File | Contents |
+|---|---|
+| `vertices.csv` | entry assets, hosts, principals, credentials, vulnerabilities, and permissions. |
+| `edges.csv` | reachability, exploit, compromise, credential, permission, and asset-control edges. |
+
+```kotlin
+val ops = TinkerGraphOperations()
+val service = SecurityAttackPathService(ops)
+service.initialize()
+
+SecurityAttackPathSampleDatasetLoader.importCsv(ops)
+val path = service.shortestAttackPath("internet", "customer-db")
+val blocked = service.remediationImpact("edge-credential-admin")
+```
+
+## Expected Output
+
+| Query | Expected IDs |
+|---|---|
+| `shortestAttackPath("internet", "customer-db")` | `internet`, `web-edge`, `vuln-web-rce`, `web-service`, `ci-admin-token`, `domain-admin`, `db-admin`, `customer-db` |
+| `privilegeEscalationPaths("web-service")` | `web-service`, `ci-admin-token`, `domain-admin` |
+| `unreachableCrownJewels("internet")` | `backup-vault` |
+| `remediationImpact("edge-credential-admin")` | `customer-db` |
+
+## Running Tests
+
+```bash
+./gradlew :security-attack-path-examples:test
+```
+
+The first slice uses TinkerGraph smoke coverage and graph-io CSV loader tests.

--- a/examples/security-attack-path-examples/build.gradle.kts
+++ b/examples/security-attack-path-examples/build.gradle.kts
@@ -1,0 +1,11 @@
+dependencies {
+    implementation(project(":bluetape4k-graph-core"))
+    implementation(project(":bluetape4k-graph-tinkerpop"))
+    implementation(project(":bluetape4k-graph-io-csv"))
+
+    implementation(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core.lib)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.kotlinx.coroutines.test.lib)
+}

--- a/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/io/SecurityAttackPathSampleDatasetLoader.kt
+++ b/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/io/SecurityAttackPathSampleDatasetLoader.kt
@@ -1,0 +1,89 @@
+package io.bluetape4k.graph.examples.securityattack.io
+
+import io.bluetape4k.graph.io.csv.CsvGraphBulkImporter
+import io.bluetape4k.graph.io.csv.CsvGraphImportSource
+import io.bluetape4k.graph.io.csv.CsvGraphIoOptions
+import io.bluetape4k.graph.io.csv.SuspendCsvGraphBulkImporter
+import io.bluetape4k.graph.io.options.GraphImportOptions
+import io.bluetape4k.graph.io.report.GraphImportReport
+import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import java.io.InputStream
+
+/**
+ * Imports the security attack-path sample CSV dataset with graph-io.
+ */
+object SecurityAttackPathSampleDatasetLoader {
+
+    const val DEFAULT_VERTICES_RESOURCE: String = "sample-data/security-attack-path/vertices.csv"
+    const val DEFAULT_EDGES_RESOURCE: String = "sample-data/security-attack-path/edges.csv"
+
+    fun importCsv(
+        operations: GraphOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSource(verticesResource, edgesResource) { source ->
+            CsvGraphBulkImporter().importGraph(source, operations, options, csvOptions)
+        }
+
+    suspend fun importCsvSuspending(
+        operations: GraphSuspendOperations,
+        verticesResource: String = DEFAULT_VERTICES_RESOURCE,
+        edgesResource: String = DEFAULT_EDGES_RESOURCE,
+        options: GraphImportOptions = GraphImportOptions(),
+        csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
+    ): GraphImportReport =
+        withImportSourceSuspending(verticesResource, edgesResource) { source ->
+            SuspendCsvGraphBulkImporter().importGraphSuspending(source, operations, options, csvOptions)
+        }
+
+    private fun <T> withImportSource(
+        verticesResource: String,
+        edgesResource: String,
+        block: (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private suspend fun <T> withImportSourceSuspending(
+        verticesResource: String,
+        edgesResource: String,
+        block: suspend (CsvGraphImportSource) -> T,
+    ): T {
+        val vertices = resourceStreamOrThrow(verticesResource)
+        return vertices.use { vertexInput ->
+            val edges = resourceStreamOrThrow(edgesResource)
+            edges.use { edgeInput ->
+                block(CsvGraphImportSource(vertexInput.toSource(), edgeInput.toSource()))
+            }
+        }
+    }
+
+    private fun InputStream.toSource(): GraphImportSource =
+        GraphImportSource.InputStreamSource(
+            input = this,
+            closeInput = false,
+        )
+
+    private fun resourceStreamOrThrow(resourceName: String): InputStream =
+        requireNotNull(
+            listOfNotNull(
+                Thread.currentThread().contextClassLoader,
+                SecurityAttackPathSampleDatasetLoader::class.java.classLoader,
+            ).asSequence()
+                .mapNotNull { it.getResourceAsStream(resourceName) }
+                .firstOrNull()
+        ) {
+            "Sample dataset resource not found: $resourceName"
+        }
+}

--- a/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/schema/SecurityAttackPathGraphSchema.kt
+++ b/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/schema/SecurityAttackPathGraphSchema.kt
@@ -1,0 +1,138 @@
+package io.bluetape4k.graph.examples.securityattack.schema
+
+import io.bluetape4k.graph.schema.EdgeLabel
+import io.bluetape4k.graph.schema.VertexLabel
+
+/**
+ * External or internal entry point that can start an attack path.
+ */
+object EntryAssetLabel: VertexLabel("EntryAsset") {
+    val assetId = string("assetId")
+    val name = string("name")
+    val exposure = string("exposure")
+    val status = string("status")
+}
+
+/**
+ * Host, workload, or data store that can participate in an attack path.
+ */
+object HostLabel: VertexLabel("Host") {
+    val hostId = string("hostId")
+    val name = string("name")
+    val exposure = string("exposure")
+    val criticality = string("criticality")
+    val status = string("status")
+}
+
+/**
+ * Human, service, or assumed identity.
+ */
+object PrincipalLabel: VertexLabel("Principal") {
+    val principalId = string("principalId")
+    val name = string("name")
+    val kind = string("kind")
+    val privilege = string("privilege")
+    val status = string("status")
+}
+
+/**
+ * Credential or token material that may unlock another identity.
+ */
+object CredentialLabel: VertexLabel("Credential") {
+    val credentialId = string("credentialId")
+    val name = string("name")
+    val kind = string("kind")
+    val status = string("status")
+}
+
+/**
+ * Vulnerability signal used only for educational risk scoring.
+ */
+object VulnerabilityLabel: VertexLabel("Vulnerability") {
+    val vulnerabilityId = string("vulnerabilityId")
+    val name = string("name")
+    val severity = string("severity")
+    val status = string("status")
+}
+
+/**
+ * Permission or resource capability attached to a principal.
+ */
+object PermissionLabel: VertexLabel("Permission") {
+    val permissionId = string("permissionId")
+    val name = string("name")
+    val privilege = string("privilege")
+    val status = string("status")
+}
+
+/**
+ * Reachability or lateral-movement edge.
+ */
+object CanReachLabel: EdgeLabel("CAN_REACH", EntryAssetLabel, HostLabel) {
+    val edgeId = string("edgeId")
+    val kind = string("kind")
+    val status = string("status")
+}
+
+/**
+ * Exploit relationship from an attacker-controlled node to a vulnerability.
+ */
+object ExploitsLabel: EdgeLabel("EXPLOITS", HostLabel, VulnerabilityLabel) {
+    val edgeId = string("edgeId")
+    val technique = string("technique")
+    val status = string("status")
+}
+
+/**
+ * Vulnerability-to-host compromise relationship.
+ */
+object CompromisesLabel: EdgeLabel("COMPROMISES", VulnerabilityLabel, PrincipalLabel) {
+    val edgeId = string("edgeId")
+    val impact = string("impact")
+    val status = string("status")
+}
+
+/**
+ * Host-to-principal execution context.
+ */
+object RunsAsLabel: EdgeLabel("RUNS_AS", HostLabel, PrincipalLabel) {
+    val edgeId = string("edgeId")
+    val kind = string("kind")
+    val status = string("status")
+}
+
+/**
+ * Credential discovery edge.
+ */
+object HasCredentialLabel: EdgeLabel("HAS_CREDENTIAL", PrincipalLabel, CredentialLabel) {
+    val edgeId = string("edgeId")
+    val location = string("location")
+    val status = string("status")
+}
+
+/**
+ * Credential-to-principal access edge.
+ */
+object GrantsAccessLabel: EdgeLabel("GRANTS_ACCESS", CredentialLabel, PrincipalLabel) {
+    val edgeId = string("edgeId")
+    val method = string("method")
+    val status = string("status")
+}
+
+/**
+ * Principal-to-permission edge.
+ */
+object HasPermissionLabel: EdgeLabel("HAS_PERMISSION", PrincipalLabel, PermissionLabel) {
+    val edgeId = string("edgeId")
+    val scope = string("scope")
+    val status = string("status")
+}
+
+/**
+ * Permission-to-host asset-control edge.
+ */
+object ControlsAssetLabel: EdgeLabel("CONTROLS_ASSET", PermissionLabel, HostLabel) {
+    val edgeId = string("edgeId")
+    val scope = string("scope")
+    val status = string("status")
+}

--- a/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/service/SecurityAttackPathService.kt
+++ b/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/service/SecurityAttackPathService.kt
@@ -1,0 +1,275 @@
+package io.bluetape4k.graph.examples.securityattack.service
+
+import io.bluetape4k.graph.examples.securityattack.schema.CanReachLabel
+import io.bluetape4k.graph.examples.securityattack.schema.CompromisesLabel
+import io.bluetape4k.graph.examples.securityattack.schema.ControlsAssetLabel
+import io.bluetape4k.graph.examples.securityattack.schema.CredentialLabel
+import io.bluetape4k.graph.examples.securityattack.schema.EntryAssetLabel
+import io.bluetape4k.graph.examples.securityattack.schema.ExploitsLabel
+import io.bluetape4k.graph.examples.securityattack.schema.GrantsAccessLabel
+import io.bluetape4k.graph.examples.securityattack.schema.HasCredentialLabel
+import io.bluetape4k.graph.examples.securityattack.schema.HasPermissionLabel
+import io.bluetape4k.graph.examples.securityattack.schema.HostLabel
+import io.bluetape4k.graph.examples.securityattack.schema.PermissionLabel
+import io.bluetape4k.graph.examples.securityattack.schema.PrincipalLabel
+import io.bluetape4k.graph.examples.securityattack.schema.RunsAsLabel
+import io.bluetape4k.graph.examples.securityattack.schema.VulnerabilityLabel
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import java.io.Serializable
+
+/**
+ * One educational attack path through business identifiers.
+ */
+data class SecurityAttackPath(
+    val nodeIds: List<String>,
+    val riskScore: Int,
+    val reason: String,
+): Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
+
+/**
+ * Educational attack-path traversal service built on top of [GraphOperations].
+ *
+ * This is not a security scanner. It demonstrates graph-shaped attack-path reasoning over a small static model:
+ * reachability, exploit steps, credential pivoting, privilege escalation, and remediation impact.
+ */
+class SecurityAttackPathService(
+    private val ops: GraphOperations,
+    private val graphName: String = "security_attack_path",
+) {
+    companion object: KLogging()
+
+    /**
+     * Creates the backing graph when it does not already exist.
+     */
+    fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Security attack-path graph '$graphName' created" }
+        }
+    }
+
+    fun shortestAttackPath(
+        sourceAssetId: String,
+        targetHostId: String,
+        blockedNodeIds: Set<String> = emptySet(),
+        blockedEdgeIds: Set<String> = emptySet(),
+    ): SecurityAttackPath? {
+        sourceAssetId.requireNotBlank("sourceAssetId")
+        targetHostId.requireNotBlank("targetHostId")
+
+        val source = entryAssetById(sourceAssetId) ?: return null
+        val target = hostById(targetHostId) ?: return null
+        return shortestPath(source, target, blockedNodeIds, blockedEdgeIds)
+            ?.toAttackPath("shortest active attack path")
+    }
+
+    fun rankedAttackPaths(
+        sourceAssetId: String,
+        targetHostId: String,
+        maxDepth: Int = 8,
+    ): List<SecurityAttackPath> {
+        sourceAssetId.requireNotBlank("sourceAssetId")
+        targetHostId.requireNotBlank("targetHostId")
+        require(maxDepth > 0) { "maxDepth must be > 0, was $maxDepth" }
+
+        val source = entryAssetById(sourceAssetId) ?: return emptyList()
+        val target = hostById(targetHostId) ?: return emptyList()
+        val paths = mutableListOf<List<GraphVertex>>()
+        val queue = ArrayDeque<List<GraphVertex>>()
+        queue += listOf(source)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val tail = path.last()
+            if (path.size > maxDepth + 1) {
+                continue
+            }
+            if (tail.id == target.id) {
+                paths += path
+                continue
+            }
+            activeOutgoingNeighbors(tail)
+                .filterNot { next -> path.any { it.id == next.id } }
+                .forEach { next -> queue += path + next }
+        }
+
+        return paths
+            .distinctBy { path -> path.map { it.id } }
+            .map { it.toAttackPath("ranked attack path candidate") }
+            .sortedWith(compareByDescending<SecurityAttackPath> { it.riskScore }.thenBy { it.nodeIds.size })
+    }
+
+    fun privilegeEscalationPaths(
+        startPrincipalId: String,
+        targetPrivilege: String = "admin",
+        maxDepth: Int = 5,
+    ): List<SecurityAttackPath> {
+        startPrincipalId.requireNotBlank("startPrincipalId")
+        targetPrivilege.requireNotBlank("targetPrivilege")
+        require(maxDepth > 0) { "maxDepth must be > 0, was $maxDepth" }
+
+        val source = principalById(startPrincipalId) ?: return emptyList()
+        val paths = mutableListOf<List<GraphVertex>>()
+        val queue = ArrayDeque<List<GraphVertex>>()
+        queue += listOf(source)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val tail = path.last()
+            if (path.size > maxDepth + 1) {
+                continue
+            }
+            if (tail !== source && hasPrivilege(tail, targetPrivilege)) {
+                paths += path
+                continue
+            }
+            activeOutgoingNeighbors(
+                tail,
+                labels = listOf(HasCredentialLabel.label, GrantsAccessLabel.label, HasPermissionLabel.label),
+            )
+                .filterNot { next -> path.any { it.id == next.id } }
+                .forEach { next -> queue += path + next }
+        }
+
+        return paths
+            .distinctBy { path -> path.map { it.id } }
+            .map { it.toAttackPath("privilege escalation path") }
+            .sortedBy { it.nodeIds.size }
+    }
+
+    fun unreachableCrownJewels(sourceAssetId: String): List<GraphVertex> {
+        sourceAssetId.requireNotBlank("sourceAssetId")
+        val source = entryAssetById(sourceAssetId) ?: return emptyList()
+        return crownJewelHosts()
+            .filter { target -> shortestPath(source, target) == null }
+            .distinctBy { it.id }
+    }
+
+    fun remediationImpact(
+        blockedEdgeId: String,
+        sourceAssetId: String = "internet",
+    ): List<GraphVertex> {
+        blockedEdgeId.requireNotBlank("blockedEdgeId")
+        sourceAssetId.requireNotBlank("sourceAssetId")
+
+        val source = entryAssetById(sourceAssetId) ?: return emptyList()
+        return crownJewelHosts()
+            .filter { target ->
+                shortestPath(source, target) != null &&
+                    shortestPath(source, target, blockedEdgeIds = setOf(blockedEdgeId)) == null
+            }
+            .distinctBy { it.id }
+    }
+
+    private fun shortestPath(
+        source: GraphVertex,
+        target: GraphVertex,
+        blockedNodeIds: Set<String> = emptySet(),
+        blockedEdgeIds: Set<String> = emptySet(),
+    ): List<GraphVertex>? {
+        if (businessId(source) in blockedNodeIds || businessId(target) in blockedNodeIds) {
+            return null
+        }
+
+        val visited = mutableSetOf(source.id)
+        val queue = ArrayDeque<List<GraphVertex>>()
+        queue += listOf(source)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val tail = path.last()
+            if (tail.id == target.id) {
+                return path
+            }
+            activeOutgoingNeighbors(tail, blockedEdgeIds = blockedEdgeIds)
+                .filterNot { next -> next.id in visited || businessId(next) in blockedNodeIds }
+                .forEach { next ->
+                    visited += next.id
+                    queue += path + next
+                }
+        }
+
+        return null
+    }
+
+    private fun activeOutgoingNeighbors(
+        vertex: GraphVertex,
+        labels: List<String> = attackEdgeLabels,
+        blockedEdgeIds: Set<String> = emptySet(),
+    ): List<GraphVertex> =
+        labels.flatMap { label -> ops.findEdgesByLabel(label).filter { it.startId == vertex.id } }
+            .filter { edge -> edge.properties["status"] == "active" && edge.edgeBusinessId() !in blockedEdgeIds }
+            .mapNotNull { edge -> ops.findVertexById(edge.endId) }
+            .filter { it.properties["status"] == "active" }
+            .distinctBy { it.id }
+
+    private fun List<GraphVertex>.toAttackPath(reason: String): SecurityAttackPath =
+        SecurityAttackPath(
+            nodeIds = map(::businessId),
+            riskScore = sumOf(::riskContribution),
+            reason = reason,
+        )
+
+    private fun hasPrivilege(vertex: GraphVertex, targetPrivilege: String): Boolean =
+        when (vertex.label) {
+            PrincipalLabel.label   -> vertex.properties[PrincipalLabel.privilege.name] == targetPrivilege
+            PermissionLabel.label  -> vertex.properties[PermissionLabel.privilege.name] == targetPrivilege
+            else                   -> false
+        }
+
+    private fun crownJewelHosts(): List<GraphVertex> =
+        ops.findVerticesByLabel(HostLabel.label)
+            .filter { it.properties[HostLabel.criticality.name] == "crown_jewel" }
+
+    private fun entryAssetById(assetId: String): GraphVertex? =
+        ops.findVerticesByLabel(EntryAssetLabel.label, mapOf(EntryAssetLabel.assetId.name to assetId)).firstOrNull()
+
+    private fun hostById(hostId: String): GraphVertex? =
+        ops.findVerticesByLabel(HostLabel.label, mapOf(HostLabel.hostId.name to hostId)).firstOrNull()
+
+    private fun principalById(principalId: String): GraphVertex? =
+        ops.findVerticesByLabel(PrincipalLabel.label, mapOf(PrincipalLabel.principalId.name to principalId)).firstOrNull()
+
+    private fun businessId(vertex: GraphVertex): String =
+        when (vertex.label) {
+            EntryAssetLabel.label    -> vertex.properties[EntryAssetLabel.assetId.name].toString()
+            HostLabel.label          -> vertex.properties[HostLabel.hostId.name].toString()
+            PrincipalLabel.label     -> vertex.properties[PrincipalLabel.principalId.name].toString()
+            CredentialLabel.label    -> vertex.properties[CredentialLabel.credentialId.name].toString()
+            VulnerabilityLabel.label -> vertex.properties[VulnerabilityLabel.vulnerabilityId.name].toString()
+            PermissionLabel.label    -> vertex.properties[PermissionLabel.permissionId.name].toString()
+            else                     -> vertex.id.value
+        }
+
+    private fun riskContribution(vertex: GraphVertex): Int =
+        when (vertex.label) {
+            VulnerabilityLabel.label -> vertex.properties[VulnerabilityLabel.severity.name].toString().toIntOrNull() ?: 0
+            HostLabel.label          -> if (vertex.properties[HostLabel.criticality.name] == "crown_jewel") 5 else 1
+            PrincipalLabel.label     -> if (vertex.properties[PrincipalLabel.privilege.name] == "admin") 4 else 1
+            PermissionLabel.label    -> if (vertex.properties[PermissionLabel.privilege.name] == "admin") 3 else 1
+            else                     -> 1
+        }
+
+    private fun GraphEdge.edgeBusinessId(): String =
+        properties["edgeId"]?.toString() ?: id.value
+}
+
+private val attackEdgeLabels = listOf(
+    ExploitsLabel.label,
+    CanReachLabel.label,
+    CompromisesLabel.label,
+    RunsAsLabel.label,
+    HasCredentialLabel.label,
+    GrantsAccessLabel.label,
+    HasPermissionLabel.label,
+    ControlsAssetLabel.label,
+)

--- a/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/service/SecurityAttackPathSuspendService.kt
+++ b/examples/security-attack-path-examples/src/main/kotlin/io/bluetape4k/graph/examples/securityattack/service/SecurityAttackPathSuspendService.kt
@@ -1,0 +1,263 @@
+package io.bluetape4k.graph.examples.securityattack.service
+
+import io.bluetape4k.graph.examples.securityattack.schema.CanReachLabel
+import io.bluetape4k.graph.examples.securityattack.schema.CompromisesLabel
+import io.bluetape4k.graph.examples.securityattack.schema.ControlsAssetLabel
+import io.bluetape4k.graph.examples.securityattack.schema.CredentialLabel
+import io.bluetape4k.graph.examples.securityattack.schema.EntryAssetLabel
+import io.bluetape4k.graph.examples.securityattack.schema.ExploitsLabel
+import io.bluetape4k.graph.examples.securityattack.schema.GrantsAccessLabel
+import io.bluetape4k.graph.examples.securityattack.schema.HasCredentialLabel
+import io.bluetape4k.graph.examples.securityattack.schema.HasPermissionLabel
+import io.bluetape4k.graph.examples.securityattack.schema.HostLabel
+import io.bluetape4k.graph.examples.securityattack.schema.PermissionLabel
+import io.bluetape4k.graph.examples.securityattack.schema.PrincipalLabel
+import io.bluetape4k.graph.examples.securityattack.schema.RunsAsLabel
+import io.bluetape4k.graph.examples.securityattack.schema.VulnerabilityLabel
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.flow.toList
+
+/**
+ * Coroutine version of [SecurityAttackPathService].
+ */
+class SecurityAttackPathSuspendService(
+    private val ops: GraphSuspendOperations,
+    private val graphName: String = "security_attack_path",
+) {
+    companion object: KLoggingChannel()
+
+    suspend fun initialize() {
+        if (!ops.graphExists(graphName)) {
+            ops.createGraph(graphName)
+            log.info { "Security attack-path graph '$graphName' created" }
+        }
+    }
+
+    suspend fun shortestAttackPath(
+        sourceAssetId: String,
+        targetHostId: String,
+        blockedNodeIds: Set<String> = emptySet(),
+        blockedEdgeIds: Set<String> = emptySet(),
+    ): SecurityAttackPath? {
+        sourceAssetId.requireNotBlank("sourceAssetId")
+        targetHostId.requireNotBlank("targetHostId")
+
+        val source = entryAssetById(sourceAssetId) ?: return null
+        val target = hostById(targetHostId) ?: return null
+        return shortestPath(source, target, blockedNodeIds, blockedEdgeIds)
+            ?.toAttackPath("shortest active attack path")
+    }
+
+    suspend fun rankedAttackPaths(
+        sourceAssetId: String,
+        targetHostId: String,
+        maxDepth: Int = 8,
+    ): List<SecurityAttackPath> {
+        sourceAssetId.requireNotBlank("sourceAssetId")
+        targetHostId.requireNotBlank("targetHostId")
+        require(maxDepth > 0) { "maxDepth must be > 0, was $maxDepth" }
+
+        val source = entryAssetById(sourceAssetId) ?: return emptyList()
+        val target = hostById(targetHostId) ?: return emptyList()
+        val paths = mutableListOf<List<GraphVertex>>()
+        val queue = ArrayDeque<List<GraphVertex>>()
+        queue += listOf(source)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val tail = path.last()
+            if (path.size > maxDepth + 1) {
+                continue
+            }
+            if (tail.id == target.id) {
+                paths += path
+                continue
+            }
+            activeOutgoingNeighbors(tail)
+                .filterNot { next -> path.any { it.id == next.id } }
+                .forEach { next -> queue += path + next }
+        }
+
+        return paths
+            .distinctBy { path -> path.map { it.id } }
+            .map { it.toAttackPath("ranked attack path candidate") }
+            .sortedWith(compareByDescending<SecurityAttackPath> { it.riskScore }.thenBy { it.nodeIds.size })
+    }
+
+    suspend fun privilegeEscalationPaths(
+        startPrincipalId: String,
+        targetPrivilege: String = "admin",
+        maxDepth: Int = 5,
+    ): List<SecurityAttackPath> {
+        startPrincipalId.requireNotBlank("startPrincipalId")
+        targetPrivilege.requireNotBlank("targetPrivilege")
+        require(maxDepth > 0) { "maxDepth must be > 0, was $maxDepth" }
+
+        val source = principalById(startPrincipalId) ?: return emptyList()
+        val paths = mutableListOf<List<GraphVertex>>()
+        val queue = ArrayDeque<List<GraphVertex>>()
+        queue += listOf(source)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val tail = path.last()
+            if (path.size > maxDepth + 1) {
+                continue
+            }
+            if (tail !== source && hasPrivilege(tail, targetPrivilege)) {
+                paths += path
+                continue
+            }
+            activeOutgoingNeighbors(
+                tail,
+                labels = listOf(HasCredentialLabel.label, GrantsAccessLabel.label, HasPermissionLabel.label),
+            )
+                .filterNot { next -> path.any { it.id == next.id } }
+                .forEach { next -> queue += path + next }
+        }
+
+        return paths
+            .distinctBy { path -> path.map { it.id } }
+            .map { it.toAttackPath("privilege escalation path") }
+            .sortedBy { it.nodeIds.size }
+    }
+
+    suspend fun unreachableCrownJewels(sourceAssetId: String): List<GraphVertex> {
+        sourceAssetId.requireNotBlank("sourceAssetId")
+        val source = entryAssetById(sourceAssetId) ?: return emptyList()
+        return crownJewelHosts()
+            .filter { target -> shortestPath(source, target) == null }
+            .distinctBy { it.id }
+    }
+
+    suspend fun remediationImpact(
+        blockedEdgeId: String,
+        sourceAssetId: String = "internet",
+    ): List<GraphVertex> {
+        blockedEdgeId.requireNotBlank("blockedEdgeId")
+        sourceAssetId.requireNotBlank("sourceAssetId")
+
+        val source = entryAssetById(sourceAssetId) ?: return emptyList()
+        return crownJewelHosts()
+            .filter { target ->
+                shortestPath(source, target) != null &&
+                    shortestPath(source, target, blockedEdgeIds = setOf(blockedEdgeId)) == null
+            }
+            .distinctBy { it.id }
+    }
+
+    private suspend fun shortestPath(
+        source: GraphVertex,
+        target: GraphVertex,
+        blockedNodeIds: Set<String> = emptySet(),
+        blockedEdgeIds: Set<String> = emptySet(),
+    ): List<GraphVertex>? {
+        if (businessId(source) in blockedNodeIds || businessId(target) in blockedNodeIds) {
+            return null
+        }
+
+        val visited = mutableSetOf(source.id)
+        val queue = ArrayDeque<List<GraphVertex>>()
+        queue += listOf(source)
+
+        while (queue.isNotEmpty()) {
+            val path = queue.removeFirst()
+            val tail = path.last()
+            if (tail.id == target.id) {
+                return path
+            }
+            activeOutgoingNeighbors(tail, blockedEdgeIds = blockedEdgeIds)
+                .filterNot { next -> next.id in visited || businessId(next) in blockedNodeIds }
+                .forEach { next ->
+                    visited += next.id
+                    queue += path + next
+                }
+        }
+
+        return null
+    }
+
+    private suspend fun activeOutgoingNeighbors(
+        vertex: GraphVertex,
+        labels: List<String> = attackEdgeLabels,
+        blockedEdgeIds: Set<String> = emptySet(),
+    ): List<GraphVertex> =
+        labels.flatMap { label -> ops.findEdgesByLabel(label).toList().filter { it.startId == vertex.id } }
+            .filter { edge -> edge.properties["status"] == "active" && edge.edgeBusinessId() !in blockedEdgeIds }
+            .mapNotNull { edge -> ops.findVertexById(edge.endId) }
+            .filter { it.properties["status"] == "active" }
+            .distinctBy { it.id }
+
+    private fun List<GraphVertex>.toAttackPath(reason: String): SecurityAttackPath =
+        SecurityAttackPath(
+            nodeIds = map(::businessId),
+            riskScore = sumOf(::riskContribution),
+            reason = reason,
+        )
+
+    private fun hasPrivilege(vertex: GraphVertex, targetPrivilege: String): Boolean =
+        when (vertex.label) {
+            PrincipalLabel.label  -> vertex.properties[PrincipalLabel.privilege.name] == targetPrivilege
+            PermissionLabel.label -> vertex.properties[PermissionLabel.privilege.name] == targetPrivilege
+            else                  -> false
+        }
+
+    private suspend fun crownJewelHosts(): List<GraphVertex> =
+        ops.findVerticesByLabel(HostLabel.label)
+            .toList()
+            .filter { it.properties[HostLabel.criticality.name] == "crown_jewel" }
+
+    private suspend fun entryAssetById(assetId: String): GraphVertex? =
+        ops.findVerticesByLabel(EntryAssetLabel.label, mapOf(EntryAssetLabel.assetId.name to assetId))
+            .toList()
+            .firstOrNull()
+
+    private suspend fun hostById(hostId: String): GraphVertex? =
+        ops.findVerticesByLabel(HostLabel.label, mapOf(HostLabel.hostId.name to hostId))
+            .toList()
+            .firstOrNull()
+
+    private suspend fun principalById(principalId: String): GraphVertex? =
+        ops.findVerticesByLabel(PrincipalLabel.label, mapOf(PrincipalLabel.principalId.name to principalId))
+            .toList()
+            .firstOrNull()
+
+    private fun businessId(vertex: GraphVertex): String =
+        when (vertex.label) {
+            EntryAssetLabel.label    -> vertex.properties[EntryAssetLabel.assetId.name].toString()
+            HostLabel.label          -> vertex.properties[HostLabel.hostId.name].toString()
+            PrincipalLabel.label     -> vertex.properties[PrincipalLabel.principalId.name].toString()
+            CredentialLabel.label    -> vertex.properties[CredentialLabel.credentialId.name].toString()
+            VulnerabilityLabel.label -> vertex.properties[VulnerabilityLabel.vulnerabilityId.name].toString()
+            PermissionLabel.label    -> vertex.properties[PermissionLabel.permissionId.name].toString()
+            else                     -> vertex.id.value
+        }
+
+    private fun riskContribution(vertex: GraphVertex): Int =
+        when (vertex.label) {
+            VulnerabilityLabel.label -> vertex.properties[VulnerabilityLabel.severity.name].toString().toIntOrNull() ?: 0
+            HostLabel.label          -> if (vertex.properties[HostLabel.criticality.name] == "crown_jewel") 5 else 1
+            PrincipalLabel.label     -> if (vertex.properties[PrincipalLabel.privilege.name] == "admin") 4 else 1
+            PermissionLabel.label    -> if (vertex.properties[PermissionLabel.privilege.name] == "admin") 3 else 1
+            else                     -> 1
+        }
+
+    private fun GraphEdge.edgeBusinessId(): String =
+        properties["edgeId"]?.toString() ?: id.value
+}
+
+private val attackEdgeLabels = listOf(
+    ExploitsLabel.label,
+    CanReachLabel.label,
+    CompromisesLabel.label,
+    RunsAsLabel.label,
+    HasCredentialLabel.label,
+    GrantsAccessLabel.label,
+    HasPermissionLabel.label,
+    ControlsAssetLabel.label,
+)

--- a/examples/security-attack-path-examples/src/main/resources/sample-data/security-attack-path/edges.csv
+++ b/examples/security-attack-path-examples/src/main/resources/sample-data/security-attack-path/edges.csv
@@ -1,0 +1,11 @@
+id,label,from,to,prop.edgeId,prop.kind,prop.technique,prop.impact,prop.location,prop.method,prop.scope,prop.status
+edge-internet-web,CAN_REACH,asset-internet,host-web,edge-internet-web,http,,,,,,active
+edge-web-rce,EXPLOITS,host-web,vuln-web-rce,edge-web-rce,,rce,,,,,active
+edge-rce-websvc,COMPROMISES,vuln-web-rce,principal-websvc,edge-rce-websvc,,,service-account,,,,active
+edge-web-app,CAN_REACH,host-web,host-app,edge-web-app,service-call,,,,,,active
+edge-app-secret,EXPLOITS,host-app,vuln-app-secret,edge-app-secret,,secret-disclosure,,,,,active
+edge-secret-credential,COMPROMISES,vuln-app-secret,credential-ci-admin,edge-secret-credential,,,token-leak,,,,active
+edge-websvc-credential,HAS_CREDENTIAL,principal-websvc,credential-ci-admin,edge-websvc-credential,,,,runtime-env,,,active
+edge-credential-admin,GRANTS_ACCESS,credential-ci-admin,principal-admin,edge-credential-admin,,,,,token-exchange,,active
+edge-admin-permission,HAS_PERMISSION,principal-admin,permission-db-admin,edge-admin-permission,,,,,,database,active
+edge-permission-db,CONTROLS_ASSET,permission-db-admin,host-db,edge-permission-db,,,,,,admin,active

--- a/examples/security-attack-path-examples/src/main/resources/sample-data/security-attack-path/vertices.csv
+++ b/examples/security-attack-path-examples/src/main/resources/sample-data/security-attack-path/vertices.csv
@@ -1,0 +1,12 @@
+id,label,prop.assetId,prop.hostId,prop.principalId,prop.credentialId,prop.vulnerabilityId,prop.permissionId,prop.name,prop.kind,prop.exposure,prop.criticality,prop.severity,prop.privilege,prop.status
+asset-internet,EntryAsset,internet,,,,,,Internet,,public,,,,active
+host-web,Host,,web-edge,,,,,Public Web Edge,,public,medium,,,active
+host-app,Host,,app-api,,,,,Application API,,internal,high,,,active
+host-db,Host,,customer-db,,,,,Customer Database,,restricted,crown_jewel,,,active
+host-backup,Host,,backup-vault,,,,,Backup Vault,,restricted,crown_jewel,,,active
+principal-websvc,Principal,,,web-service,,,,Web Service Account,service,,,,user,active
+principal-admin,Principal,,,domain-admin,,,,Domain Admin,human,,,,admin,active
+credential-ci-admin,Credential,,,,ci-admin-token,,,CI Admin Token,token,,,,,active
+vuln-web-rce,Vulnerability,,,,,vuln-web-rce,,Web Remote Code Execution,,,,9,,active
+vuln-app-secret,Vulnerability,,,,,vuln-app-secret,,Application Secret Disclosure,,,,8,,active
+permission-db-admin,Permission,,,,,,db-admin,Database Admin Permission,,,,,admin,active

--- a/examples/security-attack-path-examples/src/test/kotlin/io/bluetape4k/graph/examples/securityattack/AbstractSecurityAttackPathSuspendTest.kt
+++ b/examples/security-attack-path-examples/src/test/kotlin/io/bluetape4k/graph/examples/securityattack/AbstractSecurityAttackPathSuspendTest.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.graph.examples.securityattack
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.examples.securityattack.io.SecurityAttackPathSampleDatasetLoader
+import io.bluetape4k.graph.examples.securityattack.schema.HostLabel
+import io.bluetape4k.graph.examples.securityattack.service.SecurityAttackPathSuspendService
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSecurityAttackPathSuspendTest {
+
+    companion object: KLoggingChannel()
+
+    protected abstract val ops: GraphSuspendOperations
+    protected open val graphName: String = "security_attack_path_suspend_test"
+    protected val service: SecurityAttackPathSuspendService by lazy {
+        SecurityAttackPathSuspendService(ops, graphName)
+    }
+
+    @BeforeEach
+    fun cleanGraph() = runSuspendIO {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+        SecurityAttackPathSampleDatasetLoader.importCsvSuspending(ops).status shouldBeEqualTo GraphIoStatus.COMPLETED
+    }
+
+    @Test
+    fun `finds suspend attack path and privilege escalation`() = runSuspendIO {
+        val path = service.shortestAttackPath("internet", "customer-db")
+        val escalation = service.privilegeEscalationPaths("web-service")
+            .map { it.nodeIds }
+
+        path?.nodeIds shouldBeEqualTo listOf(
+            "internet",
+            "web-edge",
+            "vuln-web-rce",
+            "web-service",
+            "ci-admin-token",
+            "domain-admin",
+            "db-admin",
+            "customer-db",
+        )
+        escalation shouldContain listOf("web-service", "ci-admin-token", "domain-admin")
+    }
+
+    @Test
+    fun `finds suspend remediation impact and unreachable crown jewel`() = runSuspendIO {
+        val blockedTargets = service.remediationImpact("edge-credential-admin")
+            .map { it.properties[HostLabel.hostId.name] }
+        val unreachable = service.unreachableCrownJewels("internet")
+            .map { it.properties[HostLabel.hostId.name] }
+
+        blockedTargets shouldBeEqualTo listOf("customer-db")
+        unreachable shouldBeEqualTo listOf("backup-vault")
+    }
+}

--- a/examples/security-attack-path-examples/src/test/kotlin/io/bluetape4k/graph/examples/securityattack/AbstractSecurityAttackPathTest.kt
+++ b/examples/security-attack-path-examples/src/test/kotlin/io/bluetape4k/graph/examples/securityattack/AbstractSecurityAttackPathTest.kt
@@ -1,0 +1,99 @@
+package io.bluetape4k.graph.examples.securityattack
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.examples.securityattack.io.SecurityAttackPathSampleDatasetLoader
+import io.bluetape4k.graph.examples.securityattack.schema.HostLabel
+import io.bluetape4k.graph.examples.securityattack.service.SecurityAttackPathService
+import io.bluetape4k.graph.io.report.GraphIoStatus
+import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSecurityAttackPathTest {
+
+    companion object: KLogging()
+
+    protected abstract val ops: GraphOperations
+    protected open val graphName: String = "security_attack_path_test"
+    protected val service: SecurityAttackPathService by lazy { SecurityAttackPathService(ops, graphName) }
+
+    @BeforeEach
+    fun cleanGraph() {
+        if (ops.graphExists(graphName)) {
+            ops.dropGraph(graphName)
+        }
+        service.initialize()
+        SecurityAttackPathSampleDatasetLoader.importCsv(ops).status shouldBeEqualTo GraphIoStatus.COMPLETED
+    }
+
+    fun `finds reachable and unreachable crown jewel attack paths`() {
+        val path = service.shortestAttackPath("internet", "customer-db")
+        val unreachable = service.unreachableCrownJewels("internet")
+            .map { it.properties[HostLabel.hostId.name] }
+
+        path?.nodeIds shouldBeEqualTo listOf(
+            "internet",
+            "web-edge",
+            "vuln-web-rce",
+            "web-service",
+            "ci-admin-token",
+            "domain-admin",
+            "db-admin",
+            "customer-db",
+        )
+        unreachable shouldBeEqualTo listOf("backup-vault")
+    }
+
+    @Test
+    fun `ranks attack paths by risk signals`() {
+        val paths = service.rankedAttackPaths("internet", "customer-db")
+            .map { it.nodeIds }
+
+        paths shouldContain listOf(
+            "internet",
+            "web-edge",
+            "vuln-web-rce",
+            "web-service",
+            "ci-admin-token",
+            "domain-admin",
+            "db-admin",
+            "customer-db",
+        )
+        paths shouldContain listOf(
+            "internet",
+            "web-edge",
+            "app-api",
+            "vuln-app-secret",
+            "ci-admin-token",
+            "domain-admin",
+            "db-admin",
+            "customer-db",
+        )
+    }
+
+    @Test
+    fun `finds credential based privilege escalation path`() {
+        val paths = service.privilegeEscalationPaths("web-service")
+            .map { it.nodeIds }
+
+        paths shouldContain listOf("web-service", "ci-admin-token", "domain-admin")
+    }
+
+    @Test
+    fun `explains remediation impact by cutting one edge`() {
+        val blockedTargets = service.remediationImpact("edge-credential-admin")
+            .map { it.properties[HostLabel.hostId.name] }
+        val blockedPath = service.shortestAttackPath(
+            sourceAssetId = "internet",
+            targetHostId = "customer-db",
+            blockedEdgeIds = setOf("edge-credential-admin"),
+        )
+
+        blockedTargets shouldBeEqualTo listOf("customer-db")
+        blockedPath shouldBeEqualTo null
+    }
+}

--- a/examples/security-attack-path-examples/src/test/kotlin/io/bluetape4k/graph/examples/securityattack/SecurityAttackPathBackendTests.kt
+++ b/examples/security-attack-path-examples/src/test/kotlin/io/bluetape4k/graph/examples/securityattack/SecurityAttackPathBackendTests.kt
@@ -1,0 +1,14 @@
+package io.bluetape4k.graph.examples.securityattack
+
+import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
+import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+
+class TinkerGraphSecurityAttackPathTest: AbstractSecurityAttackPathTest() {
+    override val ops = TinkerGraphOperations()
+    override val graphName = "default"
+}
+
+class TinkerGraphSecurityAttackPathSuspendTest: AbstractSecurityAttackPathSuspendTest() {
+    override val ops = TinkerGraphSuspendOperations()
+    override val graphName = "default"
+}

--- a/examples/security-attack-path-examples/src/test/resources/junit-platform.properties
+++ b/examples/security-attack-path-examples/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.testinstance.lifecycle.default=per_class

--- a/examples/security-attack-path-examples/src/test/resources/logback-test.xml
+++ b/examples/security-attack-path-examples/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add `security-attack-path-examples` with graph-io CSV fixtures and TinkerGraph sync/suspend services
- cover shortest attack paths, ranked path candidates, credential-based privilege escalation, unreachable crown jewels, and remediation impact
- register the module in README/README.ko, AGENTS, Examples workflow, changelog, and lesson notes

Fixes #252

## Verification
- `./gradlew :security-attack-path-examples:test --no-daemon`
- `./gradlew :security-attack-path-examples:build --no-daemon`
- `./gradlew projects --no-daemon`
- `git diff --check`

## Notes
- Stacked on #276 / `feat/issue-251-network-topology-examples`.
- This is an educational graph-modeling example, not a security scanner or vulnerability-feed integration.
