### PR TITLE
release: prepare graph 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2026-06-01
 
 ### Added
 
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#252](https://github.com/bluetape4k/bluetape4k-graph/issues/252)).
 
 ### Changed
+
+- **Dependency alignment for the 0.5.0 release line**: updated the graph build
+  to consume `io.github.bluetape4k:bluetape4k-bom:1.10.0` while keeping the
+  shared dependency catalog on `catalog/2026-05-26-01`.
 
 ### Fixed
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,108 +1,52 @@
 # WIP - bluetape4k-graph
 
-Snapshot: 2026-05-24 KST
+Snapshot: 2026-06-01 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count: 1 issue.
+Open count: 4 issues.
 
-## 2026-05-24 Milestone Refresh
+## Current Release Gate
 
-Current evidence: latest tags `v0.3.0`, `v0.1.0`. Milestones `0.3.1` and
-`0.4.0` are complete, `0.4.1` has zero open issues, and backlog has #30 marked
-`invalid,Epic,research`.
+Prepare and publish `0.5.0`.
 
-| Lane | Candidate milestone | Current candidates | Decision |
+The `0.5.0` milestone has zero open issues and no open pull requests. The
+release line consumes `io.github.bluetape4k:bluetape4k-bom:1.10.0`, keeps
+`snapshotVersion=` empty, and has recent `develop` CI plus Examples workflow
+success on commit `8e4abdd`.
+
+## Active Queue
+
+| Priority | Issue | Milestone | Notes |
 |---|---|---|---|
-| Patch | `0.4.1` | none yet | Keep as the next patch slot only for release fallout, benchmark/report drift, CI failures, or dependency/catalog sync. |
-| Minor | `0.5.0` | revalidate #30 first | Do not schedule Amazon Neptune implementation while #30 is still `invalid`/research. Reopen only after AWS SDK, Testcontainers/localstack feasibility, and API boundary are revalidated. |
-
-Recommended order: keep `0.4.1` empty until a real patch appears; revalidate #30
-as research before creating a `0.5.0` implementation epic.
-
-## New Milestone Queue - 2026-05-24
-
-### New patch milestone `0.4.1`
-
-1. [#214](https://github.com/bluetape4k/bluetape4k-graph/issues/214)
-   `docs: refresh graph benchmark report after 0.4.0 release`
-
-### New minor milestone `0.5.0`
-
-1. [#215](https://github.com/bluetape4k/bluetape4k-graph/issues/215)
-   `research: revalidate Amazon Neptune backend feasibility`
-2. [#216](https://github.com/bluetape4k/bluetape4k-graph/issues/216)
-   `perf: unify AGE and Neo4j benchmark report output`
-3. [#217](https://github.com/bluetape4k/bluetape4k-graph/issues/217)
-   `docs: map graph backend capability matrix into README diagrams`
-
-### Backlog reference
-
-1. [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30)
-   `[Epic] Amazon Neptune 그래프 DB 백엔드 구현 (graph-neptune)` remains backlog
-   research until #215 decides whether to revive it.
-
-## Issue Discovery - 2026-05-24
-
-Patch candidates:
-
-- `docs: refresh graph benchmark report after 0.4.0 release`
-  - Keep patch-scoped: no benchmark implementation change unless current reports
-    fail to reproduce.
-
-Minor candidates:
-
-- `research: revalidate Amazon Neptune backend feasibility` (#30)
-  - Keep as research while #30 is still marked `invalid`.
-- `perf: unify AGE and Neo4j benchmark report output`
-  - Evidence: `scripts/benchmark-neo4j-age.sh` combines benchmark JSON summaries.
-- `docs: map graph backend capability matrix into README diagrams`
-  - Candidate only after benchmark/provider direction is settled.
+| P1 | [#233](https://github.com/bluetape4k/bluetape4k-graph/issues/233) feat: add chunked graph export cursor API for graph-io streaming | 0.6.0 | Next graph-io streaming feature lane after 0.5.0 release. |
+| P2 | [#234](https://github.com/bluetape4k/bluetape4k-graph/issues/234) research: evaluate backend-native bulk loaders for graph-io | 0.6.0 | Research lane for backend-native bulk import/export tradeoffs. |
+| P3 | [#215](https://github.com/bluetape4k/bluetape4k-graph/issues/215) research: revalidate Amazon Neptune backend feasibility | backlog | Required before reviving #30. |
+| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) [Epic] Amazon Neptune 그래프 DB 백엔드 구현 (graph-neptune) | backlog | Keep blocked while marked `invalid`/research; do not implement against mocks only. |
 
 ## Recently Completed
 
-- The 0.4.0 release gate is clear. Milestones `0.3.1` and `0.4.0` both have
-  zero open issues on GitHub.
-- Coroutine cancellation and suspend transaction correctness work is merged:
-  #156, #157, #158, and #160.
-- FalkorDB Spring Boot/Ktor readiness and documentation work is merged:
-  #126, #127, #133, #134, and #135.
-- Graph benchmark and self-improve evidence lanes are merged:
-  #14, #15, #41, #188, #189, #190, #191, #192, #193, #196, #197, #198, #199,
-  and #201.
-- Domain example sample loaders are merged through #111.
+- `0.5.0` Ktor managed backend DSL work is complete for Neo4j, Memgraph,
+  FalkorDB, and Apache AGE DataSource ownership.
+- `0.5.0` domain example suite is complete for observability, IAM access paths,
+  supply-chain impact, data lineage, network topology, and security attack
+  paths.
+- Root README English/Korean module lists and example test commands already
+  include the 0.5.0 example modules.
 
-## Current Direction
+## Verification Evidence
 
-Prepare and publish `0.4.0`.
+- GitHub milestone `0.5.0`: open issues `0`, closed issues `35`.
+- Open PRs: none.
+- CI: `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305940`
+  succeeded on commit `8e4abdd`.
+- Examples: `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305942`
+  succeeded on commit `8e4abdd`.
+- Maven Central pre-release check:
+  `io.github.bluetape4k.graph:bluetape4k-graph-bom:0.5.0` is not yet
+  published, as expected before the stable release dispatch.
 
-The repository already contains the 0.4.0 benchmark/self-improve work on
-`develop`, so publishing a separate `0.3.1` tag from the same head would create
-duplicate patch/minor artifacts with the same code. Treat 0.4.0 as the next
-release line and keep new backend work out until the release is complete.
+## Release Notes
 
-## Priority Queue
-
-| Priority | Issue | Difficulty | Notes |
-|---|---|---:|---|
-| P1 | [#113](https://github.com/bluetape4k/bluetape4k-graph/issues/113) Neptune local testability research | M | Required predecessor for #30; backlog milestone. |
-| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) Amazon Neptune backend | XL | Blocked on #113/research-quality evidence. |
-
-## Dependency Map
-
-```text
-#113 Neptune local testability research
-  -> #30 Neptune backend
-
-#156/#157 cancellation fixes
-#158/#160 suspend transaction fixes
-  -> 0.4.0 correctness baseline
-
-#14/#15/#41/#188/#189/#190/#191/#192/#193/#196/#197/#198/#199/#201
-  -> 0.4.0 benchmark evidence baseline
-```
-
-## WIP Limits
-
-| Lane | Limit | Current next |
-|---|---:|---|
-| Research / backend readiness | 1 | #113 before #30. |
-| Release | 1 | Finish 0.4.0 release before starting more graph feature work. |
+- Keep `0.5.0` focused on graph-ktor managed backend setup plus runnable domain
+  graph examples.
+- Move any new streaming, backend-native bulk loader, or Neptune work to `0.6.0`
+  or backlog unless it is release fallout.

--- a/docs/lessons/2026-06-01-graph-0-5-0-release-prep.md
+++ b/docs/lessons/2026-06-01-graph-0-5-0-release-prep.md
@@ -1,0 +1,38 @@
+# Graph 0.5.0 Release Prep
+
+## Context
+
+`bluetape4k-dependencies` 1.2.0 needs the latest stable graph line. The graph
+repository already has `baseVersion=0.5.0`, consumes
+`io.github.bluetape4k:bluetape4k-bom:1.10.0`, and includes the completed 0.5.0
+Ktor managed backend and domain example milestone work.
+
+## Decision
+
+Prepare `0.5.0` as the next stable graph release. Keep README unchanged because
+the English and Korean root README files already list the new example modules
+and example test commands.
+
+## Outcome
+
+Release metadata now has a dated `0.5.0` changelog section, refreshed WIP state,
+and explicit pre-release evidence. The milestone has no open issues and no open
+pull requests.
+
+## Verification
+
+- GitHub milestone `0.5.0`: open issues `0`, closed issues `35`.
+- GitHub open PRs: none.
+- CI succeeded on commit `8e4abdd`:
+  `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305940`.
+- Examples succeeded on commit `8e4abdd`:
+  `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305942`.
+- Maven Central correctly returns 404 for
+  `io.github.bluetape4k.graph:bluetape4k-graph-bom:0.5.0` before release.
+
+## Future Guidance
+
+Before publishing a graph stable release, make the target changelog section
+dated and refresh WIP from live GitHub issue and PR state. README edits are not
+required when the current module list and usage snippets already describe the
+release content.


### PR DESCRIPTION
## Summary
- date the 0.5.0 changelog section and document the projects 1.10.0 BOM alignment
- refresh WIP from live GitHub issue/PR state for the 0.5.0 release gate
- add a release-prep lesson with CI, Examples, and Maven Central pre-release evidence

## Verification
- git diff --check
- ./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache --console=plain
- ./gradlew check --no-daemon --console=plain

## Release Gate
- Milestone 0.5.0 has 0 open issues and 35 closed issues
- Open PRs: none before this release-prep PR
- Maven Central pre-release check: graph 0.5.0 BOM returns 404 as expected before publication