### PR TITLE
chore: open graph 0.6.0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Opened the `0.6.0` development line after the `0.5.0` stable release.
+- Aligned the local `bluetape4k-bom` reference to `1.11.0-SNAPSHOT`.
+
 ## [0.5.0] - 2026-06-01
 
 ### Added

--- a/WIP.md
+++ b/WIP.md
@@ -4,14 +4,11 @@ Snapshot: 2026-06-01 KST
 Scope: open GitHub issues assigned to `debop`.
 Open count: 4 issues.
 
-## Current Release Gate
+## Current Direction
 
-Prepare and publish `0.5.0`.
-
-The `0.5.0` milestone has zero open issues and no open pull requests. The
-release line consumes `io.github.bluetape4k:bluetape4k-bom:1.10.0`, keeps
-`snapshotVersion=` empty, and has recent `develop` CI plus Examples workflow
-success on commit `8e4abdd`.
+The `0.5.0` stable line has been published and consumed by
+`bluetape4k-dependencies` `1.2.0`. Development now moves to `0.6.0` with
+`snapshotVersion=` kept empty for workflow-injected snapshot publication.
 
 ## Active Queue
 
@@ -40,13 +37,12 @@ success on commit `8e4abdd`.
   succeeded on commit `8e4abdd`.
 - Examples: `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305942`
   succeeded on commit `8e4abdd`.
-- Maven Central pre-release check:
-  `io.github.bluetape4k.graph:bluetape4k-graph-bom:0.5.0` is not yet
-  published, as expected before the stable release dispatch.
+- Maven Central release check:
+  `io.github.bluetape4k.graph:bluetape4k-graph-bom:0.5.0` is published and
+  managed by `bluetape4k-dependencies` `1.2.0`.
 
 ## Release Notes
 
-- Keep `0.5.0` focused on graph-ktor managed backend setup plus runnable domain
-  graph examples.
-- Move any new streaming, backend-native bulk loader, or Neptune work to `0.6.0`
-  or backlog unless it is release fallout.
+- Use `0.6.0` for graph-io streaming and backend-native bulk loader work.
+- Keep Neptune work in backlog until local or reliable integration testability
+  is proven.

--- a/docs/lessons/2026-06-01-open-0-6-0-development.md
+++ b/docs/lessons/2026-06-01-open-0-6-0-development.md
@@ -1,0 +1,23 @@
+# 2026-06-01 Open 0.6.0 Development
+
+## Context
+
+`bluetape4k-graph` `0.5.0` was published and included in
+`bluetape4k-dependencies` `1.2.0`.
+
+## Decision
+
+Move the committed `baseVersion` to `0.6.0` while keeping `snapshotVersion=`
+empty so release workflows can inject snapshot qualifiers explicitly.
+Align the direct `bluetape4k-bom` catalog reference to
+`1.11.0-SNAPSHOT`.
+
+## Outcome
+
+The repository is ready for the next minor development line.
+
+## Verification
+
+- `gradle.properties` uses `baseVersion=0.6.0`.
+- `snapshotVersion=` remains empty.
+- `./gradlew help --no-daemon --console=plain` resolves the updated catalog.

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ kotlinx.atomicfu.jvm.languageLevel=21
 # project version
 #
 projectGroup=io.github.bluetape4k.graph
-baseVersion=0.5.0
+baseVersion=0.6.0
 snapshotVersion=
 
 # Shared bluetape4k ecosystem catalog version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.10.0"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.11.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary
- Open the next graph development line with baseVersion 0.6.0.
- Align the direct bluetape4k-bom reference to 1.11.0-SNAPSHOT.
- Add release-train notes in CHANGELOG, WIP, and docs/lessons.

## Verification
- ./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache --no-build-cache --console=plain
- git diff --check

## Release train
Requires bluetape4k-bom 1.11.0-SNAPSHOT, now published from bluetape4k-projects.