### PR TITLE
build: consume catalog 2026-06-02-00

### DIFF
--- a/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
+++ b/docs/lessons/2026-06-02-catalog-2026-06-02-00-sync.md
@@ -1,0 +1,26 @@
+# Catalog 2026-06-02-00 Sync
+
+## Context
+
+`bluetape4k-dependencies` cut `catalog/2026-06-02-00` after the issue #101
+security dependency train.
+
+## Decision
+
+Use `catalog/2026-06-02-00` as the default `bt4k` catalog ref and sync shared
+version aliases from the central catalog.
+
+## Outcome
+
+Local shared-version drift was removed without adding repo-local dependency
+pins.
+
+## Verification
+
+- `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
+- `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`
+
+## Future Guidance
+
+Consume new central catalog refs through `settings.gradle.kts` and keep synced
+aliases aligned with `bluetape4k-dependencies`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,11 +22,11 @@ okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio-fak
 okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom
 
 jackson-annotations = "2.21"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
-jackson = "2.21.3"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
-jackson3 = "3.1.3"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
+jackson = "2.21.4"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+jackson3 = "3.1.4"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 
 feign = "13.12"  # https://mvnrepository.com/artifact/io.github.openfeign/feign-bom
-netty = "4.2.13.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
+netty = "4.2.15.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
 
 slf4j = "2.0.18"  # https://mvnrepository.com/artifact/org.slf4j/slf4j-api
 logback = "1.5.32"  # https://mvnrepository.com/artifact/ch.qos.logback/logback-classic

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-05-26-01")
+    .orElse("catalog/2026-06-02-00")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary

Consume the `catalog/2026-06-02-00` dependency catalog cut from `bluetape4k-dependencies` after issue #101.

- Updates synced shared version aliases from the central catalog.
- Updates the default `bt4k` catalog ref where this repository imports the catalog by tag.
- Adds a short lesson so future catalog trains keep the ref bump and alias sync together.

## Verification

- `git diff --check`
- `scripts/sync-shared-versions.py --workspace /Users/debop/work/bluetape4k --check --summary`
- `scripts/sync-dependabot-ignores.py --workspace /Users/debop/work/bluetape4k --check --summary`

## Notes

Full repository CI is expected to validate Gradle resolution after the PR opens.