### PR TITLE
fix: refresh Nightly snapshot metadata

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -52,12 +52,12 @@ jobs:
           gradle-version: wrapper
 
       - name: Build (compile only)
-        run: ./gradlew build -x test --parallel
+        run: ./gradlew --refresh-dependencies build -x test --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Detekt static analysis
-        run: ./gradlew detekt --parallel
+        run: ./gradlew --refresh-dependencies detekt --parallel
 
       - name: Upload detekt report
         if: always()
@@ -89,7 +89,7 @@ jobs:
       - name: Test graph-core & graph-tinkerpop & graph-io
         run: |
           for attempt in 1 2 3; do
-            ./gradlew \
+            ./gradlew --refresh-dependencies \
               :bluetape4k-graph-core:test \
               :bluetape4k-graph-tinkerpop:test \
               :bluetape4k-graph-io-core:test \
@@ -108,7 +108,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --refresh-dependencies \
             :bluetape4k-graph-core:koverXmlReport \
             :bluetape4k-graph-tinkerpop:koverXmlReport \
             :bluetape4k-graph-okio:koverXmlReport \
@@ -153,7 +153,7 @@ jobs:
       - name: Test Spring Boot
         run: |
           for attempt in 1 2 3; do
-            ./gradlew \
+            ./gradlew --refresh-dependencies \
               :bluetape4k-graph-spring-boot:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
@@ -175,7 +175,7 @@ jobs:
         if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
         run: |
           for attempt in 1 2 3; do
-            ./gradlew \
+            ./gradlew --refresh-dependencies \
               :bluetape4k-graph-spring-boot:test \
               --tests "*.FalkorDBSpringBootIntegrationTest" \
               --rerun-tasks \
@@ -198,7 +198,7 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
+          ./gradlew --refresh-dependencies \
             :bluetape4k-graph-spring-boot:koverXmlReport \
             --no-daemon
         continue-on-error: true
@@ -250,7 +250,7 @@ jobs:
       - name: Test graph-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-graph-ktor:test --no-daemon --continue && break
+            ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:test --no-daemon --continue && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -267,7 +267,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-ktor:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -317,7 +317,7 @@ jobs:
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-graph-neo4j:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -334,7 +334,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -384,7 +384,7 @@ jobs:
       - name: Test graph-memgraph
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-graph-memgraph:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -401,7 +401,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-memgraph:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -451,7 +451,7 @@ jobs:
       - name: Test graph-age
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-graph-age:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-graph-age:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -468,7 +468,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-age:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-graph-age:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -518,7 +518,7 @@ jobs:
       - name: Test graph-falkordb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-graph-falkordb:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -535,7 +535,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-falkordb:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:koverXmlReport --no-daemon
         continue-on-error: true
 
       - name: Upload test results

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,8 +2,8 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '0 19 * * 1-6'  # Daily smoke, UTC 19:00 (KST 04:00) Mon-Sat
-    - cron: '0 19 * * 0'    # Weekly full, UTC 19:00 (KST 04:00) Sunday
+    - cron: '7 19 * * 1-6'  # Daily smoke, UTC 19:07 (KST 04:07) Mon-Sat
+    - cron: '7 19 * * 0'    # Weekly full, UTC 19:07 (KST 04:07) Sunday
   workflow_dispatch:
     inputs:
       scope:

--- a/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
+++ b/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
@@ -1,0 +1,22 @@
+# Nightly Snapshot Refresh
+
+## Context
+
+Nightly restores Gradle caches and consumes mutable bluetape4k Central snapshot artifacts.
+Stale snapshot metadata can make module jobs fail before tests execute.
+
+## Decision
+
+Pass `--refresh-dependencies` to Nightly Gradle invocations so snapshot metadata
+is rechecked on every scheduled or manually dispatched run.
+
+## Outcome
+
+Nightly keeps cache reuse for build state while avoiding stale Maven snapshot
+metadata during dependency resolution.
+
+## Verification
+
+- `actionlint .github/workflows/nightly-tests.yml`
+- `git diff --check`
+

--- a/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
+++ b/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
@@ -3,20 +3,21 @@
 ## Context
 
 Nightly restores Gradle caches and consumes mutable bluetape4k Central snapshot artifacts.
-Stale snapshot metadata can make module jobs fail before tests execute.
+Stale snapshot metadata or simultaneous Central snapshot metadata requests can
+make module jobs fail before tests execute.
 
 ## Decision
 
-Pass `--refresh-dependencies` to Nightly Gradle invocations so snapshot metadata
-is rechecked on every scheduled or manually dispatched run.
+Pass `--refresh-dependencies` to Nightly Gradle invocations and stagger the
+scheduled cron minute so snapshot metadata is rechecked without starting every
+downstream repository at the same time.
 
 ## Outcome
 
-Nightly keeps cache reuse for build state while avoiding stale Maven snapshot
-metadata during dependency resolution.
+Nightly keeps cache reuse for build state, refreshes mutable metadata, and
+reduces scheduled cross-repository Central snapshot contention.
 
 ## Verification
 
 - `actionlint .github/workflows/nightly-tests.yml`
 - `git diff --check`
-


### PR DESCRIPTION
## Summary

This PR hardens the Nightly workflow against recurring failures while resolving mutable bluetape4k Central snapshot dependencies.

## Background

Several downstream Nightly workflows failed while resolving io.github.bluetape4k:*:1.11.0-SNAPSHOT metadata from Central snapshots. The failures appeared before repository tests ran, so the mitigation belongs in the workflow dependency-resolution path rather than in module test code.

A manual same-time fan-out also reproduced Central snapshot 403 behavior, which showed that stale Gradle metadata was not the only risk. Scheduled downstream Nightly jobs should not all refresh mutable snapshot metadata at the same minute.

## Work Done

- Added --refresh-dependencies to Nightly Gradle invocations so restored Gradle caches cannot keep stale snapshot metadata.
- Staggered this repository schedule to minute 7 in the 19:00 UTC Nightly window.
- Added a repo-local lesson documenting the recurrence rule for future workflow changes.

## Validation

- actionlint .github/workflows/nightly-tests.yml: PASS
- git diff --check: PASS
- Gradle invocation audit: PASS, zero ./gradlew calls missing --refresh-dependencies in the Nightly workflow
- PR CI: PASS / CLEAN

## Follow-up Evidence

- The simultaneous manual full Nightly fan-out reproduced Central snapshot 403 in bluetape4k-graph, so the final merged fix includes both dependency refresh and schedule staggering.
- experimental was explicitly excluded from this sweep.

Closes #282

## Metadata

- PR: #283
- Merge commit: f09e72e9d44c94fb5d461abdcbc12ee5c98de9cd
- URL: https://github.com/bluetape4k/bluetape4k-graph/pull/283
- Assignee: debop

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Root-cause check | PASS | Snapshot metadata failures identified in prior Nightly logs |
| Workflow fix | PASS | Nightly Gradle calls refresh dependencies |
| Recurrence guard | PASS | Scheduled minute staggered across downstream repos |
| Static validation | PASS | actionlint and git diff --check passed |
| CI gate | PASS | PR status checks were CLEAN before merge |
| Merge/local sync | PASS | Merged to develop and local develop fast-forwarded |

Final status: merged