### PR TITLE
fix: align Nightly full schedule condition

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -164,7 +164,7 @@ jobs:
           SPRING_PROFILES_ACTIVE: tinkergraph
 
       - name: Restore Testcontainers image cache
-        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
         uses: ./.github/actions/testcontainers-image-cache
         with:
           mode: restore
@@ -172,7 +172,7 @@ jobs:
           restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
 
       - name: Test Spring Boot FalkorDB auto-configuration
-        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
         run: |
           for attempt in 1 2 3; do
             ./gradlew --refresh-dependencies \
@@ -190,7 +190,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
 
       - name: Save Testcontainers image cache
-        if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
+        if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
         uses: ./.github/actions/testcontainers-image-cache
         with:
           mode: save
@@ -222,7 +222,7 @@ jobs:
   # ── 4. Ktor Graph (Testcontainers) ───────────────────────────────────────
   test-graph-ktor:
     name: Test / Ktor Graph (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -289,7 +289,7 @@ jobs:
   # ── 5. Neo4j (Testcontainers) ─────────────────────────────────────────────
   test-graph-neo4j:
     name: Test / Neo4j (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -356,7 +356,7 @@ jobs:
   # ── 6. Memgraph (Testcontainers) ──────────────────────────────────────────
   test-graph-memgraph:
     name: Test / Memgraph (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -423,7 +423,7 @@ jobs:
   # ── 7. Apache AGE (Testcontainers) ────────────────────────────────────────
   test-graph-age:
     name: Test / Apache AGE (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -490,7 +490,7 @@ jobs:
   # ── 8. FalkorDB (Testcontainers) ──────────────────────────────────────────
   test-graph-falkordb:
     name: Test / FalkorDB (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -568,7 +568,7 @@ jobs:
       - test-graph-memgraph
       - test-graph-age
       - test-graph-falkordb
-    if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
+    if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/lessons/2026-06-04-nightly-full-schedule-condition.md
+++ b/docs/lessons/2026-06-04-nightly-full-schedule-condition.md
@@ -1,0 +1,25 @@
+# Lessons Learned — Nightly full schedule condition (2026-06-04)
+
+**Related issue**: #284
+
+## Context
+
+The Nightly cron minute was staggered to reduce Central snapshot metadata
+contention. Full-scope scheduled jobs still compared `github.event.schedule`
+against the old Sunday cron string, so weekly full jobs could be skipped.
+
+## Decision
+
+Keep the staggered cron, and update full-scope job conditions to compare against
+the repository's current Sunday schedule.
+
+## Verification
+
+- `actionlint .github/workflows/nightly-tests.yml`
+- `git diff --check`
+- Schedule-condition audit: no old `0 19 * * 0` full-job condition remains.
+
+## Future Rule
+
+When changing a scheduled cron string, update every `github.event.schedule`
+comparison in the same workflow.


### PR DESCRIPTION
## Summary

Align the weekly full Nightly job conditions with the staggered Sunday cron minute.

## Background

The Nightly schedule was moved away from the shared 19:00 UTC minute to reduce Central snapshot metadata contention. Full-scope jobs still compared `github.event.schedule` with the old `0 19 * * 0` cron string, so scheduled Sunday full jobs could be skipped.

## Work Done

- Updated full-scope `github.event.schedule` comparisons to the repository current Sunday cron.
- Added a repo-local lesson for cron string and condition parity.

## Validation

- actionlint .github/workflows/nightly-tests.yml: PASS
- git diff --check: PASS
- old schedule-condition audit: PASS, zero `0 19 * * 0` conditions remain
- Gradle invocation audit: PASS, zero ./gradlew calls missing --refresh-dependencies

Closes #284

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Issue | PASS | #284 |
| Fix | PASS | Full job conditions now match the staggered Sunday cron |
| Static validation | PASS | actionlint and git diff --check |
| Recurrence guard | PASS | docs/lessons/2026-06-04-nightly-full-schedule-condition.md |
| CI gate | PENDING | Awaiting PR checks |

Final status: ready for CI.