### PR TITLE
build: prevent stale Nightly Gradle cache

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
 
       - name: Build (compile only)
         run: ./gradlew --refresh-dependencies build -x test --parallel
@@ -84,6 +85,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test graph-core & graph-tinkerpop & graph-io
@@ -148,6 +150,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Test Spring Boot
@@ -238,6 +241,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -305,6 +309,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -372,6 +377,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -439,6 +445,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -506,6 +513,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -580,6 +588,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
 
       - uses: actions/setup-python@v6

--- a/docs/lessons/2026-06-04-issue-286-nightly-gradle-cache.md
+++ b/docs/lessons/2026-06-04-issue-286-nightly-gradle-cache.md
@@ -1,0 +1,22 @@
+# 2026-06-04 Issue 286 Nightly Gradle Cache
+
+## Context
+
+Nightly builds across bluetape4k repositories intermittently resolved managed dependencies as `group:artifact:.` on GitHub runners.
+
+## Decision
+
+Disable `gradle/actions/setup-gradle` cache restore/write for Nightly jobs so scheduled runs do not reuse stale dependency-management state.
+
+## Outcome
+
+Every Nightly `setup-gradle` block now sets `cache-disabled: true` while keeping explicit Gradle dependency refresh.
+
+## Verification
+
+- Audited `.github/workflows/nightly-tests.yml`: setup-gradle blocks match cache-disabled blocks.
+- Planned validation: `actionlint`, `git diff --check`.
+
+## Future Rule
+
+When a Nightly workflow uses snapshot or BOM-managed bluetape4k dependencies, keep Gradle action cache disabled unless a fresh CI proof shows cache restore cannot replay stale metadata.


### PR DESCRIPTION
## Summary
- Closes #286.
- Disable Gradle action caching for every Nightly setup-gradle step.
- Add a short lesson documenting the stale dependency metadata failure mode.

## Background
Recent bluetape4k Nightly runs resolved managed dependencies as group:artifact:. even with --refresh-dependencies. The common risk is stale Gradle action state being restored into scheduled snapshot/BOM builds.

## Work Done
- Added cache-disabled: true to all gradle/actions/setup-gradle@v6 blocks in .github/workflows/nightly-tests.yml.
- Preserved existing --refresh-dependencies and --no-configuration-cache Gradle command behavior.
- Added docs/lessons/2026-06-04-issue-286-nightly-gradle-cache.md.

## Validation
- actionlint .github/workflows/nightly-tests.yml
- git diff --check
- Audited Nightly setup-gradle blocks: every block has cache-disabled: true.

## DoD
- Nightly no longer restores or writes Gradle action cache state.
- The recurrence rule is documented for future workflow edits.