### PR TITLE
fix: retry Central snapshot metadata gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-graph-neo4j:test --no-daemon && break
+            ./gradlew :bluetape4k-graph-neo4j:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -433,7 +433,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,12 +143,22 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Build (compile only)
-        run: ./gradlew build -x test --parallel
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew build -x test --parallel && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Detekt static analysis
-        run: ./gradlew detekt --parallel
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew detekt --parallel && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -53,12 +53,22 @@ jobs:
           cache-disabled: true
 
       - name: Build (compile only)
-        run: ./gradlew --refresh-dependencies build -x test --parallel --no-configuration-cache
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew --refresh-dependencies build -x test --parallel --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Detekt static analysis
-        run: ./gradlew --refresh-dependencies detekt --parallel --no-configuration-cache
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew --refresh-dependencies detekt --parallel --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
 
       - name: Upload detekt report
         if: always()

--- a/docs/lessons/2026-06-04-issue-290-central-snapshot-retry.md
+++ b/docs/lessons/2026-06-04-issue-290-central-snapshot-retry.md
@@ -1,0 +1,18 @@
+# Issue #290 Central snapshot retry
+
+## Context
+Downstream CI and Nightly runs can fail when GitHub runners receive transient
+HTTP 403 responses from Central Portal snapshot metadata.
+
+## Decision
+Wrap the top-level Gradle build and Nightly detekt gates in bounded three-attempt
+retry loops without changing the Gradle command semantics.
+
+## Verification
+- `git diff --check`
+- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
+
+## Next Time
+If a bluetape4k SNAPSHOT dependency fails with Central metadata 403, check
+upstream publish status first, then prefer a bounded workflow retry over
+dependency or catalog churn.

--- a/docs/lessons/2026-06-04-issue-290-central-snapshot-retry.md
+++ b/docs/lessons/2026-06-04-issue-290-central-snapshot-retry.md
@@ -6,7 +6,9 @@ HTTP 403 responses from Central Portal snapshot metadata.
 
 ## Decision
 Wrap the top-level Gradle build and Nightly detekt gates in bounded three-attempt
-retry loops without changing the Gradle command semantics.
+retry loops without changing the Gradle command semantics. Also disable
+configuration cache for the Neo4j CI test/coverage job after it reproduced the
+same Central metadata 403 path.
 
 ## Verification
 - `git diff --check`


### PR DESCRIPTION
## Summary
- Wrap the top-level CI Gradle build gate in a bounded three-attempt retry loop.
- Wrap the Nightly build/detekt gates in the same bounded retry loop where present.
- Add a lesson entry for Central snapshot metadata 403 handling.

## Root Cause
GitHub runner builds can intermittently receive HTTP 403 while resolving bluetape4k SNAPSHOT metadata from Central Portal snapshots. The same commit can pass after upstream publish stabilization or rerun, so the workflow gate needs bounded retry protection instead of dependency churn.

## Verification
- git diff --check
- actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml

## Issue
Fixes #290

## DoD Status
| Item | Status | Evidence |
| --- | --- | --- |
| Workflow lint | PASS | actionlint for CI and Nightly workflows |
| Patch check | PASS | git diff --check |
| CI gate | PASS | GitHub checks completed SUCCESS or SKIPPED before merge |

