### PR TITLE
fix: retry graph coverage snapshot gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,16 +215,20 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
-            :bluetape4k-graph-core:koverXmlReport \
-            :bluetape4k-graph-tinkerpop:koverXmlReport \
-            :bluetape4k-graph-io-core:koverXmlReport \
-            :bluetape4k-graph-io-csv:koverXmlReport \
-            :bluetape4k-graph-io-jackson2:koverXmlReport \
-            :bluetape4k-graph-io-jackson3:koverXmlReport \
-            :bluetape4k-graph-io-graphml:koverXmlReport \
-            :bluetape4k-graph-okio:koverXmlReport \
-            --no-daemon --continue
+          for attempt in 1 2 3 4 5; do
+            ./gradlew \
+              :bluetape4k-graph-core:koverXmlReport \
+              :bluetape4k-graph-tinkerpop:koverXmlReport \
+              :bluetape4k-graph-io-core:koverXmlReport \
+              :bluetape4k-graph-io-csv:koverXmlReport \
+              :bluetape4k-graph-io-jackson2:koverXmlReport \
+              :bluetape4k-graph-io-jackson3:koverXmlReport \
+              :bluetape4k-graph-io-graphml:koverXmlReport \
+              :bluetape4k-graph-okio:koverXmlReport \
+              --no-daemon --continue --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -287,9 +291,13 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew \
-            :bluetape4k-graph-spring-boot:koverXmlReport \
-            --no-daemon
+          for attempt in 1 2 3 4 5; do
+            ./gradlew \
+              :bluetape4k-graph-spring-boot:koverXmlReport \
+              --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -363,7 +371,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-ktor:koverXmlReport --no-daemon
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew :bluetape4k-graph-ktor:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -434,10 +447,10 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         continue-on-error: true
 
@@ -508,7 +521,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-memgraph:koverXmlReport --no-daemon
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -578,7 +596,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-age:koverXmlReport --no-daemon
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew :bluetape4k-graph-age:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -648,7 +671,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-graph-falkordb:koverXmlReport --no-daemon
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew :bluetape4k-graph-falkordb:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -120,11 +120,15 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew --refresh-dependencies --no-configuration-cache \
-            :bluetape4k-graph-core:koverXmlReport \
-            :bluetape4k-graph-tinkerpop:koverXmlReport \
-            :bluetape4k-graph-okio:koverXmlReport \
-            --no-daemon
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies --no-configuration-cache \
+              :bluetape4k-graph-core:koverXmlReport \
+              :bluetape4k-graph-tinkerpop:koverXmlReport \
+              :bluetape4k-graph-okio:koverXmlReport \
+              --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -211,9 +215,13 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: |
-          ./gradlew --refresh-dependencies --no-configuration-cache \
-            :bluetape4k-graph-spring-boot:koverXmlReport \
-            --no-daemon
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies --no-configuration-cache \
+              :bluetape4k-graph-spring-boot:koverXmlReport \
+              --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -281,7 +289,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:koverXmlReport --no-daemon --no-configuration-cache
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -349,7 +362,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -417,7 +435,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -485,7 +508,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-graph-age:koverXmlReport --no-daemon --no-configuration-cache
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies :bluetape4k-graph-age:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results
@@ -553,7 +581,12 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:koverXmlReport --no-daemon --no-configuration-cache
+        run: |
+          for attempt in 1 2 3 4 5; do
+            ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:koverXmlReport --no-daemon --no-configuration-cache && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
+          done
         continue-on-error: true
 
       - name: Upload test results

--- a/docs/lessons/2026-06-04-issue-292-graph-coverage-retry.md
+++ b/docs/lessons/2026-06-04-issue-292-graph-coverage-retry.md
@@ -1,0 +1,21 @@
+## Context
+Graph post-merge CI failed after tests passed because a Kover report step hit a
+Central Portal snapshot metadata HTTP 403 for `bluetape4k-junit5`.
+
+## Decision
+Apply bounded retry and `--no-configuration-cache` to CI coverage report gates,
+matching the successful Neo4j follow-up pattern.
+
+## Outcome
+Coverage generation now tolerates short Central metadata outages and avoids
+configuration-cache serialization failures when snapshot classpaths are
+unresolved.
+
+## Verification
+- `git diff --check`
+- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
+
+## Future Guidance
+If tests pass but coverage fails while resolving bluetape4k snapshots, treat the
+coverage Gradle invocation as a snapshot-dependent gate and give it the same
+retry/no-configuration-cache hardening as test gates.


### PR DESCRIPTION
## Summary

- Add bounded retry/no-configuration-cache to graph CI coverage report gates.
- Extend Nightly coverage report gates with the same bounded retry behavior.
- Preserve test semantics while hardening snapshot-dependent Kover classpath resolution.

## Context

Closes #292.

Post-merge CI for #291 passed tests but failed during Core/TinkerGraph Kover generation because Central Portal returned HTTP 403 for `bluetape4k-junit5` snapshot metadata. Coverage gates resolve the same snapshot classpaths and need the same resilience policy as test gates.

## Validation

| Check | Status | Evidence |
| --- | --- | --- |
| `git diff --check` | PASS | Local validation |
| `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml` | PASS | Local validation |
| CI gate | PASS | GitHub checks completed SUCCESS or SKIPPED before merge |

## DoD Status

- [x] Workflow-only resilience change
- [x] Lesson recorded
- [x] PR body populated and verifiable
- [x] GitHub checks completed

