### PR TITLE
fix: harden Nightly snapshot retry backoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,20 +144,20 @@ jobs:
 
       - name: Build (compile only)
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew build -x test --parallel && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Detekt static analysis
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew detekt --parallel && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -195,7 +195,7 @@ jobs:
 
       - name: Test graph-core & graph-tinkerpop & graph-io
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew \
               :bluetape4k-graph-core:test \
               :bluetape4k-graph-tinkerpop:test \
@@ -207,7 +207,7 @@ jobs:
               :bluetape4k-graph-okio:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -277,12 +277,12 @@ jobs:
 
       - name: Test Spring Boot
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew \
               :bluetape4k-graph-spring-boot:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -353,10 +353,10 @@ jobs:
 
       - name: Test graph-ktor
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew :bluetape4k-graph-ktor:test --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -428,10 +428,10 @@ jobs:
 
       - name: Test graph-neo4j
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew :bluetape4k-graph-neo4j:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -503,10 +503,10 @@ jobs:
 
       - name: Test graph-memgraph
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew :bluetape4k-graph-memgraph:test --no-daemon && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -578,10 +578,10 @@ jobs:
 
       - name: Test graph-age
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew :bluetape4k-graph-age:test --no-daemon && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -653,10 +653,10 @@ jobs:
 
       - name: Test graph-falkordb
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew :bluetape4k-graph-falkordb:test --no-daemon && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and test example modules
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew \
               :code-graph-examples:build \
               :linkedin-graph-examples:build \
@@ -99,7 +99,7 @@ jobs:
               :security-attack-path-examples:build \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -54,20 +54,20 @@ jobs:
 
       - name: Build (compile only)
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies build -x test --parallel --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
       - name: Detekt static analysis
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies detekt --parallel --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
 
       - name: Upload detekt report
@@ -100,7 +100,7 @@ jobs:
 
       - name: Test graph-core & graph-tinkerpop & graph-io
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies --no-configuration-cache \
               :bluetape4k-graph-core:test \
               :bluetape4k-graph-tinkerpop:test \
@@ -112,7 +112,7 @@ jobs:
               :bluetape4k-graph-okio:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -169,12 +169,12 @@ jobs:
 
       - name: Test Spring Boot
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies --no-configuration-cache \
               :bluetape4k-graph-spring-boot:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
@@ -191,14 +191,14 @@ jobs:
       - name: Test Spring Boot FalkorDB auto-configuration
         if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies --no-configuration-cache \
               :bluetape4k-graph-spring-boot:test \
               --tests "*.FalkorDBSpringBootIntegrationTest" \
               --rerun-tasks \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -271,10 +271,10 @@ jobs:
 
       - name: Test graph-ktor
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:test --no-daemon --continue --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -344,10 +344,10 @@ jobs:
 
       - name: Test graph-neo4j
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -417,10 +417,10 @@ jobs:
 
       - name: Test graph-memgraph
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -490,10 +490,10 @@ jobs:
 
       - name: Test graph-age
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies :bluetape4k-graph-age:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
@@ -563,10 +563,10 @@ jobs:
 
       - name: Test graph-falkordb
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
-            [ $attempt -lt 3 ] && sleep 10 || exit 1
+            [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"

--- a/docs/lessons/2026-06-04-nightly-snapshot-retry-backoff.md
+++ b/docs/lessons/2026-06-04-nightly-snapshot-retry-backoff.md
@@ -1,0 +1,20 @@
+## Context
+
+Nightly and CI matrix jobs failed intermittently while resolving upstream `1.11.0-SNAPSHOT` artifacts from Central snapshots. The local Central metadata checks returned HTTP 200, while GitHub-hosted runners intermittently received HTTP 403.
+
+## Decision
+
+Use the same retry posture across CI, Nightly, and example workflow Gradle steps: five attempts with a 30 second wait between attempts.
+
+## Outcome
+
+The workflow now gives transient Central snapshot metadata failures more time to recover before marking module tests failed.
+
+## Verification
+
+- `git diff --check`
+- `actionlint .github/workflows/*.yml`
+
+## Future Guidance
+
+When a downstream bluetape4k repo consumes unreleased upstream snapshots, stabilize upstream first, then rerun downstream Nightly after the upstream CI and Nightly gates are green.


### PR DESCRIPTION
## Summary

- Increase Gradle retry loops from 3 attempts / 10 seconds to 5 attempts / 30 seconds in CI, Nightly, and examples workflows.
- Add a lesson entry documenting the upstream-first Nightly stabilization order.
- Keep the change limited to workflow resilience for transient Central snapshot metadata HTTP 403 failures.

## Context

Closes #294.

The downstream Nightly runs were dispatched only after bluetape4k-projects and bluetape4k-exposed were green. The downstream failures still resolved to Central snapshot metadata HTTP 403 errors on GitHub-hosted runners, while local Central metadata checks returned HTTP 200.

## Verification

- git diff --check
- actionlint .github/workflows/*.yml
- PR checks: passed after failed-only rerun

## DoD Status

- [x] Retry backoff is consistent across touched CI/Nightly/example Gradle steps.
- [x] Workflow syntax is validated locally.
- [x] PR body was created from a body file and verified after creation.
- [x] Required PR checks are passing or were rerun successfully after Central 403.
