### PR TITLE
ci: reduce snapshot metadata refreshes

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -50,12 +50,11 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
 
       - name: Build (compile only)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies build -x test --parallel --no-configuration-cache && break
+            ./gradlew build -x test --parallel --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -65,7 +64,7 @@ jobs:
       - name: Detekt static analysis
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies detekt --parallel --no-configuration-cache && break
+            ./gradlew detekt --parallel --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -95,13 +94,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Test graph-core & graph-tinkerpop & graph-io
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies --no-configuration-cache \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-graph-core:test \
               :bluetape4k-graph-tinkerpop:test \
               :bluetape4k-graph-io-core:test \
@@ -121,7 +119,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies --no-configuration-cache \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-graph-core:koverXmlReport \
               :bluetape4k-graph-tinkerpop:koverXmlReport \
               :bluetape4k-graph-okio:koverXmlReport \
@@ -164,13 +162,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Test Spring Boot
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies --no-configuration-cache \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-graph-spring-boot:test \
               --no-daemon --continue && break
             echo "Attempt $attempt failed"
@@ -192,7 +189,7 @@ jobs:
         if: ${{ (github.event_name == 'schedule' && github.event.schedule == '7 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies --no-configuration-cache \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-graph-spring-boot:test \
               --tests "*.FalkorDBSpringBootIntegrationTest" \
               --rerun-tasks \
@@ -216,7 +213,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies --no-configuration-cache \
+            ./gradlew --no-configuration-cache \
               :bluetape4k-graph-spring-boot:koverXmlReport \
               --no-daemon && break
             echo "Attempt $attempt failed"
@@ -259,7 +256,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -272,7 +268,7 @@ jobs:
       - name: Test graph-ktor
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:test --no-daemon --continue --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-ktor:test --no-daemon --continue --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -291,7 +287,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-ktor:koverXmlReport --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-ktor:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -332,7 +328,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -345,7 +340,7 @@ jobs:
       - name: Test graph-neo4j
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-neo4j:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -364,7 +359,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -405,7 +400,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -418,7 +412,7 @@ jobs:
       - name: Test graph-memgraph
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-memgraph:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -437,7 +431,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -478,7 +472,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -491,7 +484,7 @@ jobs:
       - name: Test graph-age
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-age:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-age:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -510,7 +503,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-age:koverXmlReport --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-age:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -551,7 +544,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - name: Restore Testcontainers image cache
@@ -564,7 +556,7 @@ jobs:
       - name: Test graph-falkordb
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-falkordb:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -583,7 +575,7 @@ jobs:
         if: always()
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew --refresh-dependencies :bluetape4k-graph-falkordb:koverXmlReport --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-graph-falkordb:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -631,7 +623,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-          cache-disabled: true
           cache-read-only: true
 
       - uses: actions/setup-python@v6

--- a/docs/lessons/2026-06-06-snapshot-cache-actions.md
+++ b/docs/lessons/2026-06-06-snapshot-cache-actions.md
@@ -1,0 +1,29 @@
+# Snapshot Cache Actions
+
+## Context
+
+Nightly already uses a one-day changing-module cache TTL, but the workflow still
+forced dependency refreshes and disabled Gradle dependency caching for jobs.
+
+## Decision
+
+Remove `--refresh-dependencies` and remove Nightly `cache-disabled: true`.
+
+## Outcome
+
+Nightly keeps its existing graph backend task structure, but regular dependency
+resolution can use Gradle cache metadata instead of forcing Central snapshot
+metadata requests on every job.
+
+## Verification
+
+- `actionlint .github/workflows/*.yml`
+- `rg -n -- '--refresh-dependencies|cache-disabled: true' .github/workflows` -> no matches
+- `./gradlew help --no-daemon`
+- `git diff --check`
+
+## Future Guidance
+
+Use explicit dependency refresh only in dedicated post-publish freshness checks.
+Ordinary CI, Nightly, and Examples workflows should rely on cached changing-module
+metadata plus targeted warm-up when a test-only SNAPSHOT dependency needs it.


### PR DESCRIPTION
## Summary

- Reduces ordinary workflow exposure to transient Central snapshots metadata failures.
- Removes forced dependency refresh or disabled Gradle dependency cache settings where present.
- Uses a one-day Gradle changing-module cache TTL where this repo had a zero-second TTL.
- Adds a tracked lesson for future CI, Nightly, and Examples workflow maintenance.

## Validation

- `actionlint .github/workflows/*.yml`
- `rg -n -- '--refresh-dependencies|cache-disabled: true' .github/workflows` -> no matches
- `./gradlew help --no-daemon`
- `git diff --check`
- `git diff --cached --check`

## Review Artifacts

- `docs/lessons/2026-06-06-snapshot-cache-actions.md`

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Workflow lint | PASS | `actionlint .github/workflows/*.yml` completed successfully |
| Refresh policy | PASS | No `--refresh-dependencies` or `cache-disabled: true` remains under `.github/workflows` |
| Gradle configuration | PASS | `./gradlew help --no-daemon` completed successfully |
| Diff hygiene | PASS | `git diff --check` and `git diff --cached --check` completed successfully |
| GitHub checks | PENDING | PR CI must complete before merge |
