### PR TITLE
build(dependencies): consume catalog 2026-06-07-00

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -142,13 +142,13 @@ jakarta-xml-bind = { module = "jakarta.xml.bind:jakarta.xml.bind-api" }  # versi
 
 # Apache Commons
 commons-beanutils = { module = "commons-beanutils:commons-beanutils", version = "1.11.0" }  # https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils
-commons-compress = { module = "org.apache.commons:commons-compress", version = "1.27.1" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-compress
+commons-compress = { module = "org.apache.commons:commons-compress", version = "1.28.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-compress
 commons-codec = { module = "commons-codec:commons-codec" }  # version from bt4k catalog
 commons-collections4 = { module = "org.apache.commons:commons-collections4", version = "4.5.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
 commons-csv = { module = "org.apache.commons:commons-csv" }  # version from bt4k catalog
 commons-exec = { module = "org.apache.commons:commons-exec" }  # version from bt4k catalog
 commons-io = { module = "commons-io:commons-io" }  # version from bt4k catalog
-commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.17.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.20.0" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
 commons-logging = { module = "commons-logging:commons-logging" }  # version from bt4k catalog
 commons-math3 = { module = "org.apache.commons:commons-math3", version = "3.6.1" }  # https://mvnrepository.com/artifact/org.apache.commons/commons-math3
 commons-pool2 = { module = "org.apache.commons:commons-pool2" }  # version from bt4k catalog

--- a/graph-io/okio/README.ko.md
+++ b/graph-io/okio/README.ko.md
@@ -332,7 +332,7 @@ dependencies {
     implementation("org.lz4:lz4-java:1.8.0")
     implementation("org.xerial.snappy:snappy-java:1.1.10.7")
     implementation("com.github.luben:zstd-jni:1.5.6-6")
-    implementation("org.apache.commons:commons-compress:1.27.1")
+    implementation("org.apache.commons:commons-compress:1.28.0")
 }
 ```
 

--- a/graph-io/okio/README.md
+++ b/graph-io/okio/README.md
@@ -350,7 +350,7 @@ dependencies {
     implementation("org.lz4:lz4-java:1.8.0")
     implementation("org.xerial.snappy:snappy-java:1.1.10.7")
     implementation("com.github.luben:zstd-jni:1.5.6-6")
-    implementation("org.apache.commons:commons-compress:1.27.1")
+    implementation("org.apache.commons:commons-compress:1.28.0")
 }
 ```
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-02-00")
+    .orElse("catalog/2026-06-07-00")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary

- Move the default bluetape4k-dependencies catalog ref to `catalog/2026-06-07-00`.
- Align graph-local Commons versions with the shared catalog train.
- Update graph-io Okio README snippets so the documented commons-compress version matches the catalog.

## Validation

- `git diff --check`.
- `./gradlew projects --no-configuration-cache`.
- `./gradlew :bluetape4k-graph-okio:dependencyInsight --dependency org.apache.commons:commons-compress --configuration testRuntimeClasspath --no-configuration-cache` selected `1.28.0`.
- `./gradlew :bluetape4k-graph-core:dependencyInsight --dependency org.apache.commons:commons-lang3 --configuration runtimeClasspath --no-configuration-cache` selected `3.20.0`.

## DoD Status

- [x] Catalog default points at `catalog/2026-06-07-00`.
- [x] Commons Compress and Commons Lang3 are aligned with the shared catalog.
- [x] README and README.ko dependency snippets remain in sync.
- [x] Local Gradle project resolution and targeted dependency insight passed.
- [x] Diff hygiene passed.