### PR TITLE
Apply Kotlin 2.4 catalog train

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ allprojects {
 // Capture root-project catalog reference once; used inside subprojects {} closures
 // where `libs` is not in scope (different receiver type in the lambda).
 val rootLibs = libs
+val detektSupportedKotlinVersion = "2.3.21"
 val bt4kCatalog = extensions.getByType<org.gradle.api.artifacts.VersionCatalogsExtension>().named("bt4k")
 fun bt4kVersion(alias: String): String {
     val version = bt4kCatalog.findVersion(alias).get()
@@ -171,6 +172,14 @@ subprojects {
         extensions.configure<dev.detekt.gradle.extensions.DetektExtension>("detekt") {
             baseline.set(detektBaselineFile)
             buildUponDefaultConfig.set(true)
+        }
+        configurations.named("detekt") {
+            resolutionStrategy.eachDependency {
+                if (requested.group == "org.jetbrains.kotlin") {
+                    useVersion(detektSupportedKotlinVersion)
+                    because("detekt 2.0.0-alpha.3 is built and validated with Kotlin 2.3.21")
+                }
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 bluetape4k = "1.11.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
-kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
+kotlin = "2.4.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom
 kotlinx-serialization = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-json
 kotlinx-atomicfu = "0.32.1"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/atomicfu

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-07-00")
+    .orElse("catalog/2026-06-09-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary
- Apply shared dependencies catalog tag `catalog/2026-06-09-01`.
- Move Kotlin catalog entries to `2.4.0` through the synced version catalog.
- Keep downstream builds pinned to an immutable catalog train.

## Notes
- Kotlin language/API levels remain controlled by each repo build configuration; this change advances catalog dependency/plugin versions only.
- detekt 2.0.0-alpha.3 is validated with Kotlin 2.3.21, so graph keeps the detekt runtime Kotlin classpath isolated from the project Kotlin BOM.

## Validation
- ./gradlew --no-daemon build -x test --parallel --no-configuration-cache: BUILD SUCCESSFUL in 28s; :bluetape4k-graph-core:detekt passed after detekt runtime Kotlin guard

## DoD Status
- [x] Catalog ref points to `catalog/2026-06-09-01` where this repo consumes raw catalog refs.
- [x] Kotlin catalog value is `2.4.0`.
- [x] Local build validation completed as listed above.
- [ ] Merge after GitHub checks are green.