### PR TITLE
docs: use published dependency coordinates

### DIFF
--- a/examples/fraud-detection-examples/README.ko.md
+++ b/examples/fraud-detection-examples/README.ko.md
@@ -124,11 +124,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/fraud-detection-examples/README.md
+++ b/examples/fraud-detection-examples/README.md
@@ -127,11 +127,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/knowledge-graph-examples/README.ko.md
+++ b/examples/knowledge-graph-examples/README.ko.md
@@ -122,11 +122,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/knowledge-graph-examples/README.md
+++ b/examples/knowledge-graph-examples/README.md
@@ -125,11 +125,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/observability-graph-examples/README.ko.md
+++ b/examples/observability-graph-examples/README.ko.md
@@ -111,11 +111,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/observability-graph-examples/README.md
+++ b/examples/observability-graph-examples/README.md
@@ -111,11 +111,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/recommendation-examples/README.ko.md
+++ b/examples/recommendation-examples/README.ko.md
@@ -126,11 +126,11 @@ TinkerGraph 테스트는 메모리에서 실행됩니다. Neo4j, Memgraph, Apach
 ## 의존성
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/examples/recommendation-examples/README.md
+++ b/examples/recommendation-examples/README.md
@@ -127,11 +127,11 @@ TinkerGraph tests run in memory. Neo4j, Memgraph, Apache AGE, and FalkorDB tests
 ## Dependencies
 
 ```kotlin
-implementation(project(":bluetape4k-graph-core"))
-implementation(project(":bluetape4k-graph-neo4j"))
-implementation(project(":bluetape4k-graph-memgraph"))
-implementation(project(":bluetape4k-graph-age"))
-implementation(project(":bluetape4k-graph-falkordb"))
-implementation(project(":bluetape4k-graph-tinkerpop"))
-implementation(project(":bluetape4k-graph-io-csv"))
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-memgraph:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-age:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-falkordb:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop:${bluetape4kVersion}")
+implementation("io.github.bluetape4k.graph:bluetape4k-graph-io-csv:${bluetape4kVersion}")
 ```

--- a/graph/graph-age/README.ko.md
+++ b/graph/graph-age/README.ko.md
@@ -73,7 +73,7 @@ Apache AGE (PostgreSQL 그래프 확장)를 기반으로 한 `GraphOperations` �
 ```kotlin
 // build.gradle.kts
 dependencies {
-    api(project(":graph-core"))
+    api("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
     api(Libs.exposed_core)
     api(Libs.exposed_dao)
     api(Libs.exposed_jdbc)
@@ -525,7 +525,7 @@ connectionInitSql = "LOAD 'age'; SET search_path = ag_catalog, \"${'$'}user\", p
 
 ```kotlin
 // 필수
-api(project(":graph-core"))
+api("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
 api(Libs.exposed_core)
 api(Libs.exposed_jdbc)
 api(Libs.postgresql_driver)

--- a/graph/graph-age/README.md
+++ b/graph/graph-age/README.md
@@ -50,7 +50,7 @@
 
 ```kotlin
 dependencies {
-    api(project(":graph-core"))
+    api("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
     api(Libs.exposed_core)
     api(Libs.exposed_jdbc)
     api(Libs.postgresql_driver)

--- a/graph/graph-neo4j/README.ko.md
+++ b/graph/graph-neo4j/README.ko.md
@@ -166,7 +166,7 @@ suspend fun allPaths(
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation(project(":graph-neo4j"))
+    implementation("io.github.bluetape4k.graph:bluetape4k-graph-neo4j:${bluetape4kVersion}")
     implementation(Libs.neo4j_java_driver)
     implementation(Libs.kotlinx_coroutines_reactive)
 }

--- a/graph/graph-tinkerpop/README.ko.md
+++ b/graph/graph-tinkerpop/README.ko.md
@@ -28,7 +28,7 @@ TinkerGraph(in-memory JVM 그래프 DB)를 사용하여 `graph-core` 인터페�
 
 ```kotlin
 dependencies {
-    api(project(":graph-core"))
+    api("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
     api(Libs.tinkerpop_gremlin_core)
     api(Libs.tinkergraph_gremlin)
 }

--- a/graph/graph-tinkerpop/README.md
+++ b/graph/graph-tinkerpop/README.md
@@ -28,7 +28,7 @@ It runs standalone without an external server, making it well suited for testing
 
 ```kotlin
 dependencies {
-    api(project(":graph-core"))
+    api("io.github.bluetape4k.graph:bluetape4k-graph-core:${bluetape4kVersion}")
     api(Libs.tinkerpop_gremlin_core)
     api(Libs.tinkergraph_gremlin)
 }


### PR DESCRIPTION
## Summary

Replace README dependency snippets that used internal Gradle `project(\":...\")` references with user-facing dependency guidance.

## Background

Public README dependency sections should be usable from consumer builds. Internal Gradle project paths only work inside this repository checkout, so they are misleading when shown as installation snippets.

## Work Done

- Updated README dependency examples to use published Maven coordinates where the referenced module is published.
- Removed or clarified repository-only example wiring where no published artifact is intended.
- Kept the change documentation-only.

## Validation

- `rg 'project\(\":' -g 'README*.md' .`: PASS, no matches.
- `git diff --check`: PASS.
- Changed scope: 13 files changed, 62 insertions(+), 62 deletions(-).

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| R - Route | PASS | Type E documentation maintenance; README dependency snippets only. |
| D - Discover | PASS | Found README snippets that assumed repository-local Gradle project paths. |
| C - Apply | PASS | Replaced install snippets with Maven coordinates or clarified repository-internal support code. |
| V - Verify | PASS | Targeted `rg` found no README `project(\":...\")` references; `git diff --check` passed. |
| 6-E - Scope | PASS | Documentation-only; no source, build logic, or generated assets changed. |
