### PR TITLE
build: consume June dependency catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -396,7 +396,7 @@ subprojects {
             dependency("jakarta.xml.bind:jakarta.xml.bind-api:${bt4kVersion("jakarta-xml-bind")}")
 
             // Jackson
-            dependency(rootLibs.jackson.annotations.get().toString())
+            dependency("com.fasterxml.jackson.core:jackson-annotations:${bt4kVersion("jackson-annotations")}")
             dependency(rootLibs.jackson.core.get().toString())
             dependency(rootLibs.jackson3.core.get().toString())
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/ex
 okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio-fakefilesystem
 okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom
 
-jackson-annotations = "2.21"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
 jackson = "2.22.0"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
 jackson3 = "3.2.0"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 
@@ -187,7 +186,7 @@ okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", versio
 
 # Jackson 2
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson-annotations" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }  # version from bt4k catalog
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-module-blackbird = { module = "com.fasterxml.jackson.module:jackson-module-blackbird", version.ref = "jackson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlinx-atomicfu = "0.32.1"  # https://mvnrepository.com/artifact/org.jetbrains.
 kotlinx-benchmark = "0.4.17"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-runtime
 ktor = "3.5.0"  # https://mvnrepository.com/artifact/io.ktor/ktor-bom
 
-spring-boot4 = "4.0.6"  # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
+spring-boot4 = "4.1.0"  # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
 
 neo4j-java-driver = "6.1.0"  # https://mvnrepository.com/artifact/org.neo4j.driver/neo4j-java-driver
 neo4j-bolt-connection = "11.0.2"  # https://mvnrepository.com/artifact/org.neo4j.bolt/neo4j-bolt-connection-bom
@@ -22,8 +22,8 @@ okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio-fak
 okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom
 
 jackson-annotations = "2.21"  # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations
-jackson = "2.21.4"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
-jackson3 = "3.1.4"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
+jackson = "2.22.0"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+jackson3 = "3.2.0"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 
 feign = "13.12"  # https://mvnrepository.com/artifact/io.github.openfeign/feign-bom
 netty = "4.2.15.Final"  # https://mvnrepository.com/artifact/io.netty/netty-bom
@@ -55,9 +55,9 @@ dependency-management = "1.1.7"  # https://mvnrepository.com/artifact/io.spring.
 dokka = "2.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.dokka/dokka-gradle-plugin
 kover = "0.9.8"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kover-gradle-plugin
 test-logger = "4.0.0"  # https://mvnrepository.com/artifact/com.adarshr/gradle-test-logger-plugin
-shadow = "9.4.1"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
-gatling = "3.15.0"  # https://mvnrepository.com/artifact/io.gatling/gatling-app
-nmcp = "1.5.0"  # https://mvnrepository.com/artifact/com.gradleup.nmcp/nmcp
+shadow = "9.4.2"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
+gatling = "3.15.1"  # https://mvnrepository.com/artifact/io.gatling/gatling-app
+nmcp = "1.6.0"  # https://mvnrepository.com/artifact/com.gradleup.nmcp/nmcp
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-09-01")
+    .orElse("catalog/2026-06-25-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-25-03")
+    .orElse("catalog/2026-06-25-04")
     .get()
 val bluetape4kDependenciesCatalogCacheKey = bluetape4kDependenciesCatalogRef.replace(Regex("[^A-Za-z0-9._-]"), "_")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-25-04")
+    .orElse("catalog/2026-06-25-05")
     .get()
 val bluetape4kDependenciesCatalogCacheKey = bluetape4kDependenciesCatalogRef.replace(Regex("[^A-Za-z0-9._-]"), "_")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,8 +14,9 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-25-01")
+    .orElse("catalog/2026-06-25-03")
     .get()
+val bluetape4kDependenciesCatalogCacheKey = bluetape4kDependenciesCatalogRef.replace(Regex("[^A-Za-z0-9._-]"), "_")
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {
     providers.gradleProperty("bluetape4kDependenciesCatalogPath")
@@ -29,7 +30,7 @@ fun resolveBluetape4kDependenciesCatalogFile(): File {
         "bluetape4k-dependencies/gradle/libs.versions.toml",
     ).map(::file).firstOrNull { it.isFile }?.let { return it }
 
-    val catalogFile = file(".gradle/bluetape4k-dependencies/libs.versions.toml")
+    val catalogFile = file(".gradle/bluetape4k-dependencies/$bluetape4kDependenciesCatalogCacheKey/libs.versions.toml")
     if (!catalogFile.isFile) {
         catalogFile.parentFile.mkdirs()
         val catalogUrl =


### PR DESCRIPTION
## Summary
- Pins this repository to `catalog/2026-06-25-05` from `bluetape4k-dependencies`.
- Aligns centrally governed shared dependency versions with the June 25 catalog train.
- Includes local API adaptations where the upgraded dependency set changed or removed APIs.

## DoD Status
- [x] Catalog reference points at immutable `catalog/2026-06-25-05` where this repository supports catalog refs.
- [x] Shared version catalog is aligned with `bluetape4k-dependencies`.
- [x] Deprecated or removed API usages that blocked compile were replaced.
- [x] `git diff --check` passed.
- [x] Compile-level verification was run for this catalog train.
- [ ] Full repository test suite was not run.
