### PR TITLE
build: reduce graph compile warning noise

### DIFF
--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphDbComparisonBenchmark.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphDbComparisonBenchmark.kt
@@ -34,8 +34,6 @@ import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.annotations.Warmup
-import redis.clients.jedis.JedisPool
-import redis.clients.jedis.JedisPoolConfig
 import java.util.concurrent.TimeUnit
 
 /**
@@ -140,14 +138,7 @@ open class GraphDbComparisonState {
                     start()
                 }
                 falkorServer = server
-                falkorDriver = DriverImpl(
-                    JedisPool(
-                        JedisPoolConfig().apply { maxTotal = 4 },
-                        server.host,
-                        server.port,
-                        60_000,
-                    ),
-                )
+                falkorDriver = DriverImpl(server.host, server.port)
                 FalkorDBGraphOperations(falkorDriver!!, GRAPH_NAME)
             }
             else -> error("Unsupported graph benchmark backend: $backend")

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphWriteIngestionBenchmark.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphWriteIngestionBenchmark.kt
@@ -32,8 +32,6 @@ import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.annotations.Warmup
-import redis.clients.jedis.JedisPool
-import redis.clients.jedis.JedisPoolConfig
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
@@ -173,14 +171,7 @@ open class GraphWriteIngestionState {
                     start()
                 }
                 falkorServer = server
-                val driver = DriverImpl(
-                    JedisPool(
-                        JedisPoolConfig().apply { maxTotal = 4 },
-                        server.host,
-                        server.port,
-                        60_000,
-                    ),
-                )
+                val driver = DriverImpl(server.host, server.port)
                 falkorDriver = driver
                 FalkorDBGraphOperations(driver, GRAPH_NAME)
             }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     constraints {
         rootProject.subprojects {
             if (name != "bluetape4k-graph-bom" && !isNonPublishedModule()) {
-                api(this)
+                api(project(mapOf("path" to path)))
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ fun Project.isNonPublishedModule(): Boolean {
 
 val detektBaselineFile = layout.projectDirectory.file("config/detekt/baseline.xml")
 
-val detektProjectBaseline by tasks.registering(DetektCreateBaselineTask::class) {
+val detektProjectBaseline = tasks.register<DetektCreateBaselineTask>("detektProjectBaseline") {
     description = "Regenerates the shared Detekt baseline for existing findings."
     ignoreFailures.set(true)
     parallel.set(true)
@@ -443,44 +443,35 @@ subprojects {
     }
 
     dependencies {
-        val api by configurations
-        val testApi by configurations
-        val implementation by configurations
-        val testImplementation by configurations
+        add("compileOnly", platform(rootLibs.bluetape4k.bom))
+        add("compileOnly", platform(rootLibs.jackson.bom))
+        add("compileOnly", platform(rootLibs.kotlinx.coroutines.bom))
 
-        val compileOnly by configurations
-        val testCompileOnly by configurations
-        val testRuntimeOnly by configurations
+        add("implementation", rootLibs.kotlin.stdlib)
+        add("implementation", rootLibs.kotlin.reflect)
+        add("testImplementation", rootLibs.kotlin.test.api)
+        add("testImplementation", rootLibs.kotlin.test.junit5)
 
-        compileOnly(platform(rootLibs.bluetape4k.bom))
-        compileOnly(platform(rootLibs.jackson.bom))
-        compileOnly(platform(rootLibs.kotlinx.coroutines.bom))
+        add("implementation", rootLibs.kotlinx.coroutines.core.lib)
+        add("implementation", rootLibs.kotlinx.atomicfu)
 
-        implementation(rootLibs.kotlin.stdlib)
-        implementation(rootLibs.kotlin.reflect)
-        testImplementation(rootLibs.kotlin.test.api)
-        testImplementation(rootLibs.kotlin.test.junit5)
-
-        implementation(rootLibs.kotlinx.coroutines.core.lib)
-        implementation(rootLibs.kotlinx.atomicfu)
-
-        implementation(rootLibs.slf4j.api)
-        implementation(rootLibs.bluetape4k.logging)
-        implementation(rootLibs.logback.classic)
-        testImplementation(rootLibs.jcl.over.slf4j)
-        testImplementation(rootLibs.jul.to.slf4j)
-        testImplementation(rootLibs.log4j.over.slf4j)
+        add("implementation", rootLibs.slf4j.api)
+        add("implementation", rootLibs.bluetape4k.logging)
+        add("implementation", rootLibs.logback.classic)
+        add("testImplementation", rootLibs.jcl.over.slf4j)
+        add("testImplementation", rootLibs.jul.to.slf4j)
+        add("testImplementation", rootLibs.log4j.over.slf4j)
 
         // JUnit 5
-        testImplementation(rootLibs.bluetape4k.junit5)
-        testImplementation(rootLibs.junit.jupiter.all)
-        testRuntimeOnly(rootLibs.junit.platform.engine)
+        add("testImplementation", rootLibs.bluetape4k.junit5)
+        add("testImplementation", rootLibs.junit.jupiter.all)
+        add("testRuntimeOnly", rootLibs.junit.platform.engine)
 
-        testImplementation(rootLibs.mockk)
-        testImplementation(rootLibs.awaitility.kotlin)
+        add("testImplementation", rootLibs.mockk)
+        add("testImplementation", rootLibs.awaitility.kotlin)
 
-        testImplementation(rootLibs.datafaker)
-        testImplementation(rootLibs.random.beans)
+        add("testImplementation", rootLibs.datafaker)
+        add("testImplementation", rootLibs.random.beans)
     }
 
     /*
@@ -497,12 +488,12 @@ subprojects {
                 create<MavenPublication>("BluetapeGraph") {
                     val binaryJar = components["java"]
 
-                    val sourcesJar by tasks.registering(Jar::class) {
+                    val sourcesJar = tasks.register<Jar>("sourcesJar") {
                         archiveClassifier.set("sources")
                         from(sourceSets["main"].allSource)
                     }
 
-                    val javadocJar by tasks.registering(Jar::class) {
+                    val javadocJar = tasks.register<Jar>("javadocJar") {
                         archiveClassifier.set("javadoc")
                         val javadocDir = layout.buildDirectory.asFile.get().resolve("javadoc")
                         from(javadocDir.path)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,11 +25,6 @@ fun resolveBluetape4kDependenciesCatalogFile(): File {
         ?.let(::file)
         ?.let { return it }
 
-    listOf(
-        "../bluetape4k-dependencies/gradle/libs.versions.toml",
-        "bluetape4k-dependencies/gradle/libs.versions.toml",
-    ).map(::file).firstOrNull { it.isFile }?.let { return it }
-
     val catalogFile = file(".gradle/bluetape4k-dependencies/$bluetape4kDependenciesCatalogCacheKey/libs.versions.toml")
     if (!catalogFile.isFile) {
         catalogFile.parentFile.mkdirs()
@@ -46,7 +41,7 @@ val bluetape4kDependenciesCatalogFile = resolveBluetape4kDependenciesCatalogFile
 
 require(bluetape4kDependenciesCatalogFile.isFile) {
     "bluetape4k-dependencies catalog not found: $bluetape4kDependenciesCatalogFile. " +
-        "Checkout bluetape4k-dependencies at the release-train tag or set bluetape4kDependenciesCatalogPath."
+        "Verify bluetape4kDependenciesCatalogRef or set bluetape4kDependenciesCatalogPath."
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

This PR reduces warning noise from `compileTestKotlin --warning-mode all --rerun-tasks` so graph repository warnings point to actionable remaining issues.

## Background

The compile pass previously surfaced deprecated direct Jedis pool usage in graph benchmarks and Gradle Kotlin DSL deprecation warnings from repository build scripts. The local workspace also preferred a sibling `bluetape4k-dependencies` checkout whose `develop` catalog lacked aliases required by the graph repository's configured catalog ref.

## Work Done

- Replaced benchmark FalkorDB direct `JedisPool` / `JedisPoolConfig` construction with `DriverImpl(server.host, server.port)`.
- Updated root Gradle Kotlin DSL deprecated delegated-property patterns to explicit `tasks.register` and `dependencies.add(...)` calls.
- Updated BOM constraints to use Gradle 10-compatible project dependency notation.
- Made the configured `bluetape4kDependenciesCatalogRef` cache the default catalog source while preserving explicit property/env path overrides.

## Validation

- `./gradlew compileTestKotlin --warning-mode all --rerun-tasks`: PASS, `BUILD SUCCESSFUL`, Kotlin compiler warnings 0.
- `git diff --check`: PASS.

## Review Notes

- One Gradle deprecation remains from Kover 0.9.8 plugin internals (`PrepareKover.kt:29`). Kover 0.9.8 is the latest plugin portal version, and the warning is tracked upstream, so this PR does not hide it with suppression.
- Full test suite and benchmark runs were not executed; this change is compile/build-script focused.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Warning reproduction | PASS | Initial `compileTestKotlin --warning-mode all --rerun-tasks` found 8 deprecated Jedis compiler warnings. |
| Repository warning cleanup | PASS | Gradle DSL and BOM project-notation warnings were updated in repo scripts. |
| Deprecated API replacement | PASS | Benchmarks now use `DriverImpl(server.host, server.port)` instead of direct `JedisPool` APIs. |
| Validation | PASS | `./gradlew compileTestKotlin --warning-mode all --rerun-tasks`: `BUILD SUCCESSFUL`, Kotlin compiler warnings 0; `git diff --check`: PASS. |
| Residual risk | PASS | Remaining warning is Kover 0.9.8 upstream plugin internals, not repository code. |
