### PR TITLE
feat: stream graph export by repository chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Chunked graph export cursor API**: graph repositories now expose sync and
+  coroutine chunked label lookups, TinkerGraph provides the reference chunked
+  traversal implementation, and Jackson3 NDJSON export consumes the chunked path
+  through `GraphExportOptions.exportChunkSize`
+  ([#233](https://github.com/bluetape4k/bluetape4k-graph/issues/233)).
+
 ### Changed
 
 - Opened the `0.6.0` development line after the `0.5.0` stable release.

--- a/README.ko.md
+++ b/README.ko.md
@@ -214,6 +214,12 @@ SuspendGraphMlBulkExporter().exportGraphSuspending(
 
 임포터는 `GraphImportOptions.batchSize`를 백엔드 쓰기 플러시 크기로 사용합니다. 대기 중인 정점과 간선을 라벨별로 묶어 `createVertices`/`createEdges`로 플러시하며, 중복 ID와 누락 엔드포인트 정책의 의미는 그대로 유지됩니다.
 
+스트리밍 가능한 exporter는 `GraphExportOptions.exportChunkSize`와 chunk-aware
+repository API를 사용합니다. `Jackson3NdJsonBulkExporter`와
+`SuspendJackson3NdJsonBulkExporter`는 `findVerticesByLabelChunked`,
+`findEdgesByLabelChunked`를 소비합니다. Cursor 구현이 없는 백엔드는 기존
+list/Flow fallback을 유지하고, TinkerGraph는 reference chunked path를 제공합니다.
+
 | 모듈 | 포맷 | 문서 |
 |------|------|------|
 | `graph-io-core` | 공유 계약·모델·옵션·헬퍼 (`GraphBulkImporter`, `GraphBulkExporter`, `GraphIoPaths`, `GraphIoExternalIdMap`) | [README](graph-io/core/README.ko.md) |

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ SuspendGraphMlBulkExporter().exportGraphSuspending(
 
 Importers use `GraphImportOptions.batchSize` as the backend write flush size. Pending vertices and edges are grouped by label and flushed through `createVertices`/`createEdges`; duplicate-ID and missing-endpoint policies keep their existing semantics.
 
+Streaming-capable exporters use `GraphExportOptions.exportChunkSize` with
+chunk-aware repository methods. `Jackson3NdJsonBulkExporter` and
+`SuspendJackson3NdJsonBulkExporter` consume `findVerticesByLabelChunked` and
+`findEdgesByLabelChunked`; backends without a cursor implementation keep the
+compatible list/Flow fallback, while TinkerGraph provides the reference chunked
+path.
+
 | Module | Format | Docs |
 |--------|--------|------|
 | `graph-io-core` | Shared contracts, models, options, and helpers (`GraphBulkImporter`, `GraphBulkExporter`, `GraphIoPaths`, `GraphIoExternalIdMap`) | [README](graph-io/core/README.md) |

--- a/WIP.md
+++ b/WIP.md
@@ -2,7 +2,7 @@
 
 Snapshot: 2026-06-26 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count after merging pending research PR: 3 issues.
+Open count after merging the issue #233/#234 PRs: 2 issues.
 
 ## Current Direction
 
@@ -14,7 +14,6 @@ The `0.5.0` stable line has been published and consumed by
 
 | Priority | Issue | Milestone | Notes |
 |---|---|---|---|
-| P1 | [#233](https://github.com/bluetape4k/bluetape4k-graph/issues/233) feat: add chunked graph export cursor API for graph-io streaming | 0.6.0 | Next graph-io streaming feature lane after 0.5.0 release. |
 | P3 | [#215](https://github.com/bluetape4k/bluetape4k-graph/issues/215) research: revalidate Amazon Neptune backend feasibility | backlog | Required before reviving #30. |
 | P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) [Epic] Amazon Neptune 그래프 DB 백엔드 구현 (graph-neptune) | backlog | Keep blocked while marked `invalid`/research; do not implement against mocks only. |
 
@@ -29,6 +28,9 @@ The `0.5.0` stable line has been published and consumed by
   Neo4j/Memgraph/AGE/FalkorDB native fast paths from `0.6.0`, reject
   TinkerPop/TinkerGraph as a native-loader lane, and keep issue #233 as the
   next separate graph-io implementation PR.
+- [#233](https://github.com/bluetape4k/bluetape4k-graph/issues/233)
+  chunked graph export cursor API is implemented with a TinkerGraph reference
+  path and Jackson3 NDJSON exporter proof.
 - Root README English/Korean module lists and example test commands already
   include the 0.5.0 example modules.
 - Aligned Ktor examples with shared bluetape4k-ktor-core modules.

--- a/graph-io/core/README.ko.md
+++ b/graph-io/core/README.ko.md
@@ -70,6 +70,7 @@ data class GraphExportOptions(
     val vertexLabels: Set<String> = emptySet(),  // 비어있으면 전체 레이블
     val edgeLabels: Set<String> = emptySet(),    // 비어있으면 전체 레이블
     val includeEmptyProperties: Boolean = true,
+    val exportChunkSize: Int = 1_000,
 )
 
 enum class DuplicateVertexPolicy { FAIL, SKIP }
@@ -77,6 +78,13 @@ enum class MissingEndpointPolicy { FAIL, SKIP_EDGE }
 ```
 
 `batchSize`는 임포트 중 백엔드 쓰기 플러시 크기를 제어합니다. 임포터는 대기 중인 정점과 간선을 라벨별로 묶고, 라벨별 버퍼가 이 크기에 도달하면 `createVertices`/`createEdges`를 호출하며, 마지막 부분 버퍼는 종료 시 플러시합니다. 중복 ID나 누락 엔드포인트 정책의 의미는 바꾸지 않습니다.
+
+`exportChunkSize`는 스트리밍 가능한 exporter가 `findVerticesByLabelChunked`,
+`findEdgesByLabelChunked` 같은 chunk-aware repository API에서 한 번에 요청하는
+레코드 수를 제어합니다. 이 메서드를 override하지 않은 백엔드는 기존 list/Flow
+fallback을 사용하고, cursor-aware 백엔드는 전체 label materialization을 피할 수
+있습니다. CSV처럼 전역 헤더가 필요한 포맷은 여전히 포맷별 pre-scan을 수행할 수
+있습니다.
 
 레이블 필드와 레이블 세트의 모든 원소에 `requireNotBlank` 검증이 적용됩니다.
 

--- a/graph-io/core/README.md
+++ b/graph-io/core/README.md
@@ -70,6 +70,7 @@ data class GraphExportOptions(
     val vertexLabels: Set<String> = emptySet(),  // empty = all labels
     val edgeLabels: Set<String> = emptySet(),    // empty = all labels
     val includeEmptyProperties: Boolean = true,
+    val exportChunkSize: Int = 1_000,
 )
 
 enum class DuplicateVertexPolicy { FAIL, SKIP }
@@ -77,6 +78,13 @@ enum class MissingEndpointPolicy { FAIL, SKIP_EDGE }
 ```
 
 `batchSize` controls backend write flushing during imports. Importers group pending vertices and edges by label, call `createVertices`/`createEdges` when a label buffer reaches this size, and flush final partial buffers at the end. It does not change duplicate-ID or missing-endpoint policy semantics.
+
+`exportChunkSize` controls how many records streaming-capable exporters request
+from chunk-aware repository methods such as `findVerticesByLabelChunked` and
+`findEdgesByLabelChunked`. Backends that do not override those methods use the
+compatible list/Flow fallback, while cursor-aware backends can avoid
+whole-label materialization. Formats that need global headers, such as CSV, may
+still perform format-specific pre-scans.
 
 `requireNotBlank` is enforced on label fields and on every element of label sets.
 

--- a/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/options/GraphExportOptions.kt
+++ b/graph-io/core/src/main/kotlin/io/bluetape4k/graph/io/options/GraphExportOptions.kt
@@ -1,21 +1,30 @@
 package io.bluetape4k.graph.io.options
 
+import io.bluetape4k.graph.repository.DEFAULT_GRAPH_EXPORT_CHUNK_SIZE
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.Serializable
 
 /**
- * 그래프 익스포트 옵션.
- * `vertexLabels`/`edgeLabels`에 빈 문자열이 포함되면 즉시 실패한다.
+ * Options for graph export operations.
+ *
+ * Blank values in [vertexLabels] or [edgeLabels] fail fast.
+ *
+ * @property exportChunkSize streaming-capable exporters request at most this
+ * many records per repository chunk. Formats that need a global header, such as
+ * CSV, may still perform a format-specific pre-scan.
  */
 data class GraphExportOptions(
     val vertexLabels: Set<String> = emptySet(),
     val edgeLabels: Set<String> = emptySet(),
     val includeEmptyProperties: Boolean = true,
+    val exportChunkSize: Int = DEFAULT_GRAPH_EXPORT_CHUNK_SIZE,
 ) : Serializable {
     init {
         vertexLabels.forEach { it.requireNotBlank("vertexLabels element") }
         edgeLabels.forEach { it.requireNotBlank("edgeLabels element") }
+        exportChunkSize.requirePositiveNumber("exportChunkSize")
     }
 
     companion object : KLogging() {

--- a/graph-io/jackson3/README.ko.md
+++ b/graph-io/jackson3/README.ko.md
@@ -15,6 +15,7 @@ Jackson3는 mapper 구현을 `tools.jackson`으로 전환하면서도 Jackson2 �
 - `Jackson3EnvelopeCodec`이 각 JSON 라인을 `vertex` 또는 `edge` envelope로 매핑합니다.
 - Import는 먼저 정점을 생성하고 외부 ID를 저장한 뒤, 버퍼링한 간선을 해석합니다.
 - Export는 선택한 label을 스캔하고 정점 envelope를 간선 envelope보다 먼저 씁니다.
+- Export는 선택한 label을 chunk-aware repository API로 읽어 cursor-capable 백엔드가 전체 label materialization을 피할 수 있게 합니다.
 - 동기, 가상 스레드, suspend API는 같은 envelope 계약을 공유합니다.
 
 ## 핵심 기능
@@ -60,6 +61,7 @@ Jackson3는 mapper 구현을 `tools.jackson`으로 전환하면서도 Jackson2 �
 ### 유연한 설정
 
 - 선택적 정점/간선 라벨 필터링
+- `GraphExportOptions.exportChunkSize` 기반 chunk-aware export
 - 속성에 외부 ID 보존
 - 설정 가능한 간선 버퍼 크기
 - 작업별 진행 상황 보고
@@ -201,6 +203,12 @@ val report = future.join()
 - `vertexLabels: Set<String>` - 익스포트할 특정 라벨 (비어있으면 모두)
 - `edgeLabels: Set<String>` - 익스포트할 특정 라벨 (비어있으면 모두)
 - `includeEmptyProperties: Boolean` - 속성이 비어있어도 레코드 방출 (기본 `true`)
+- `exportChunkSize: Int` - streaming-capable exporter가 repository에서 한 번에 읽는 최대 레코드 수 (기본 `1_000`)
+
+Jackson3 export는 `findVerticesByLabelChunked`, `findEdgesByLabelChunked`를
+소비합니다. 이 repository 메서드를 override하지 않은 백엔드는 호환 가능한
+list/Flow fallback을 사용하고, cursor-aware 백엔드는 bounded chunk를 NDJSON
+writer로 바로 흘릴 수 있습니다.
 
 ## 의존성
 

--- a/graph-io/jackson3/README.md
+++ b/graph-io/jackson3/README.md
@@ -15,6 +15,7 @@ Jackson3 uses the same NDJSON envelope contract as the Jackson2 module while swi
 - `Jackson3EnvelopeCodec` maps each JSON line to a `vertex` or `edge` envelope.
 - Import creates vertices first, stores external IDs, then resolves buffered edges.
 - Export scans selected labels and writes vertex envelopes before edge envelopes.
+- Export reads selected labels through chunk-aware repository APIs so cursor-capable backends can avoid whole-label materialization.
 - Sync, virtual-thread, and suspend APIs share the same envelope contract.
 
 ## Key Features
@@ -60,6 +61,7 @@ The module offers three distinct execution models to fit different runtime envir
 ### Flexible Configuration
 
 - Selective vertex/edge label filtering
+- Chunk-aware export via `GraphExportOptions.exportChunkSize`
 - External ID preservation in properties
 - Configurable edge buffer size
 - Per-operation progress reporting
@@ -201,6 +203,12 @@ val report = future.join()
 - `vertexLabels: Set<String>` - Specific labels to export (empty = all)
 - `edgeLabels: Set<String>` - Specific labels to export (empty = all)
 - `includeEmptyProperties: Boolean` - Emit records even when properties are empty (default `true`)
+- `exportChunkSize: Int` - Maximum records per repository export chunk for streaming-capable exporters (default `1_000`)
+
+Jackson3 export consumes `findVerticesByLabelChunked` and
+`findEdgesByLabelChunked`. Backends that do not override those repository
+methods use the compatible list/Flow fallback, while cursor-aware backends can
+stream bounded chunks to the NDJSON writer.
 
 ## Dependencies
 

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonBulkExporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3NdJsonBulkExporter.kt
@@ -55,20 +55,24 @@ class Jackson3NdJsonBulkExporter : GraphBulkExporter<GraphExportSink> {
         GraphIoPaths.openWriter(sink).use { writer ->
             // 정점 쓰기
             for (label in options.vertexLabels) {
-                for (v in operations.findVerticesByLabel(label)) {
-                    val rec = GraphIoVertexRecord(v.id.value, v.label, v.properties)
-                    writer.write(codec.writeVertex(rec))
-                    writer.newLine()
-                    vWritten++
+                for (chunk in operations.findVerticesByLabelChunked(label, chunkSize = options.exportChunkSize)) {
+                    for (v in chunk) {
+                        val rec = GraphIoVertexRecord(v.id.value, v.label, v.properties)
+                        writer.write(codec.writeVertex(rec))
+                        writer.newLine()
+                        vWritten++
+                    }
                 }
             }
             // 간선 쓰기
             for (label in options.edgeLabels) {
-                for (e in operations.findEdgesByLabel(label)) {
-                    val rec = GraphIoEdgeRecord(e.id.value, e.label, e.startId.value, e.endId.value, e.properties)
-                    writer.write(codec.writeEdge(rec))
-                    writer.newLine()
-                    eWritten++
+                for (chunk in operations.findEdgesByLabelChunked(label, chunkSize = options.exportChunkSize)) {
+                    for (e in chunk) {
+                        val rec = GraphIoEdgeRecord(e.id.value, e.label, e.startId.value, e.endId.value, e.properties)
+                        writer.write(codec.writeEdge(rec))
+                        writer.newLine()
+                        eWritten++
+                    }
                 }
             }
         }

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkExporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkExporter.kt
@@ -16,7 +16,6 @@ import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
 /**
@@ -54,19 +53,23 @@ class SuspendJackson3NdJsonBulkExporter : GraphSuspendBulkExporter<GraphExportSi
 
         GraphIoPaths.openWriter(sink).use { writer ->
             for (label in options.vertexLabels) {
-                for (v in operations.findVerticesByLabel(label).toList()) {
-                    val rec = GraphIoVertexRecord(v.id.value, v.label, v.properties)
-                    writer.write(codec.writeVertex(rec))
-                    writer.newLine()
-                    vWritten++
+                operations.findVerticesByLabelChunked(label, chunkSize = options.exportChunkSize).collect { chunk ->
+                    for (v in chunk) {
+                        val rec = GraphIoVertexRecord(v.id.value, v.label, v.properties)
+                        writer.write(codec.writeVertex(rec))
+                        writer.newLine()
+                        vWritten++
+                    }
                 }
             }
             for (label in options.edgeLabels) {
-                for (e in operations.findEdgesByLabel(label).toList()) {
-                    val rec = GraphIoEdgeRecord(e.id.value, e.label, e.startId.value, e.endId.value, e.properties)
-                    writer.write(codec.writeEdge(rec))
-                    writer.newLine()
-                    eWritten++
+                operations.findEdgesByLabelChunked(label, chunkSize = options.exportChunkSize).collect { chunk ->
+                    for (e in chunk) {
+                        val rec = GraphIoEdgeRecord(e.id.value, e.label, e.startId.value, e.endId.value, e.properties)
+                        writer.write(codec.writeEdge(rec))
+                        writer.newLine()
+                        eWritten++
+                    }
                 }
             }
         }

--- a/graph-io/jackson3/src/test/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3RoundTripTest.kt
+++ b/graph-io/jackson3/src/test/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3RoundTripTest.kt
@@ -5,6 +5,9 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -41,5 +44,50 @@ class Jackson3RoundTripTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 3L
         report.edgesCreated shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `sync export uses chunked repository API instead of full label list`(@TempDir dir: Path) {
+        val out = dir.resolve("graph.ndjson")
+        val src = TinkerGraphOperations()
+        val vertices = (1..5).map { index ->
+            src.createVertex("Person", mapOf("name" to "Person-$index"))
+        }
+        src.createEdge(vertices[0].id, vertices[1].id, "KNOWS", mapOf("rank" to 1))
+        src.createEdge(vertices[1].id, vertices[2].id, "KNOWS", mapOf("rank" to 2))
+
+        val report = Jackson3NdJsonBulkExporter().exportGraph(
+            GraphExportSink.PathSink(out),
+            ChunkOnlyGraphOperations(src),
+            GraphExportOptions(vertexLabels = setOf("Person"), edgeLabels = setOf("KNOWS"), exportChunkSize = 2),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.COMPLETED
+        report.verticesWritten shouldBeEqualTo 5L
+        report.edgesWritten shouldBeEqualTo 2L
+    }
+
+    private class ChunkOnlyGraphOperations(
+        private val delegate: GraphOperations,
+    ) : GraphOperations by delegate {
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> =
+            error("full vertex list lookup must not be used by Jackson3 export")
+
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): List<GraphEdge> =
+            error("full edge list lookup must not be used by Jackson3 export")
+
+        override fun findVerticesByLabelChunked(
+            label: String,
+            filter: Map<String, Any?>,
+            chunkSize: Int,
+        ): Sequence<List<GraphVertex>> =
+            delegate.findVerticesByLabelChunked(label, filter, chunkSize)
+
+        override fun findEdgesByLabelChunked(
+            label: String,
+            filter: Map<String, Any?>,
+            chunkSize: Int,
+        ): Sequence<List<GraphEdge>> =
+            delegate.findEdgesByLabelChunked(label, filter, chunkSize)
     }
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphEdgeRepository.kt
@@ -79,6 +79,33 @@ interface GraphEdgeRepository {
     fun findEdgesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): List<GraphEdge>
 
     /**
+     * Finds edges by label and property filter as bounded chunks.
+     *
+     * ## Contract
+     *
+     * - The default implementation splits the [findEdgesByLabel] result into chunks for compatibility.
+     * - Backends that must avoid whole-label materialization during large exports should override this method.
+     * - [chunkSize] must be positive.
+     *
+     * ```kotlin
+     * for (chunk in ops.findEdgesByLabelChunked("KNOWS", chunkSize = 500)) {
+     *     chunk.forEach { edge -> println(edge.id) }
+     * }
+     * ```
+     *
+     * @param label edge label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @param chunkSize maximum number of edges per chunk.
+     * @return chunk sequence containing matching [GraphEdge] values.
+     */
+    fun findEdgesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?> = emptyMap(),
+        chunkSize: Int = DEFAULT_GRAPH_EXPORT_CHUNK_SIZE,
+    ): Sequence<List<GraphEdge>> =
+        findEdgesByLabel(label, filter).asGraphExportChunks(chunkSize)
+
+    /**
      * 특정 정점에서 출발하는 간선 목록을 조회한다.
      *
      * Dijkstra/A* 알고리즘의 인접 간선 수집에 사용된다.

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphExportChunking.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphExportChunking.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.graph.repository
+
+import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Default number of records requested by chunk-aware graph export paths.
+ */
+const val DEFAULT_GRAPH_EXPORT_CHUNK_SIZE: Int = 1_000
+
+internal fun validateGraphExportChunkSize(chunkSize: Int): Int {
+    chunkSize.requirePositiveNumber("chunkSize")
+    return chunkSize
+}
+
+internal fun <T> Iterable<T>.asGraphExportChunks(chunkSize: Int): Sequence<List<T>> =
+    asSequence().asGraphExportChunks(chunkSize)
+
+internal fun <T> Sequence<T>.asGraphExportChunks(chunkSize: Int): Sequence<List<T>> = sequence {
+    val validatedChunkSize = validateGraphExportChunkSize(chunkSize)
+    val chunk = ArrayList<T>(validatedChunkSize)
+    for (record in this@asGraphExportChunks) {
+        chunk += record
+        if (chunk.size == validatedChunkSize) {
+            yield(chunk.toList())
+            chunk.clear()
+        }
+    }
+    if (chunk.isNotEmpty()) {
+        yield(chunk.toList())
+    }
+}
+
+internal fun <T> Flow<T>.asGraphExportChunks(chunkSize: Int): Flow<List<T>> = flow {
+    val validatedChunkSize = validateGraphExportChunkSize(chunkSize)
+    val chunk = ArrayList<T>(validatedChunkSize)
+    collect { record ->
+        chunk += record
+        if (chunk.size == validatedChunkSize) {
+            emit(chunk.toList())
+            chunk.clear()
+        }
+    }
+    if (chunk.isNotEmpty()) {
+        emit(chunk.toList())
+    }
+}

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendEdgeRepository.kt
@@ -81,6 +81,30 @@ interface GraphSuspendEdgeRepository {
     fun findEdgesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): Flow<GraphEdge>
 
     /**
+     * Finds edges by label and property filter as a Flow of bounded chunks.
+     *
+     * The default implementation groups the record Flow from [findEdgesByLabel].
+     * Backends with driver cursors or paging APIs can override this method so the
+     * backend query itself runs chunk-by-chunk.
+     *
+     * ```kotlin
+     * ops.findEdgesByLabelChunked("KNOWS", chunkSize = 500)
+     *     .collect { chunk -> println(chunk.size) }
+     * ```
+     *
+     * @param label edge label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @param chunkSize maximum number of edges per chunk.
+     * @return Flow of chunks containing matching [GraphEdge] values.
+     */
+    fun findEdgesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?> = emptyMap(),
+        chunkSize: Int = DEFAULT_GRAPH_EXPORT_CHUNK_SIZE,
+    ): Flow<List<GraphEdge>> =
+        findEdgesByLabel(label, filter).asGraphExportChunks(chunkSize)
+
+    /**
      * 특정 정점에서 출발하는 간선 목록을 스트림으로 조회한다.
      *
      * ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendVertexRepository.kt
@@ -100,6 +100,30 @@ interface GraphSuspendVertexRepository {
     fun findVerticesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): Flow<GraphVertex>
 
     /**
+     * Finds vertices by label and property filter as a Flow of bounded chunks.
+     *
+     * The default implementation groups the record Flow from [findVerticesByLabel].
+     * Backends with driver cursors or paging APIs can override this method so the
+     * backend query itself runs chunk-by-chunk.
+     *
+     * ```kotlin
+     * ops.findVerticesByLabelChunked("Person", chunkSize = 500)
+     *     .collect { chunk -> println(chunk.size) }
+     * ```
+     *
+     * @param label vertex label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @param chunkSize maximum number of vertices per chunk.
+     * @return Flow of chunks containing matching [GraphVertex] values.
+     */
+    fun findVerticesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?> = emptyMap(),
+        chunkSize: Int = DEFAULT_GRAPH_EXPORT_CHUNK_SIZE,
+    ): Flow<List<GraphVertex>> =
+        findVerticesByLabel(label, filter).asGraphExportChunks(chunkSize)
+
+    /**
      * 기존 정점의 속성을 갱신하고 갱신된 정점을 반환한다.
      *
      * ```kotlin

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVertexRepository.kt
@@ -108,6 +108,33 @@ interface GraphVertexRepository {
     fun findVerticesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): List<GraphVertex>
 
     /**
+     * Finds vertices by label and property filter as bounded chunks.
+     *
+     * ## Contract
+     *
+     * - The default implementation splits the [findVerticesByLabel] result into chunks for compatibility.
+     * - Backends that must avoid whole-label materialization during large exports should override this method.
+     * - [chunkSize] must be positive.
+     *
+     * ```kotlin
+     * for (chunk in ops.findVerticesByLabelChunked("Person", chunkSize = 500)) {
+     *     chunk.forEach { vertex -> println(vertex.id) }
+     * }
+     * ```
+     *
+     * @param label vertex label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @param chunkSize maximum number of vertices per chunk.
+     * @return chunk sequence containing matching [GraphVertex] values.
+     */
+    fun findVerticesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?> = emptyMap(),
+        chunkSize: Int = DEFAULT_GRAPH_EXPORT_CHUNK_SIZE,
+    ): Sequence<List<GraphVertex>> =
+        findVerticesByLabel(label, filter).asGraphExportChunks(chunkSize)
+
+    /**
      * 기존 정점의 속성을 갱신하고 갱신된 정점을 반환한다.
      *
      * ```kotlin

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/repository/GraphBatchOperationsTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/repository/GraphBatchOperationsTest.kt
@@ -11,6 +11,8 @@ import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.Test
 
 class GraphBatchOperationsTest {
@@ -66,6 +68,50 @@ class GraphBatchOperationsTest {
     }
 
     @Test
+    fun `default findVerticesByLabelChunked splits list fallback`() {
+        val repo = ListingVertexRepository(
+            (1..5).map { index ->
+                GraphVertex(GraphElementId.of("v$index"), "Person", mapOf("index" to index))
+            }
+        )
+
+        val chunks = repo.findVerticesByLabelChunked("Person", chunkSize = 2).toList()
+
+        chunks.map { it.size } shouldBeEqualTo listOf(2, 2, 1)
+        chunks.flatten().map { it.id.value } shouldBeEqualTo listOf("v1", "v2", "v3", "v4", "v5")
+    }
+
+    @Test
+    fun `default findEdgesByLabelChunked splits list fallback`() {
+        val repo = ListingEdgeRepository(
+            (1..3).map { index ->
+                GraphEdge(
+                    GraphElementId.of("e$index"),
+                    "KNOWS",
+                    GraphElementId.of("v$index"),
+                    GraphElementId.of("v${index + 1}"),
+                )
+            }
+        )
+
+        val chunks = repo.findEdgesByLabelChunked("KNOWS", chunkSize = 2).toList()
+
+        chunks.map { it.size } shouldBeEqualTo listOf(2, 1)
+        chunks.flatten().map { it.id.value } shouldBeEqualTo listOf("e1", "e2", "e3")
+    }
+
+    @Test
+    fun `default chunked lookup rejects non-positive chunk size`() {
+        val repo = ListingVertexRepository(emptyList())
+
+        val ex = assertFailsWith<IllegalArgumentException> {
+            repo.findVerticesByLabelChunked("Person", chunkSize = 0).toList()
+        }
+
+        ex.message shouldContain "chunkSize"
+    }
+
+    @Test
     fun `suspend default createVertices preserves order`() = runSuspendIO {
         val repo = RecordingSuspendVertexRepository()
         val rows = listOf(mapOf("name" to "Alice"), mapOf("name" to "Bob"))
@@ -88,6 +134,39 @@ class GraphBatchOperationsTest {
 
         edges.map { it.properties["since"] } shouldBeEqualTo listOf(2024, 2025)
         repo.createdEdges shouldBeEqualTo rows
+    }
+
+    @Test
+    fun `suspend default findVerticesByLabelChunked splits Flow fallback`() = runSuspendIO {
+        val repo = ListingSuspendVertexRepository(
+            (1..5).map { index ->
+                GraphVertex(GraphElementId.of("v$index"), "Person", mapOf("index" to index))
+            }
+        )
+
+        val chunks = repo.findVerticesByLabelChunked("Person", chunkSize = 2).toList()
+
+        chunks.map { it.size } shouldBeEqualTo listOf(2, 2, 1)
+        chunks.flatten().map { it.id.value } shouldBeEqualTo listOf("v1", "v2", "v3", "v4", "v5")
+    }
+
+    @Test
+    fun `suspend default findEdgesByLabelChunked splits Flow fallback`() = runSuspendIO {
+        val repo = ListingSuspendEdgeRepository(
+            (1..3).map { index ->
+                GraphEdge(
+                    GraphElementId.of("e$index"),
+                    "KNOWS",
+                    GraphElementId.of("v$index"),
+                    GraphElementId.of("v${index + 1}"),
+                )
+            }
+        )
+
+        val chunks = repo.findEdgesByLabelChunked("KNOWS", chunkSize = 2).toList()
+
+        chunks.map { it.size } shouldBeEqualTo listOf(2, 1)
+        chunks.flatten().map { it.id.value } shouldBeEqualTo listOf("e1", "e2", "e3")
     }
 
     @Test
@@ -178,6 +257,34 @@ class GraphBatchOperationsTest {
         override fun deleteEdge(label: String, id: GraphElementId): Boolean = unsupported()
     }
 
+    private class ListingVertexRepository(
+        private val vertices: List<GraphVertex>,
+    ) : GraphVertexRepository {
+        override fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex = unsupported()
+        override fun findVertexById(label: String, id: GraphElementId): GraphVertex? = unsupported()
+        override fun findVertexById(id: GraphElementId): GraphVertex? = unsupported()
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> = vertices
+        override fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex? =
+            unsupported()
+        override fun deleteVertex(label: String, id: GraphElementId): Boolean = unsupported()
+        override fun countVertices(label: String): Long = vertices.size.toLong()
+    }
+
+    private class ListingEdgeRepository(
+        private val edges: List<GraphEdge>,
+    ) : GraphEdgeRepository {
+        override fun createEdge(
+            fromId: GraphElementId,
+            toId: GraphElementId,
+            label: String,
+            properties: Map<String, Any?>,
+        ): GraphEdge = unsupported()
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): List<GraphEdge> = edges
+        override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> = unsupported()
+        override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): List<GraphEdge> = unsupported()
+        override fun deleteEdge(label: String, id: GraphElementId): Boolean = unsupported()
+    }
+
     private class RecordingSuspendVertexRepository : GraphSuspendVertexRepository {
         val createdProperties = mutableListOf<Map<String, Any?>>()
 
@@ -212,6 +319,39 @@ class GraphBatchOperationsTest {
         }
 
         override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> = unsupported()
+        override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = unsupported()
+        override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = unsupported()
+        override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean = unsupported()
+    }
+
+    private class ListingSuspendVertexRepository(
+        private val vertices: List<GraphVertex>,
+    ) : GraphSuspendVertexRepository {
+        override suspend fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex = unsupported()
+        override suspend fun findVertexById(label: String, id: GraphElementId): GraphVertex? = unsupported()
+        override suspend fun findVertexById(id: GraphElementId): GraphVertex? = unsupported()
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> =
+            vertices.asFlow()
+        override suspend fun updateVertex(
+            label: String,
+            id: GraphElementId,
+            properties: Map<String, Any?>,
+        ): GraphVertex? = unsupported()
+        override suspend fun deleteVertex(label: String, id: GraphElementId): Boolean = unsupported()
+        override suspend fun countVertices(label: String): Long = vertices.size.toLong()
+    }
+
+    private class ListingSuspendEdgeRepository(
+        private val edges: List<GraphEdge>,
+    ) : GraphSuspendEdgeRepository {
+        override suspend fun createEdge(
+            fromId: GraphElementId,
+            toId: GraphElementId,
+            label: String,
+            properties: Map<String, Any?>,
+        ): GraphEdge = unsupported()
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> =
+            edges.asFlow()
         override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = unsupported()
         override fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = unsupported()
         override suspend fun deleteEdge(label: String, id: GraphElementId): Boolean = unsupported()

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -24,6 +24,7 @@ import io.bluetape4k.graph.model.TraversalVisit
 import io.bluetape4k.graph.repository.GraphAlgorithmRepository
 import io.bluetape4k.graph.repository.GraphBatchValidation
 import io.bluetape4k.graph.repository.GraphEdgeRepository
+import io.bluetape4k.graph.repository.DEFAULT_GRAPH_EXPORT_CHUNK_SIZE
 import io.bluetape4k.graph.repository.GraphMergeOperations
 import io.bluetape4k.graph.repository.GraphMergeValidation
 import io.bluetape4k.graph.repository.GraphOperations
@@ -36,6 +37,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
 import org.apache.tinkerpop.gremlin.process.traversal.P
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource
@@ -218,6 +220,23 @@ class TinkerGraphOperations :
         return traversal.toList().map { GremlinRecordMapper.vertexToGraphVertex(it) }
     }
 
+    override fun findVerticesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?>,
+        chunkSize: Int,
+    ): Sequence<List<GraphVertex>> {
+        label.requireNotBlank("label")
+        chunkSize.requirePositiveNumber("chunkSize")
+
+        return sequence {
+            val traversal = g.V().hasLabel(label)
+            filter.forEach { (key, value) ->
+                traversal.has(key, value)
+            }
+            yieldMappedChunks(traversal, chunkSize, GremlinRecordMapper::vertexToGraphVertex)
+        }
+    }
+
     override fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex? {
         label.requireNotBlank("label")
 
@@ -357,6 +376,23 @@ class TinkerGraphOperations :
             traversal.has(key, value)
         }
         return traversal.toList().map { GremlinRecordMapper.edgeToGraphEdge(it) }
+    }
+
+    override fun findEdgesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?>,
+        chunkSize: Int,
+    ): Sequence<List<GraphEdge>> {
+        label.requireNotBlank("label")
+        chunkSize.requirePositiveNumber("chunkSize")
+
+        return sequence {
+            val traversal = g.E().hasLabel(label)
+            filter.forEach { (key, value) ->
+                traversal.has(key, value)
+            }
+            yieldMappedChunks(traversal, chunkSize, GremlinRecordMapper::edgeToGraphEdge)
+        }
     }
 
     override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): List<GraphEdge> {
@@ -566,6 +602,28 @@ class TinkerGraphOperations :
         }
 
         return GraphPath(steps)
+    }
+
+    private suspend fun <E, R> SequenceScope<List<R>>.yieldMappedChunks(
+        traversal: Traversal<*, E>,
+        chunkSize: Int = DEFAULT_GRAPH_EXPORT_CHUNK_SIZE,
+        mapper: (E) -> R,
+    ) {
+        val chunk = ArrayList<R>(chunkSize)
+        try {
+            while (traversal.hasNext()) {
+                chunk += mapper(traversal.next())
+                if (chunk.size == chunkSize) {
+                    yield(chunk.toList())
+                    chunk.clear()
+                }
+            }
+            if (chunk.isNotEmpty()) {
+                yield(chunk.toList())
+            }
+        } finally {
+            traversal.close()
+        }
     }
 
     // -- GraphAlgorithmRepository --

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphSuspendOperations.kt
@@ -193,6 +193,22 @@ class TinkerGraphSuspendOperations(
         list.forEach { emit(it) }
     }
 
+    override fun findVerticesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?>,
+        chunkSize: Int,
+    ): Flow<List<GraphVertex>> = flow {
+        val iterator = withContext(Dispatchers.IO) {
+            delegate.findVerticesByLabelChunked(label, filter, chunkSize).iterator()
+        }
+        while (true) {
+            val chunk = withContext(Dispatchers.IO) {
+                if (iterator.hasNext()) iterator.next() else null
+            } ?: break
+            emit(chunk)
+        }
+    }
+
     override suspend fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex? =
         withContext(Dispatchers.IO) {
             delegate.updateVertex(label, id, properties)
@@ -229,6 +245,22 @@ class TinkerGraphSuspendOperations(
             delegate.findEdgesByLabel(label, filter)
         }
         list.forEach { emit(it) }
+    }
+
+    override fun findEdgesByLabelChunked(
+        label: String,
+        filter: Map<String, Any?>,
+        chunkSize: Int,
+    ): Flow<List<GraphEdge>> = flow {
+        val iterator = withContext(Dispatchers.IO) {
+            delegate.findEdgesByLabelChunked(label, filter, chunkSize).iterator()
+        }
+        while (true) {
+            val chunk = withContext(Dispatchers.IO) {
+                if (iterator.hasNext()) iterator.next() else null
+            } ?: break
+            emit(chunk)
+        }
     }
 
     override fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String?): Flow<GraphEdge> = flow {

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperationsTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperationsTest.kt
@@ -121,6 +121,20 @@ class TinkerGraphOperationsTest {
     }
 
     @Test
+    @Order(251)
+    fun `label로 정점을 chunk 단위로 조회한다`() {
+        (1..5).forEach { index ->
+            ops.createVertex("Person", mapOf("name" to "Person-$index"))
+        }
+
+        val chunks = ops.findVerticesByLabelChunked("Person", chunkSize = 2).toList()
+
+        chunks.map { it.size } shouldBeEqualTo listOf(2, 2, 1)
+        chunks.flatten().map { it.properties["name"] }.toSet() shouldBeEqualTo
+                setOf("Person-1", "Person-2", "Person-3", "Person-4", "Person-5")
+    }
+
+    @Test
     @Order(26)
     fun `정점의 properties를 업데이트한다`() {
         val vertex = ops.createVertex("Person", mapOf("name" to "Charlie", "age" to 25L))
@@ -181,6 +195,22 @@ class TinkerGraphOperationsTest {
         val knowsEdges = ops.findEdgesByLabel("KNOWS")
         knowsEdges.shouldHaveSize(2)
         knowsEdges.all { it.label == "KNOWS" }.shouldBeTrue()
+    }
+
+    @Test
+    @Order(311)
+    fun `label로 간선을 chunk 단위로 조회한다`() {
+        val vertices = (1..4).map { index ->
+            ops.createVertex("Person", mapOf("name" to "Person-$index"))
+        }
+        (0..2).forEach { index ->
+            ops.createEdge(vertices[index].id, vertices[index + 1].id, "KNOWS", mapOf("rank" to index))
+        }
+
+        val chunks = ops.findEdgesByLabelChunked("KNOWS", chunkSize = 2).toList()
+
+        chunks.map { it.size } shouldBeEqualTo listOf(2, 1)
+        chunks.flatten().map { it.properties["rank"] }.toSet() shouldBeEqualTo setOf(0, 1, 2)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #233.

- Add backend-neutral sync and coroutine chunked repository lookup APIs for graph export paths.
- Add a TinkerGraph cursor-style reference implementation that maps Gremlin traversal results into bounded chunks.
- Route Jackson3 NDJSON sync and suspend exporters through the chunked API using `GraphExportOptions.exportChunkSize`.
- Document the export chunk option in English and Korean READMEs and record the change in CHANGELOG/WIP.

## Notes

CSV export is intentionally left on its existing path because global header generation still requires a format-specific pre-scan. Other production backends can now override the chunked repository methods without changing the graph-io exporter contract.

## DoD Status

- [x] Issue metadata mirrored: assignee `debop`, milestone `0.6.0`, labels `enhancement`, `performance`.
- [x] Backend-neutral sync/coroutine chunked export API added in graph-core.
- [x] TinkerGraph reference chunked implementation added.
- [x] Jackson3 NDJSON exporter proof uses chunked repository APIs.
- [x] Tests added for default fallback chunking, TinkerGraph chunking, and Jackson3 exporter no-full-list usage.
- [x] Documentation updated in `README.md`, `README.ko.md`, graph-io core README, Jackson3 README, `CHANGELOG.md`, and `WIP.md`.
- [x] Verified: `./gradlew :bluetape4k-graph-core:test :bluetape4k-graph-tinkerpop:test :bluetape4k-graph-io-jackson3:test`.
- [x] Verified: `git diff --check`.
