### PR TITLE
chore: align graph to core 1.11.1 snapshot

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.11.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.11.1-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
 kotlin = "2.4.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom
 kotlinx-coroutines = "1.11.0"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-bom


### PR DESCRIPTION
## Summary

- Align `bluetape4k-graph` with the post-release bluetape4k core development line.
- Replace the stale `1.11.0-SNAPSHOT` core BOM reference with `1.11.1-SNAPSHOT`.
- Keep the existing graph development line at `0.6.0-SNAPSHOT` via `baseVersion=0.6.0` and empty `snapshotVersion=`.

## Validation

- `git diff --check`
- Version target inspection for `gradle.properties` and `gradle/libs.versions.toml`
- GitHub PR checks passed
- Post-merge snapshot publish passed

## Release Train Notes

- Target development line: `0.6.0`
- Internal core BOM: `bluetape4k-bom:1.11.1-SNAPSHOT`
- Snapshot publication: `bluetape4k-graph-bom:0.6.0-SNAPSHOT`

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| Core snapshot aligned | PASS | `bluetape4k = "1.11.1-SNAPSHOT"` |
| Version line retained | PASS | `baseVersion=0.6.0`; `snapshotVersion=` remains empty |
| Local static check | PASS | `git diff --check` passed |
| Local Gradle resolution | N/A | `./gradlew help --refresh-dependencies` was intercepted by context-mode in this Codex session |
| CI | PASS | https://github.com/bluetape4k/bluetape4k-graph/actions/runs/28443687492 and examples run https://github.com/bluetape4k/bluetape4k-graph/actions/runs/28443687430 passed |
| Snapshot publish | PASS | https://github.com/bluetape4k/bluetape4k-graph/actions/runs/28444115405; metadata timestamp `20260630.122740`, build `28` |
