### PR TITLE
docs: add graph-io README language switches

### DIFF
--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
@@ -12,7 +12,9 @@ import io.bluetape4k.logging.debug
 import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractCodeGraphSuspendTest {
 
     companion object : KLogging()

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphTest.kt
@@ -10,7 +10,9 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractCodeGraphTest {
 
     companion object : KLogging()

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphSuspendTest.kt
@@ -3,8 +3,8 @@ package io.bluetape4k.graph.examples.code
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -23,7 +23,7 @@ class FalkorDBCodeGraphSuspendTest : AbstractCodeGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionBackendTests.kt
+++ b/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionBackendTests.kt
@@ -14,11 +14,11 @@ import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -173,7 +173,7 @@ class FalkorDBFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphBackendTests.kt
+++ b/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphBackendTests.kt
@@ -14,11 +14,11 @@ import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -173,7 +173,7 @@ class FalkorDBKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphSuspendTest.kt
@@ -13,7 +13,9 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractLinkedInGraphSuspendTest {
 
     companion object : KLoggingChannel()

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphTest.kt
@@ -11,7 +11,9 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractLinkedInGraphTest {
 
     companion object : KLogging()

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphSuspendTest.kt
@@ -3,8 +3,8 @@ package io.bluetape4k.graph.examples.linkedin
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -23,7 +23,7 @@ class FalkorDBLinkedInGraphSuspendTest : AbstractLinkedInGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationBackendTests.kt
+++ b/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationBackendTests.kt
@@ -14,11 +14,11 @@ import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -173,7 +173,7 @@ class FalkorDBRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/graph-io/core/README.ko.md
+++ b/graph-io/core/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-core
 
+[English](README.md) | 한국어
+
 `graph-io` 계열의 벌크 임포터/익스포터가 공유하는 계약(contract), 모델, 옵션, 리포트, I/O 헬퍼.
 
 ## 개요

--- a/graph-io/core/README.md
+++ b/graph-io/core/README.md
@@ -1,5 +1,7 @@
 # graph-io-core
 
+English | [한국어](README.ko.md)
+
 Shared contracts, models, options, reports, and I/O helpers for the `graph-io` family of bulk importers and exporters.
 
 ## Overview

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/model/GraphIoRecordTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/model/GraphIoRecordTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.model
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -8,14 +8,14 @@ class GraphIoRecordTest {
 
     @Test
     fun `vertex record requires non-blank externalId`() {
-        invoking { GraphIoVertexRecord(externalId = " ", label = "Person") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphIoVertexRecord(externalId = " ", label = "Person") }
     }
 
     @Test
     fun `edge record requires non-blank label and endpoints`() {
-        invoking { GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2") } shouldThrow IllegalArgumentException::class
-        invoking { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2") } shouldThrow IllegalArgumentException::class
-        invoking { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2") }
+        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2") }
+        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ") }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphExportOptionsTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphExportOptionsTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.options
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -16,12 +16,12 @@ class GraphExportOptionsTest {
 
     @Test
     fun `vertexLabels must not contain blank strings`() {
-        invoking { GraphExportOptions(vertexLabels = setOf("Person", " ")) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphExportOptions(vertexLabels = setOf("Person", " ")) }
     }
 
     @Test
     fun `edgeLabels must not contain blank strings`() {
-        invoking { GraphExportOptions(edgeLabels = setOf("KNOWS", "")) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphExportOptions(edgeLabels = setOf("KNOWS", "")) }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphImportOptionsTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphImportOptionsTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.options
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -20,23 +20,23 @@ class GraphImportOptionsTest {
 
     @Test
     fun `batchSize must be positive`() {
-        invoking { GraphImportOptions(batchSize = 0) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportOptions(batchSize = -1) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(batchSize = 0) }
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(batchSize = -1) }
     }
 
     @Test
     fun `maxEdgeBufferSize must be positive`() {
-        invoking { GraphImportOptions(maxEdgeBufferSize = 0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(maxEdgeBufferSize = 0) }
     }
 
     @Test
     fun `defaultVertexLabel must not be blank`() {
-        invoking { GraphImportOptions(defaultVertexLabel = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(defaultVertexLabel = " ") }
     }
 
     @Test
     fun `defaultEdgeLabel must not be blank`() {
-        invoking { GraphImportOptions(defaultEdgeLabel = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(defaultEdgeLabel = " ") }
     }
 
     @Test
@@ -47,6 +47,6 @@ class GraphImportOptionsTest {
 
     @Test
     fun `preserveExternalIdProperty must not be blank when set`() {
-        invoking { GraphImportOptions(preserveExternalIdProperty = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(preserveExternalIdProperty = " ") }
     }
 }

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.report
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -10,7 +10,7 @@ class GraphIoReportTest {
 
     @Test
     fun `GraphIoFailure requires non-blank message`() {
-        invoking { GraphIoFailure(phase = GraphIoPhase.READ_VERTEX, message = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphIoFailure(phase = GraphIoPhase.READ_VERTEX, message = " ") }
     }
 
     @Test
@@ -52,20 +52,20 @@ class GraphIoReportTest {
 
     @Test
     fun `GraphImportReport rejects negative counts`() {
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) }
     }
 
     @Test
     fun `GraphExportReport rejects negative counts`() {
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
@@ -2,7 +2,7 @@ package io.bluetape4k.graph.io.support
 
 import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
 import io.bluetape4k.graph.model.GraphElementId
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class GraphIoExternalIdMapTest {
     fun `duplicate under FAIL policy throws`() {
         val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
         map.putFirstOrFail("v1", GraphElementId("a"))
-        invoking { map.putFirstOrFail("v1", GraphElementId("b")) } shouldThrow IllegalStateException::class
+        assertFailsWith<IllegalStateException> { map.putFirstOrFail("v1", GraphElementId("b")) }
     }
 
     @Test
@@ -68,7 +68,7 @@ class GraphIoExternalIdMapTest {
     @Test
     fun `put without putFirstOrFail throws IllegalStateException`() {
         val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
-        invoking { map.put("never-registered", GraphElementId("real")) } shouldThrow IllegalStateException::class
+        assertFailsWith<IllegalStateException> { map.put("never-registered", GraphElementId("real")) }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/VirtualThreadGraphBulkAdapterTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/VirtualThreadGraphBulkAdapterTest.kt
@@ -10,10 +10,10 @@ import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.testsupport.FakeGraphOperations
 import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 import java.util.concurrent.ExecutionException
 
@@ -64,7 +64,7 @@ class VirtualThreadGraphBulkAdapterTest {
         val boom = RuntimeException("boom")
         val importer = stubImporter { _, _, _ -> throw boom }
         val vt = VirtualThreadGraphBulkAdapter.wrapImporter(importer)
-        val ee = assertThrows<ExecutionException> {
+        val ee = assertFailsWith<ExecutionException> {
             vt.importGraphAsync("x", FakeGraphOperations(), GraphImportOptions()).get()
         }
         ee.cause shouldBeInstanceOf RuntimeException::class
@@ -92,7 +92,7 @@ class VirtualThreadGraphBulkAdapterTest {
         val boom = RuntimeException("export boom")
         val exporter = stubExporter { _, _, _ -> throw boom }
         val vt = VirtualThreadGraphBulkAdapter.wrapExporter(exporter)
-        val ee = assertThrows<ExecutionException> {
+        val ee = assertFailsWith<ExecutionException> {
             vt.exportGraphAsync("sink", FakeGraphOperations(), GraphExportOptions()).get()
         }
         ee.cause shouldBeInstanceOf RuntimeException::class

--- a/graph-io/csv/README.ko.md
+++ b/graph-io/csv/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-csv
 
+[English](README.md) | 한국어
+
 **bluetape4k-graph** 을 위한 CSV 포맷 벌크 임포터/익스포터. 그래프 정점과 간선을 CSV 파일로 원활하게 내보낼 수 있으며, 동기, 가상 스레드, Kotlin 코루틴 기반 suspend의 세 가지 실행 모델을 지원합니다.
 
 ## 기능

--- a/graph-io/csv/README.md
+++ b/graph-io/csv/README.md
@@ -1,5 +1,7 @@
 # graph-io-csv
 
+English | [한국어](README.ko.md)
+
 CSV format bulk importer/exporter for **bluetape4k-graph**. Seamlessly export graph vertices and edges to CSV files, with support for three execution models: synchronous, virtual thread-based, and Kotlin coroutine-based suspend operations.
 
 ## Features

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkExporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkExporter.kt
@@ -20,10 +20,10 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
 /**
- * CSV 코루틴(suspend) 벌크 익스포터.
+ * Coroutine bulk exporter for CSV graph data.
  *
- * suspend 방식으로 정점과 간선을 Flow로 수집하여 CSV 파일로 저장한다.
- * `Dispatchers.IO`에서 실행되며 Kotlin 코루틴 구조적 동시성을 활용한다.
+ * Graph reads stay in the caller coroutine context while blocking file writes
+ * are isolated on [Dispatchers.IO].
  *
  * ```kotlin
  * val exporter = SuspendCsvGraphBulkExporter()
@@ -34,7 +34,7 @@ import kotlinx.coroutines.withContext
  * val report = coroutineScope {
  *     exporter.exportGraphSuspending(sink, suspendOps, GraphExportOptions(vertexLabels = setOf("Person")))
  * }
- * println("exported ${report.verticesWritten} vertices — ${report.status}")
+ * println("exported ${report.verticesWritten} vertices - ${report.status}")
  * ```
  */
 class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink> {
@@ -50,7 +50,7 @@ class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink>
         operations: GraphSuspendOperations,
         options: GraphExportOptions = GraphExportOptions(),
         csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
-    ): GraphExportReport = withContext(Dispatchers.IO) {
+    ): GraphExportReport {
         log.debug { "Starting CSV export (suspend): vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }
         val watch = GraphIoStopwatch()
         val codec = CsvRecordCodec(csvOptions.propertyMode)
@@ -66,20 +66,22 @@ class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink>
         }
         val vHeader = codec.unionVertexHeader(allVertices)
         val prefix = (csvOptions.propertyMode as? CsvPropertyMode.PrefixedColumns)?.prefix ?: ""
-        GraphIoPaths.openWriter(sink.vertices).use { w ->
-            val csv = CsvRecordWriter(w)
-            csv.writeHeaders(vHeader)
-            for (v in allVertices) {
-                val row = buildList<Any?> {
-                    add(v.externalId)
-                    add(v.label)
-                    vHeader.drop(2).forEach { col ->
-                        val key = col.removePrefix(prefix)
-                        add(v.properties[key]?.toString() ?: "")
+        withContext(Dispatchers.IO) {
+            GraphIoPaths.openWriter(sink.vertices).use { w ->
+                val csv = CsvRecordWriter(w)
+                csv.writeHeaders(vHeader)
+                for (v in allVertices) {
+                    val row = buildList<Any?> {
+                        add(v.externalId)
+                        add(v.label)
+                        vHeader.drop(2).forEach { col ->
+                            val key = col.removePrefix(prefix)
+                            add(v.properties[key]?.toString() ?: "")
+                        }
                     }
+                    csv.writeRow(row)
+                    vWritten++
                 }
-                csv.writeRow(row)
-                vWritten++
             }
         }
 
@@ -90,27 +92,29 @@ class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink>
             }
         }
         val eHeader = codec.unionEdgeHeader(allEdges)
-        GraphIoPaths.openWriter(sink.edges).use { w ->
-            val csv = CsvRecordWriter(w)
-            csv.writeHeaders(eHeader)
-            for (ed in allEdges) {
-                val row = buildList<Any?> {
-                    add(ed.externalId ?: "")
-                    add(ed.label)
-                    add(ed.fromExternalId)
-                    add(ed.toExternalId)
-                    eHeader.drop(4).forEach { col ->
-                        val key = col.removePrefix(prefix)
-                        add(ed.properties[key]?.toString() ?: "")
+        withContext(Dispatchers.IO) {
+            GraphIoPaths.openWriter(sink.edges).use { w ->
+                val csv = CsvRecordWriter(w)
+                csv.writeHeaders(eHeader)
+                for (ed in allEdges) {
+                    val row = buildList<Any?> {
+                        add(ed.externalId ?: "")
+                        add(ed.label)
+                        add(ed.fromExternalId)
+                        add(ed.toExternalId)
+                        eHeader.drop(4).forEach { col ->
+                            val key = col.removePrefix(prefix)
+                            add(ed.properties[key]?.toString() ?: "")
+                        }
                     }
+                    csv.writeRow(row)
+                    eWritten++
                 }
-                csv.writeRow(row)
-                eWritten++
             }
         }
 
         val status = if (failures.isEmpty()) GraphIoStatus.COMPLETED else GraphIoStatus.PARTIAL
-        GraphExportReport(
+        return GraphExportReport(
             status = status,
             format = GraphIoFormat.CSV,
             verticesWritten = vWritten,

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkImporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkImporter.kt
@@ -25,10 +25,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * CSV 코루틴(suspend) 벌크 임포터.
+ * Coroutine bulk importer for CSV graph data.
  *
- * [SuspendCsvRecordReader]로 정점과 간선을 Flow로 스트리밍하여 처리하는 2-패스 방식이다.
- * Kotlin 코루틴 구조적 동시성을 활용하며 `Dispatchers.IO`에서 실행된다.
+ * The CSV reader performs blocking file reads on [Dispatchers.IO]. Batched
+ * graph writes stay in the caller coroutine context so backend implementations
+ * keep control over their own dispatcher policy.
  *
  * ```kotlin
  * val importer = SuspendCsvGraphBulkImporter()
@@ -37,7 +38,7 @@ import kotlinx.coroutines.withContext
  *     edges    = GraphImportSource.PathSource(Paths.get("edges.csv")),
  * )
  * val report = importer.importGraphSuspending(source, suspendOps, GraphImportOptions())
- * println("imported ${report.verticesCreated} vertices — ${report.status}")
+ * println("imported ${report.verticesCreated} vertices - ${report.status}")
  * ```
  */
 class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSource> {
@@ -53,7 +54,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
         operations: GraphSuspendOperations,
         options: GraphImportOptions = GraphImportOptions(),
         csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
-    ): GraphImportReport = withContext(Dispatchers.IO) {
+    ): GraphImportReport {
         log.debug { "Starting CSV import (suspend): defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }
         val watch = GraphIoStopwatch()
         val codec = CsvRecordCodec(csvOptions.propertyMode)
@@ -70,7 +71,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
 
         // --- 정점 패스 ---
         SuspendCsvRecordReader().read(
-            GraphIoPaths.openInputStream(source.vertices),
+            withContext(Dispatchers.IO) { GraphIoPaths.openInputStream(source.vertices) },
             skipHeaders = true,
         ) { it }.collect { record ->
             if (status == GraphIoStatus.FAILED) return@collect
@@ -110,7 +111,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
 
         if (status == GraphIoStatus.FAILED) {
             log.warn { "CSV import (suspend) failed during vertex pass: vertices=$verticesCreated/$verticesRead, elapsed=${watch.elapsed()}" }
-            return@withContext buildReport(
+            return buildReport(
                 watch, failures, GraphIoStatus.FAILED,
                 verticesRead, verticesCreated, edgesRead, edgesCreated, skippedVertices, skippedEdges
             )
@@ -120,7 +121,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
 
         // --- 엣지 패스 ---
         SuspendCsvRecordReader().read(
-            GraphIoPaths.openInputStream(source.edges),
+            withContext(Dispatchers.IO) { GraphIoPaths.openInputStream(source.edges) },
             skipHeaders = true,
         ) { it }.collect { record ->
             if (status == GraphIoStatus.FAILED) return@collect
@@ -170,7 +171,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
             edgesCreated += batchWriter.flushEdges()
         }
 
-        buildReport(
+        return buildReport(
             watch, failures, status,
             verticesRead, verticesCreated, edgesRead, edgesCreated, skippedVertices, skippedEdges
         ).also {

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvGraphIoOptionsTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvGraphIoOptionsTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.graph.io.csv
 
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -18,11 +18,11 @@ class CsvGraphIoOptionsTest {
 
     @Test
     fun `prefixed prefix must not be blank`() {
-        invoking { CsvPropertyMode.PrefixedColumns(" ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CsvPropertyMode.PrefixedColumns(" ") }
     }
 
     @Test
     fun `raw json column name must not be blank`() {
-        invoking { CsvPropertyMode.RawJsonColumn(" ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CsvPropertyMode.RawJsonColumn(" ") }
     }
 }

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvSuspendRoundTripTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvSuspendRoundTripTest.kt
@@ -5,13 +5,23 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.model.BatchEdge
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import java.util.Collections
+import java.util.concurrent.Executors
 
 class CsvSuspendRoundTripTest {
 
@@ -45,5 +55,84 @@ class CsvSuspendRoundTripTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend csv graph operations stay on caller dispatcher`(@TempDir dir: Path) {
+        val dispatcher = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "csv-graph-caller")
+        }.asCoroutineDispatcher()
+
+        try {
+            runBlocking(dispatcher) {
+                val vOut = dir.resolve("caller-v.csv")
+                val eOut = dir.resolve("caller-e.csv")
+
+                val sourceOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations())
+                val alice = sourceOps.createVertex("Person", mapOf("name" to "Alice"))
+                val bob = sourceOps.createVertex("Person", mapOf("name" to "Bob"))
+                sourceOps.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to "2024"))
+                sourceOps.clear()
+
+                SuspendCsvGraphBulkExporter().exportGraphSuspending(
+                    CsvGraphExportSink(GraphExportSink.PathSink(vOut), GraphExportSink.PathSink(eOut)),
+                    sourceOps,
+                    GraphExportOptions(vertexLabels = setOf("Person"), edgeLabels = setOf("KNOWS")),
+                )
+
+                sourceOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                sourceOps.recordedThreads.all { it.startsWith("csv-graph-caller") }.shouldBeTrue()
+
+                val targetOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations())
+                SuspendCsvGraphBulkImporter().importGraphSuspending(
+                    CsvGraphImportSource(GraphImportSource.PathSource(vOut), GraphImportSource.PathSource(eOut)),
+                    targetOps,
+                    GraphImportOptions(),
+                )
+
+                targetOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                targetOps.recordedThreads.all { it.startsWith("csv-graph-caller") }.shouldBeTrue()
+            }
+        } finally {
+            dispatcher.close()
+        }
+    }
+
+    private class ThreadRecordingSuspendOperations(
+        private val delegate: GraphSuspendOperations,
+    ): GraphSuspendOperations by delegate {
+
+        val recordedThreads: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+        fun clear() {
+            recordedThreads.clear()
+        }
+
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
+            record()
+            return delegate.findVerticesByLabel(label, filter)
+        }
+
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> {
+            record()
+            return delegate.findEdgesByLabel(label, filter)
+        }
+
+        override suspend fun createVertices(
+            label: String,
+            propertiesList: List<Map<String, Any?>>,
+        ): List<GraphVertex> {
+            record()
+            return delegate.createVertices(label, propertiesList)
+        }
+
+        override suspend fun createEdges(label: String, edges: List<BatchEdge>): List<GraphEdge> {
+            record()
+            return delegate.createEdges(label, edges)
+        }
+
+        private fun record() {
+            recordedThreads.add(Thread.currentThread().name)
+        }
     }
 }

--- a/graph-io/graphml/README.ko.md
+++ b/graph-io/graphml/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-graphml
 
+[English](README.md) | 한국어
+
 StAX 스트리밍 파서를 이용한 GraphML (XML) 대량 임포터 및 익스포터.
 
 ## 개요

--- a/graph-io/graphml/README.md
+++ b/graph-io/graphml/README.md
@@ -1,5 +1,7 @@
 # graph-io-graphml
 
+English | [한국어](README.ko.md)
+
 GraphML (XML) bulk importer and exporter using StAX streaming parser for efficient memory usage and performance.
 
 ## Overview

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkExporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkExporter.kt
@@ -20,11 +20,10 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
 /**
- * GraphML 코루틴(suspend) 벌크 익스포터.
- * Flow로 정점/간선을 수집한 뒤 StAX 라이터로 XML 파일에 기록한다.
- */
-/**
  * Coroutine bulk exporter for GraphML.
+ *
+ * Graph reads stay in the caller coroutine context while blocking StAX writes
+ * are isolated on [Dispatchers.IO].
  *
  * Example:
  *
@@ -57,7 +56,7 @@ class SuspendGraphMlBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
         operations: GraphSuspendOperations,
         options: GraphExportOptions = GraphExportOptions(),
         graphMlOptions: GraphMlExportOptions = GraphMlExportOptions(),
-    ): GraphExportReport = withContext(Dispatchers.IO) {
+    ): GraphExportReport {
         log.debug { "Starting GRAPHML suspend export" }
         val watch = GraphIoStopwatch()
         val failures = mutableListOf<GraphIoFailure>()
@@ -73,11 +72,13 @@ class SuspendGraphMlBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
             }
         }
 
-        GraphIoPaths.openOutputStream(sink).use { output ->
-            writer.write(output, vertices, edges, graphMlOptions)
+        withContext(Dispatchers.IO) {
+            GraphIoPaths.openOutputStream(sink).use { output ->
+                writer.write(output, vertices, edges, graphMlOptions)
+            }
         }
 
-        GraphExportReport(
+        return GraphExportReport(
             status = if (failures.isEmpty()) GraphIoStatus.COMPLETED else GraphIoStatus.PARTIAL,
             format = GraphIoFormat.GRAPHML,
             verticesWritten = vertices.size.toLong(),

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
@@ -27,8 +27,9 @@ import kotlinx.coroutines.withContext
 /**
  * Coroutine bulk importer for GraphML.
  *
- * StAX parsing runs on [Dispatchers.IO], and vertex/edge creation is delegated
- * to the provided suspend graph operations.
+ * StAX parsing runs on [Dispatchers.IO]. Vertex and edge creation stays in the
+ * caller coroutine context so backend implementations keep control over their
+ * own dispatcher policy.
  *
  * Example:
  *
@@ -61,11 +62,13 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
         operations: GraphSuspendOperations,
         options: GraphImportOptions = GraphImportOptions(),
         graphMlOptions: GraphMlImportOptions = GraphMlImportOptions(),
-    ): GraphImportReport = withContext(Dispatchers.IO) {
+    ): GraphImportReport {
         log.debug { "Starting GRAPHML suspend import" }
         val watch = GraphIoStopwatch()
 
-        val parsed = GraphIoPaths.openInputStream(source).use { reader.read(it, graphMlOptions) }
+        val parsed = withContext(Dispatchers.IO) {
+            GraphIoPaths.openInputStream(source).use { reader.read(it, graphMlOptions) }
+        }
 
         val idMap = GraphIoExternalIdMap(options.onDuplicateVertexId)
         val batchWriter = SuspendGraphIoBatchWriter(operations, options.batchSize)
@@ -84,7 +87,7 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
         }
 
         if (status == GraphIoStatus.FAILED) {
-            return@withContext GraphImportReport(
+            return GraphImportReport(
                 status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures
             )
         }
@@ -153,7 +156,7 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
             ec += batchWriter.flushEdges()
         }
 
-        GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
+        return GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
             .also { log.debug { "Suspend import completed: vertices=$vc/$vr, edges=$ec/$er, status=$status" } }
     }
 

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
@@ -123,13 +123,22 @@ internal class StaxGraphMlReader {
 
         var label = options.defaultVertexLabel
         val props = mutableMapOf<String, Any?>()
-        for ((keyId, rawValue) in dataMap) {
+        for ((keyId, data) in dataMap) {
             val attrName = keyIdToName[keyId] ?: keyId
             val attrType = keyIdToType[keyId] ?: GraphMlAttrType.STRING
             if (attrName == options.labelAttrName) {
-                label = rawValue
+                label = data.value
             } else {
-                props[attrName] = attrType.coerce(rawValue)
+                coerceDataValue(
+                    attrType = attrType,
+                    rawValue = data.value,
+                    phase = GraphIoPhase.READ_VERTEX,
+                    elementName = "node",
+                    recordId = nodeId,
+                    columnName = attrName,
+                    location = data.location,
+                    failures = failures,
+                )?.let { props[attrName] = it }
             }
         }
         vertices += GraphIoVertexRecord(externalId = nodeId, label = label, properties = props)
@@ -169,13 +178,22 @@ internal class StaxGraphMlReader {
 
         var label = options.defaultEdgeLabel
         val props = mutableMapOf<String, Any?>()
-        for ((keyId, rawValue) in dataMap) {
+        for ((keyId, data) in dataMap) {
             val attrName = keyIdToName[keyId] ?: keyId
             val attrType = keyIdToType[keyId] ?: GraphMlAttrType.STRING
             if (attrName == options.labelAttrName) {
-                label = rawValue
+                label = data.value
             } else {
-                props[attrName] = attrType.coerce(rawValue)
+                coerceDataValue(
+                    attrType = attrType,
+                    rawValue = data.value,
+                    phase = GraphIoPhase.READ_EDGE,
+                    elementName = "edge",
+                    recordId = edgeId,
+                    columnName = attrName,
+                    location = data.location,
+                    failures = failures,
+                )?.let { props[attrName] = it }
             }
         }
         edges += GraphIoEdgeRecord(
@@ -187,21 +205,51 @@ internal class StaxGraphMlReader {
         )
     }
 
+    private fun coerceDataValue(
+        attrType: GraphMlAttrType,
+        rawValue: String,
+        phase: GraphIoPhase,
+        elementName: String,
+        recordId: String?,
+        columnName: String,
+        location: String?,
+        failures: MutableList<GraphIoFailure>,
+    ): Any? {
+        val coerced = attrType.coerce(rawValue)
+        if (attrType != GraphMlAttrType.STRING && coerced == rawValue) {
+            failures += GraphIoFailure(
+                phase = phase,
+                severity = GraphIoFailureSeverity.ERROR,
+                location = location,
+                fileRole = GraphIoFileRole.UNIFIED,
+                recordId = recordId,
+                columnName = columnName,
+                elementName = elementName,
+                message = "Invalid GraphML ${attrType.xmlName} value for '$columnName': $rawValue",
+            )
+            return null
+        }
+        return coerced
+    }
+
     /** 현재 요소의 `<data key="...">text</data>` 자식들을 읽어 keyId→value 맵으로 반환한다. */
     private fun readDataChildren(
         reader: XMLStreamReader,
         parentLocalName: String,
         options: GraphMlImportOptions,
         failures: MutableList<GraphIoFailure>,
-    ): Map<String, String> {
-        val result = mutableMapOf<String, String>()
+    ): Map<String, GraphMlDataValue> {
+        val result = mutableMapOf<String, GraphMlDataValue>()
         while (reader.hasNext()) {
             when (reader.next()) {
                 XMLStreamConstants.START_ELEMENT -> {
                     if (reader.localName == "data") {
                         val key = reader.getAttributeValue(null, "key") ?: continue
+                        val location = reader.location.lineNumber
+                            .takeIf { it > 0 }
+                            ?.let { "line:$it" }
                         val value = reader.elementText ?: ""
-                        result[key] = value
+                        result[key] = GraphMlDataValue(value, location)
                     } else {
                         when (reader.localName) {
                             "graph" -> recordUnsupportedElement(
@@ -219,6 +267,11 @@ internal class StaxGraphMlReader {
         }
         return result
     }
+
+    private data class GraphMlDataValue(
+        val value: String,
+        val location: String?,
+    )
 
     private fun skipElement(reader: XMLStreamReader, localName: String) {
         var depth = 1

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlSuspendTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlSuspendTest.kt
@@ -5,13 +5,23 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.model.BatchEdge
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import java.util.Collections
+import java.util.concurrent.Executors
 
 class GraphMlSuspendTest {
 
@@ -44,5 +54,83 @@ class GraphMlSuspendTest {
         importReport.status shouldBeEqualTo GraphIoStatus.COMPLETED
         importReport.verticesCreated shouldBeEqualTo 2L
         importReport.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend graphml graph operations stay on caller dispatcher`(@TempDir dir: Path) {
+        val dispatcher = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "graphml-graph-caller")
+        }.asCoroutineDispatcher()
+
+        try {
+            runBlocking(dispatcher) {
+                val out = dir.resolve("caller.graphml")
+
+                val sourceOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations())
+                val alice = sourceOps.createVertex("Product", mapOf("name" to "Widget"))
+                val bob = sourceOps.createVertex("Product", mapOf("name" to "Gadget"))
+                sourceOps.createEdge(alice.id, bob.id, "SIMILAR", mapOf("score" to 0.8))
+                sourceOps.clear()
+
+                SuspendGraphMlBulkExporter().exportGraphSuspending(
+                    GraphExportSink.PathSink(out),
+                    sourceOps,
+                    GraphExportOptions(vertexLabels = setOf("Product"), edgeLabels = setOf("SIMILAR")),
+                )
+
+                sourceOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                sourceOps.recordedThreads.all { it.startsWith("graphml-graph-caller") }.shouldBeTrue()
+
+                val targetOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations(TinkerGraphOperations()))
+                SuspendGraphMlBulkImporter().importGraphSuspending(
+                    GraphImportSource.PathSource(out),
+                    targetOps,
+                    GraphImportOptions(),
+                )
+
+                targetOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                targetOps.recordedThreads.all { it.startsWith("graphml-graph-caller") }.shouldBeTrue()
+            }
+        } finally {
+            dispatcher.close()
+        }
+    }
+
+    private class ThreadRecordingSuspendOperations(
+        private val delegate: GraphSuspendOperations,
+    ): GraphSuspendOperations by delegate {
+
+        val recordedThreads: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+        fun clear() {
+            recordedThreads.clear()
+        }
+
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
+            record()
+            return delegate.findVerticesByLabel(label, filter)
+        }
+
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> {
+            record()
+            return delegate.findEdgesByLabel(label, filter)
+        }
+
+        override suspend fun createVertices(
+            label: String,
+            propertiesList: List<Map<String, Any?>>,
+        ): List<GraphVertex> {
+            record()
+            return delegate.createVertices(label, propertiesList)
+        }
+
+        override suspend fun createEdges(label: String, edges: List<BatchEdge>): List<GraphEdge> {
+            record()
+            return delegate.createEdges(label, edges)
+        }
+
+        private fun record() {
+            recordedThreads.add(Thread.currentThread().name)
+        }
     }
 }

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
@@ -141,6 +141,57 @@ class StaxGraphMlReaderWriterTest {
     }
 
     @Test
+    fun `reader records errors for invalid typed data values`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <key id="age" for="node" attr.name="age" attr.type="int"/>
+  <key id="score" for="edge" attr.name="score" attr.type="double"/>
+  <graph id="G" edgedefault="directed">
+    <node id="n1"><data key="age">not-an-int</data></node>
+    <node id="n2"><data key="age">42</data></node>
+    <edge id="e1" source="n1" target="n2"><data key="score">not-a-double</data></edge>
+  </graph>
+</graphml>"""
+
+        val result = reader.read(ByteArrayInputStream(xml.toByteArray()))
+
+        result.vertices shouldHaveSize 2
+        result.edges shouldHaveSize 1
+        result.failures shouldHaveSize 2
+        result.failures.map { it.severity }.toSet() shouldBeEqualTo setOf(GraphIoFailureSeverity.ERROR)
+        result.failures.map { it.columnName } shouldContain "age"
+        result.failures.map { it.columnName } shouldContain "score"
+        result.failures.map { it.message } shouldContain "Invalid GraphML int value for 'age': not-an-int"
+        result.failures.map { it.message } shouldContain "Invalid GraphML double value for 'score': not-a-double"
+        result.vertices[0].properties.containsKey("age") shouldBeEqualTo false
+        result.vertices[1].properties["age"] shouldBeEqualTo 42
+        result.edges[0].properties.containsKey("score") shouldBeEqualTo false
+    }
+
+    @Test
+    fun `bulk importer fails before writes for invalid typed data values`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <key id="age" for="node" attr.name="age" attr.type="int"/>
+  <graph id="G" edgedefault="directed">
+    <node id="n1"><data key="age">not-an-int</data></node>
+  </graph>
+</graphml>"""
+
+        val report = GraphMlBulkImporter().importGraph(
+            GraphImportSource.InputStreamSource(ByteArrayInputStream(xml.toByteArray()), closeInput = true),
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.verticesRead shouldBeEqualTo 1L
+        report.verticesCreated shouldBeEqualTo 0L
+        report.failures shouldHaveSize 1
+        report.failures.single().columnName shouldBeEqualTo "age"
+    }
+
+    @Test
     fun `reader records warnings for unsupported graphml fixture with SKIP policy`() {
         val result = fixture("unsupported-constructs.graphml").use { reader.read(it) }
 

--- a/graph-io/jackson2/README.ko.md
+++ b/graph-io/jackson2/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-jackson2
 
+[English](README.md) | 한국어
+
 Jackson 2.x를 사용한 NDJSON(Newline-Delimited JSON) 그래프 데이터 벌크 임포터/익스포터.
 
 ## 개요

--- a/graph-io/jackson2/README.md
+++ b/graph-io/jackson2/README.md
@@ -1,5 +1,7 @@
 # graph-io-jackson2
 
+English | [한국어](README.ko.md)
+
 Jackson 2.x NDJSON (Newline-Delimited JSON) bulk importer and exporter for graph database operations.
 
 ## Overview

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
@@ -24,7 +24,11 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CancellationException
 
 /**
  * Coroutine NDJSON bulk importer backed by Jackson 2.
@@ -63,56 +67,98 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         var vr = 0L; var vc = 0L; var er = 0L; var ec = 0L; var sv = 0L; var se = 0L
         var status = GraphIoStatus.COMPLETED
 
-        val lines = withContext(Dispatchers.IO) {
-            GraphIoPaths.openReader(source).use { it.readLines() }
-        }
-
-        for ((index, raw) in lines.withIndex()) {
-            if (status == GraphIoStatus.FAILED) break
-            val lineNo = index + 1
-            val line = raw.trim().ifBlank { continue }
-            val env = runCatching { codec.parseLine(line) }.getOrElse { e ->
-                log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
-                failures += GraphIoFailure(
-                    phase = GraphIoPhase.READ_VERTEX,
-                    fileRole = GraphIoFileRole.UNIFIED,
-                    location = "line:$lineNo",
-                    message = "Malformed JSON: ${e.message}",
-                )
-                status = GraphIoStatus.FAILED
-                break
-            }
-            when (env.type) {
-                NdJsonEnvelope.TYPE_VERTEX -> {
-                    vr++
-                    val rec = codec.toVertex(env, options.defaultVertexLabel)
-                    val props = options.preserveExternalIdProperty
-                        ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
-                    when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
-                        GraphIoExternalIdMap.PutResult.CREATED -> {
-                            vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+        val coroutineContext = currentCoroutineContext()
+        val reader = withContext(Dispatchers.IO) { GraphIoPaths.openReader(source) }
+        try {
+            var lineNo = 0
+            while (status != GraphIoStatus.FAILED) {
+                coroutineContext.ensureActive()
+                val raw = withContext(Dispatchers.IO) { reader.readLine() } ?: break
+                lineNo++
+                val line = raw.trim().ifBlank { continue }
+                val env = try {
+                    codec.parseLine(line)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
+                    failures += GraphIoFailure(
+                        phase = GraphIoPhase.READ_VERTEX,
+                        fileRole = GraphIoFileRole.UNIFIED,
+                        location = "line:$lineNo",
+                        message = "Malformed JSON: ${e.message}",
+                    )
+                    status = GraphIoStatus.FAILED
+                    break
+                }
+                when (env.type) {
+                    NdJsonEnvelope.TYPE_VERTEX -> {
+                        val rec = try {
+                            codec.toVertex(env, options.defaultVertexLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_VERTEX,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid vertex envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
                         }
-                        GraphIoExternalIdMap.PutResult.SKIPPED -> {
-                            sv++
-                            status = GraphIoStatus.PARTIAL
+                        vr++
+                        val props = options.preserveExternalIdProperty
+                            ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
+                        when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
+                            GraphIoExternalIdMap.PutResult.CREATED -> {
+                                vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+                            }
+                            GraphIoExternalIdMap.PutResult.SKIPPED -> {
+                                sv++
+                                status = GraphIoStatus.PARTIAL
+                            }
                         }
                     }
-                }
-                NdJsonEnvelope.TYPE_EDGE -> {
-                    er++
-                    bufferedEdges += codec.toEdge(env, options.defaultEdgeLabel)
-                    if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                    NdJsonEnvelope.TYPE_EDGE -> {
+                        val rec = try {
+                            codec.toEdge(env, options.defaultEdgeLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid edge envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
+                        }
+                        er++
+                        bufferedEdges += rec
+                        if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}; " +
+                                    "verticesCreated=$vc remain in graph as partial state",
+                            )
+                            status = GraphIoStatus.FAILED
+                        }
+                    }
+                    else -> {
                         failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
+                            phase = GraphIoPhase.READ_VERTEX,
+                            severity = GraphIoFailureSeverity.WARN,
                             fileRole = GraphIoFileRole.UNIFIED,
                             location = "line:$lineNo",
-                            message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}",
+                            message = "Unknown envelope type=${env.type}",
                         )
-                        status = GraphIoStatus.FAILED
+                        status = GraphIoStatus.PARTIAL
                     }
                 }
-                else -> {}
             }
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) { reader.close() }
         }
 
         vc += batchWriter.flushVertices(idMap)
@@ -143,6 +189,13 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
                     MissingEndpointPolicy.SKIP_EDGE -> {
                         se++
                         status = GraphIoStatus.PARTIAL
+                        failures += GraphIoFailure(
+                            phase = GraphIoPhase.READ_EDGE,
+                            severity = GraphIoFailureSeverity.WARN,
+                            fileRole = GraphIoFileRole.UNIFIED,
+                            recordId = e.externalId,
+                            message = "Missing endpoint skipped from=${e.fromExternalId} to=${e.toExternalId}",
+                        )
                         continue
                     }
                 }

--- a/graph-io/jackson2/src/test/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2SuspendTest.kt
+++ b/graph-io/jackson2/src/test/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2SuspendTest.kt
@@ -6,10 +6,12 @@ import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 
 class Jackson2SuspendTest {
@@ -38,5 +40,21 @@ class Jackson2SuspendTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend importer reports invalid vertex envelope`(@TempDir dir: Path) = runTest {
+        val input = dir.resolve("invalid-vertex.ndjson")
+        Files.writeString(input, """{"type":"vertex","label":"Person"}""" + "\n")
+
+        val report = SuspendJackson2NdJsonBulkImporter().importGraphSuspending(
+            GraphImportSource.PathSource(input),
+            TinkerGraphSuspendOperations(),
+            GraphImportOptions(),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.failures.single().location shouldBeEqualTo "line:1"
+        report.failures.single().message shouldContain "missing id"
     }
 }

--- a/graph-io/jackson3/README.ko.md
+++ b/graph-io/jackson3/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-jackson3
 
+[English](README.md) | 한국어
+
 Bluetape4k 그래프 연산을 위한 Jackson 3.x 기반 NDJSON 벌크 임포터/익스포터.
 
 ## 개요

--- a/graph-io/jackson3/README.md
+++ b/graph-io/jackson3/README.md
@@ -1,5 +1,7 @@
 # graph-io-jackson3
 
+English | [한국어](README.ko.md)
+
 Jackson 3.x based NDJSON bulk importer and exporter for Bluetape4k graph operations.
 
 ## Overview

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
@@ -24,7 +24,11 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CancellationException
 
 /**
  * Coroutine NDJSON bulk importer backed by Jackson 3.
@@ -63,56 +67,98 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         var vr = 0L; var vc = 0L; var er = 0L; var ec = 0L; var sv = 0L; var se = 0L
         var status = GraphIoStatus.COMPLETED
 
-        val lines = withContext(Dispatchers.IO) {
-            GraphIoPaths.openReader(source).use { it.readLines() }
-        }
-
-        for ((index, raw) in lines.withIndex()) {
-            if (status == GraphIoStatus.FAILED) break
-            val lineNo = index + 1
-            val line = raw.trim().ifBlank { continue }
-            val env = runCatching { codec.parseLine(line) }.getOrElse { e ->
-                log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
-                failures += GraphIoFailure(
-                    phase = GraphIoPhase.READ_VERTEX,
-                    fileRole = GraphIoFileRole.UNIFIED,
-                    location = "line:$lineNo",
-                    message = "Malformed JSON: ${e.message}",
-                )
-                status = GraphIoStatus.FAILED
-                break
-            }
-            when (env.type) {
-                NdJsonEnvelope.TYPE_VERTEX -> {
-                    vr++
-                    val rec = codec.toVertex(env, options.defaultVertexLabel)
-                    val props = options.preserveExternalIdProperty
-                        ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
-                    when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
-                        GraphIoExternalIdMap.PutResult.CREATED -> {
-                            vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+        val coroutineContext = currentCoroutineContext()
+        val reader = withContext(Dispatchers.IO) { GraphIoPaths.openReader(source) }
+        try {
+            var lineNo = 0
+            while (status != GraphIoStatus.FAILED) {
+                coroutineContext.ensureActive()
+                val raw = withContext(Dispatchers.IO) { reader.readLine() } ?: break
+                lineNo++
+                val line = raw.trim().ifBlank { continue }
+                val env = try {
+                    codec.parseLine(line)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
+                    failures += GraphIoFailure(
+                        phase = GraphIoPhase.READ_VERTEX,
+                        fileRole = GraphIoFileRole.UNIFIED,
+                        location = "line:$lineNo",
+                        message = "Malformed JSON: ${e.message}",
+                    )
+                    status = GraphIoStatus.FAILED
+                    break
+                }
+                when (env.type) {
+                    NdJsonEnvelope.TYPE_VERTEX -> {
+                        val rec = try {
+                            codec.toVertex(env, options.defaultVertexLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_VERTEX,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid vertex envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
                         }
-                        GraphIoExternalIdMap.PutResult.SKIPPED -> {
-                            sv++
-                            status = GraphIoStatus.PARTIAL
+                        vr++
+                        val props = options.preserveExternalIdProperty
+                            ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
+                        when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
+                            GraphIoExternalIdMap.PutResult.CREATED -> {
+                                vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+                            }
+                            GraphIoExternalIdMap.PutResult.SKIPPED -> {
+                                sv++
+                                status = GraphIoStatus.PARTIAL
+                            }
                         }
                     }
-                }
-                NdJsonEnvelope.TYPE_EDGE -> {
-                    er++
-                    bufferedEdges += codec.toEdge(env, options.defaultEdgeLabel)
-                    if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                    NdJsonEnvelope.TYPE_EDGE -> {
+                        val rec = try {
+                            codec.toEdge(env, options.defaultEdgeLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid edge envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
+                        }
+                        er++
+                        bufferedEdges += rec
+                        if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}; " +
+                                    "verticesCreated=$vc remain in graph as partial state",
+                            )
+                            status = GraphIoStatus.FAILED
+                        }
+                    }
+                    else -> {
                         failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
+                            phase = GraphIoPhase.READ_VERTEX,
+                            severity = GraphIoFailureSeverity.WARN,
                             fileRole = GraphIoFileRole.UNIFIED,
                             location = "line:$lineNo",
-                            message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}",
+                            message = "Unknown envelope type=${env.type}",
                         )
-                        status = GraphIoStatus.FAILED
+                        status = GraphIoStatus.PARTIAL
                     }
                 }
-                else -> {}
             }
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) { reader.close() }
         }
 
         vc += batchWriter.flushVertices(idMap)
@@ -143,6 +189,13 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
                     MissingEndpointPolicy.SKIP_EDGE -> {
                         se++
                         status = GraphIoStatus.PARTIAL
+                        failures += GraphIoFailure(
+                            phase = GraphIoPhase.READ_EDGE,
+                            severity = GraphIoFailureSeverity.WARN,
+                            fileRole = GraphIoFileRole.UNIFIED,
+                            recordId = e.externalId,
+                            message = "Missing endpoint skipped from=${e.fromExternalId} to=${e.toExternalId}",
+                        )
                         continue
                     }
                 }

--- a/graph-io/jackson3/src/test/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3SuspendTest.kt
+++ b/graph-io/jackson3/src/test/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3SuspendTest.kt
@@ -6,10 +6,12 @@ import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 
 class Jackson3SuspendTest {
@@ -38,5 +40,21 @@ class Jackson3SuspendTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend importer reports invalid vertex envelope`(@TempDir dir: Path) = runTest {
+        val input = dir.resolve("invalid-vertex.ndjson")
+        Files.writeString(input, """{"type":"vertex","label":"Person"}""" + "\n")
+
+        val report = SuspendJackson3NdJsonBulkImporter().importGraphSuspending(
+            GraphImportSource.PathSource(input),
+            TinkerGraphSuspendOperations(),
+            GraphImportOptions(),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.failures.single().location shouldBeEqualTo "line:1"
+        report.failures.single().message shouldContain "missing id"
     }
 }

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
@@ -89,17 +89,24 @@ object GraphIoOkioPaths : KLogging() {
      * @throws IOException when the path cannot be opened for writing
      */
     @Throws(IOException::class)
-    fun openSink(sink: OkioGraphExportSink): BufferedSink = when (sink) {
+    fun openSink(sink: OkioGraphExportSink): BufferedSink =
+        openSinkHandle(sink).sink
+
+    private fun openSinkHandle(sink: OkioGraphExportSink): OpenedSink = when (sink) {
         is OkioGraphExportSink.PathSink -> openPathSink(sink)
 
         is OkioGraphExportSink.SinkBased ->
-            if (sink.ownsSink) sink.sink.buffer()
-            else nonClosingSink(sink.sink).buffer()
+            OpenedSink(
+                if (sink.ownsSink) sink.sink.buffer()
+                else nonClosingSink(sink.sink).buffer()
+            )
 
         is OkioGraphExportSink.OutputStreamBased -> {
             val rawSink = sink.outputStream.sink()
-            if (sink.ownsStream) rawSink.buffer()
-            else nonClosingSink(rawSink).buffer()
+            OpenedSink(
+                if (sink.ownsStream) rawSink.buffer()
+                else nonClosingSink(rawSink).buffer()
+            )
         }
     }
 
@@ -192,10 +199,12 @@ object GraphIoOkioPaths : KLogging() {
      */
     @Throws(IOException::class)
     fun openGzipSink(sink: OkioGraphExportSink): BufferedSink {
-        val bs = openSink(sink)
+        val opened = openSinkHandle(sink)
+        val bs = opened.sink
         return try {
             openCompressedSink(bs, Compressor.GZIP)
         } catch (e: Throwable) {
+            opened.abort()
             try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip init failure" } }
             throw e
         }
@@ -213,10 +222,12 @@ object GraphIoOkioPaths : KLogging() {
         chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
         associatedData: ByteArray = ByteArray(0),
     ): BufferedSink {
-        val bs = openSink(sink)
+        val opened = openSinkHandle(sink)
+        val bs = opened.sink
         return try {
             openDaeadEncryptedSink(bs, daead, chunkSize, associatedData)
         } catch (e: Throwable) {
+            opened.abort()
             try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after DAEAD init failure" } }
             throw e
         }
@@ -234,11 +245,13 @@ object GraphIoOkioPaths : KLogging() {
         chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
         associatedData: ByteArray = ByteArray(0),
     ): BufferedSink {
-        val bs = openSink(sink)
+        val opened = openSinkHandle(sink)
+        val bs = opened.sink
         return try {
             val encrypted = openDaeadEncryptedSink(bs, daead, chunkSize, associatedData)
             openCompressedSink(encrypted, Compressor.GZIP)
         } catch (e: Throwable) {
+            opened.abort()
             try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip+DAEAD init failure" } }
             throw e
         }
@@ -311,7 +324,7 @@ object GraphIoOkioPaths : KLogging() {
 
     /** Opens a [OkioGraphExportSink.PathSink] and applies the atomic-write strategy when requested. */
     @Throws(IOException::class)
-    private fun openPathSink(sink: OkioGraphExportSink.PathSink): BufferedSink {
+    private fun openPathSink(sink: OkioGraphExportSink.PathSink): OpenedSink {
         val fs = sink.fileSystem
         val target = sink.path
 
@@ -326,7 +339,7 @@ object GraphIoOkioPaths : KLogging() {
         }
 
         if (!sink.atomicWrite) {
-            return fs.sink(target, mustCreate = false).buffer()
+            return OpenedSink(fs.sink(target, mustCreate = false).buffer())
         }
 
         // atomicWrite=true: temporary path, then atomicMove.
@@ -335,7 +348,11 @@ object GraphIoOkioPaths : KLogging() {
             ?: ("${target}.tmp.${UUID.randomUUID()}".toPath())
 
         val rawSink = fs.sink(tmpPath, mustCreate = false)
-        return AtomicMoveSink(rawSink, tmpPath, target, fs).buffer()
+        val atomicSink = AtomicMoveSink(rawSink, tmpPath, target, fs)
+        return OpenedSink(
+            sink = atomicSink.buffer(),
+            abort = atomicSink::abort,
+        )
     }
 
     /** Wrapper that does not close the underlying caller-owned source. */
@@ -372,6 +389,15 @@ object GraphIoOkioPaths : KLogging() {
         }
     }
 
+    private data class OpenedSink(
+        val sink: BufferedSink,
+        private val abort: (() -> Unit)? = null,
+    ) {
+        fun abort() {
+            abort?.invoke()
+        }
+    }
+
     /**
      * Sink wrapper that atomically moves a temporary file to the target path on close.
      *
@@ -385,6 +411,10 @@ object GraphIoOkioPaths : KLogging() {
     ) : ForwardingSink(delegate) {
         @Volatile
         private var failed = false
+
+        fun abort() {
+            failed = true
+        }
 
         override fun write(source: Buffer, byteCount: Long) {
             try {

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
@@ -167,6 +167,24 @@ class GraphIoOkioPathsTest {
     }
 
     @Test
+    fun `atomicWrite DAEAD setup failure leaves target unchanged and deletes tmp`() {
+        ensureTmpDir()
+        val path = "/tmp/graph-setup-fail.enc".toPath()
+        fakeFs.write(path) { writeUtf8("ORIGINAL") }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoOkioPaths.openDaeadEncryptedSink(
+                sink = OkioGraphExportSink.PathSink(path, fakeFs, atomicWrite = true),
+                daead = TinkDaeads.AES256_SIV,
+                chunkSize = 0,
+            )
+        }
+
+        fakeFs.read(path) { readUtf8() } shouldBeEqualTo "ORIGINAL"
+        tempFilesFor(path) shouldBeEqualTo emptyList()
+    }
+
+    @Test
     fun `gzip DAEAD chunk round trip with FakeFileSystem`() {
         ensureTmpDir()
         val path = "/tmp/graph.ndjson.gz.enc".toPath()
@@ -186,6 +204,24 @@ class GraphIoOkioPathsTest {
         ).use { bs -> bs.readUtf8() }
 
         result shouldBeEqualTo data.repeat(100)
+    }
+
+    @Test
+    fun `atomicWrite gzip DAEAD setup failure leaves target unchanged and deletes tmp`() {
+        ensureTmpDir()
+        val path = "/tmp/graph-setup-fail.ndjson.gz.enc".toPath()
+        fakeFs.write(path) { writeUtf8("ORIGINAL") }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoOkioPaths.openGzipDaeadEncryptedSink(
+                sink = OkioGraphExportSink.PathSink(path, fakeFs, atomicWrite = true),
+                daead = TinkDaeads.AES256_SIV,
+                chunkSize = 0,
+            )
+        }
+
+        fakeFs.read(path) { readUtf8() } shouldBeEqualTo "ORIGINAL"
+        tempFilesFor(path) shouldBeEqualTo emptyList()
     }
 
     @Test
@@ -274,4 +310,8 @@ class GraphIoOkioPathsTest {
 
         result shouldBeEqualTo data
     }
+
+    private fun tempFilesFor(path: okio.Path): List<okio.Path> =
+        fakeFs.list(path.parent ?: "/".toPath())
+            .filter { it.segments.last().startsWith("${path.segments.last()}.tmp.") }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
@@ -8,7 +8,7 @@ import io.bluetape4k.graph.model.MissingWeightPolicy
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.model.PathStep
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeNear
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldContainAll
@@ -167,7 +167,7 @@ class AStarRunnerTest {
 
     @Test
     fun `weightProperty 없으면 IllegalArgumentException 발생`() {
-        invoking { runner().run(id("A"), id("C"), PathOptions()) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { runner().run(id("A"), id("C"), PathOptions()) }
     }
 
     // ─── Direction.BOTH ───────────────────────────────────────────────────────────

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/DijkstraRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/DijkstraRunnerTest.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.graph.model.PathStep
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeNear
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldContainAll
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -170,7 +170,7 @@ class DijkstraRunnerTest {
 
     @Test
     fun `weightProperty가 null이면 IllegalArgumentException을 던진다`() {
-        invoking { runner().run(id("A"), id("C"), PathOptions()) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { runner().run(id("A"), id("C"), PathOptions()) }
     }
 
     // ─── fetchVertex mid-traversal null ──────────────────────────────────────────

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/WeightExtractorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/WeightExtractorTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.MissingWeightException
 import io.bluetape4k.graph.model.MissingWeightPolicy
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeNear
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -23,7 +23,7 @@ class WeightExtractorTest {
     @Test
     fun `Fail 정책 - 속성 없으면 MissingWeightException 발생`() {
         val extractor = WeightExtractor("cost", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge()) } shouldThrow MissingWeightException::class
+        assertFailsWith<MissingWeightException> { extractor.extract(edge()) }
     }
 
     @Test
@@ -97,47 +97,47 @@ class WeightExtractorTest {
     @Test
     fun `NaN weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to Double.NaN)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to Double.NaN)) }
     }
 
     @Test
     fun `양의 무한대 weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to Double.POSITIVE_INFINITY)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to Double.POSITIVE_INFINITY)) }
     }
 
     @Test
     fun `음수 weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to -1.0)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to -1.0)) }
     }
 
     @Test
     fun `0 weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to 0.0)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to 0.0)) }
     }
 
     @Test
     fun `String 비숫자 속성은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to "abc")) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to "abc")) }
     }
 
     // ─── MissingWeightPolicy 생성 ─────────────────────────────────────────────
 
     @Test
     fun `UseDefault value 0은 IllegalArgumentException`() {
-        invoking { MissingWeightPolicy.UseDefault(0.0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { MissingWeightPolicy.UseDefault(0.0) }
     }
 
     @Test
     fun `UseDefault value 음수는 IllegalArgumentException`() {
-        invoking { MissingWeightPolicy.UseDefault(-1.0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { MissingWeightPolicy.UseDefault(-1.0) }
     }
 
     @Test
     fun `UseDefault Infinity는 IllegalArgumentException`() {
-        invoking { MissingWeightPolicy.UseDefault(Double.POSITIVE_INFINITY) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { MissingWeightPolicy.UseDefault(Double.POSITIVE_INFINITY) }
     }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/CycleDetectorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/CycleDetectorTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.graph.algo.internal
 
 import io.bluetape4k.graph.model.GraphElementId
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
@@ -88,11 +88,11 @@ class CycleDetectorTest {
 
     @Test
     fun `maxDepth가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking { CycleDetector.findCycles(emptyMap(), maxDepth = 0, maxCycles = 1) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CycleDetector.findCycles(emptyMap(), maxDepth = 0, maxCycles = 1) }
     }
 
     @Test
     fun `maxCycles가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking { CycleDetector.findCycles(emptyMap(), maxDepth = 1, maxCycles = 0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CycleDetector.findCycles(emptyMap(), maxDepth = 1, maxCycles = 0) }
     }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculatorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculatorTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.graph.algo.internal
 
 import io.bluetape4k.graph.model.GraphElementId
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -72,30 +72,30 @@ class PageRankCalculatorTest {
 
     @Test
     fun `iterations가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), iterations = 0)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     @Test
     fun `dampingFactor가 1 초과이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), dampingFactor = 1.5)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     @Test
     fun `dampingFactor가 음수이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), dampingFactor = -0.1)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     @Test
     fun `tolerance가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), tolerance = 0.0)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     // ─── dangling node ────────────────────────────────────────────────────────────

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -113,7 +113,7 @@ class TinkerGraphOperations :
 
     override fun <T> transaction(block: GraphTransactionScope.() -> T): T =
         withTransactionGate {
-            synchronized(graph) {
+            writeLock.withLock {
                 val snapshot = snapshot()
                 try {
                     block(TinkerGraphTransactionScope(this))
@@ -136,12 +136,12 @@ class TinkerGraphOperations :
     }
 
     internal fun createTransactionSnapshot(): Any =
-        synchronized(graph) {
+        writeLock.withLock {
             snapshot()
         }
 
     internal fun restoreTransactionSnapshot(snapshot: Any) {
-        synchronized(graph) {
+        writeLock.withLock {
             restore(snapshot as TinkerGraphSnapshot)
         }
     }
@@ -277,7 +277,7 @@ class TinkerGraphOperations :
         setProperties: Map<String, Any?>,
     ): GraphVertex =
         withTransactionGate {
-            synchronized(graph) {
+            writeLock.withLock {
                 val properties = GraphMergeValidation.validateVertex(label, matchProperties, setProperties)
                 val traversal = g.V().hasLabel(label)
                 properties.matchProperties.forEach { (key, value) ->
@@ -426,7 +426,7 @@ class TinkerGraphOperations :
         setProperties: Map<String, Any?>,
     ): GraphEdge =
         withTransactionGate {
-            synchronized(graph) {
+            writeLock.withLock {
                 val properties = GraphMergeValidation.validateEdge(fromId, toId, label, matchProperties, setProperties)
                 val fromIdValue = fromId.value.toLongOrNull()
                     ?: throw GraphQueryException("Invalid fromId: ${fromId.value}")

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/AgeGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/AgeGraphPluginConfig.kt
@@ -33,13 +33,5 @@ fun GraphPluginConfig.age(
         backendName = "age",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("AgeGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("AgeGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/FalkorDBGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/FalkorDBGraphPluginConfig.kt
@@ -33,13 +33,5 @@ fun GraphPluginConfig.falkorDB(
         backendName = "falkorDB",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("FalkorDBGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("FalkorDBGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/MemgraphGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/MemgraphGraphPluginConfig.kt
@@ -34,13 +34,5 @@ fun GraphPluginConfig.memgraph(
         backendName = "memgraph",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("MemgraphGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("MemgraphGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/Neo4jGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/Neo4jGraphPluginConfig.kt
@@ -33,13 +33,5 @@ fun GraphPluginConfig.neo4j(
         backendName = "neo4j",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("Neo4jGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("Neo4jGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
+++ b/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
@@ -136,6 +136,40 @@ class GraphPluginTest {
     }
 
     @Test
+    fun `caller owned backend helper 는 close action 을 등록하지 않는다`() {
+        GraphPluginConfig()
+            .neo4j(mockk(), database = "neo4j")
+            .closeActions.size shouldBeEqualTo 0
+
+        GraphPluginConfig()
+            .memgraph(mockk(), database = "memgraph")
+            .closeActions.size shouldBeEqualTo 0
+
+        GraphPluginConfig()
+            .falkorDB(mockk(), graphName = "graph")
+            .closeActions.size shouldBeEqualTo 0
+
+        GraphPluginConfig()
+            .age("graph")
+            .closeActions.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `managed backend DSL 은 plugin owned close action 을 등록한다`() {
+        val neo4jConfig = GraphPluginConfig().neo4j {
+            uri = "bolt://localhost:7687"
+        }
+        neo4jConfig.closeActions.size shouldBeEqualTo 3
+        neo4jConfig.resolveState().close()
+
+        val memgraphConfig = GraphPluginConfig().memgraph {
+            uri = "bolt://localhost:7687"
+        }
+        memgraphConfig.closeActions.size shouldBeEqualTo 3
+        memgraphConfig.resolveState().close()
+    }
+
+    @Test
     fun `managed backend DSL 은 잘못된 property 를 fail fast 한다`() {
         assertFailsWith<IllegalArgumentException> {
             GraphPluginConfig().neo4j {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
@@ -18,7 +18,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
-import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -49,8 +48,13 @@ import javax.sql.DataSource
  * val operations = context.getBean(GraphOperations::class.java)
  * ```
  */
-@AutoConfiguration(after = [DataSourceAutoConfiguration::class])
-@ConditionalOnClass(AgeGraphOperations::class, DataSource::class)
+@AutoConfiguration(afterName = ["org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"])
+@ConditionalOnClass(
+    name = [
+        "io.bluetape4k.graph.age.AgeGraphOperations",
+        "javax.sql.DataSource",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "age")
 @ConditionalOnSingleCandidate(DataSource::class)
 @EnableConfigurationProperties(AgeGraphProperties::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfiguration.kt
@@ -29,12 +29,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * ```
  */
 @AutoConfiguration(
-    before = [
-        GraphTinkerGraphAutoConfiguration::class,
-        GraphNeo4jAutoConfiguration::class,
-        GraphMemgraphAutoConfiguration::class,
-        GraphAgeAutoConfiguration::class,
-        GraphFalkorDBAutoConfiguration::class,
+    beforeName = [
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphTinkerGraphAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphNeo4jAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphMemgraphAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphAgeAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphFalkorDBAutoConfiguration",
     ],
 )
 @EnableConfigurationProperties(GraphProperties::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -43,7 +43,12 @@ import org.springframework.context.annotation.Configuration
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(com.falkordb.Driver::class, FalkorDBGraphOperations::class)
+@ConditionalOnClass(
+    name = [
+        "com.falkordb.Driver",
+        "io.bluetape4k.graph.falkordb.FalkorDBGraphOperations",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "falkordb")
 @EnableConfigurationProperties(FalkorDBGraphProperties::class)
 class GraphFalkorDBAutoConfiguration {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -47,7 +47,12 @@ import java.util.concurrent.TimeUnit
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(Driver::class, MemgraphGraphOperations::class)
+@ConditionalOnClass(
+    name = [
+        "org.neo4j.driver.Driver",
+        "io.bluetape4k.graph.memgraph.MemgraphGraphOperations",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "memgraph")
 @EnableConfigurationProperties(MemgraphGraphProperties::class)
 class GraphMemgraphAutoConfiguration {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -13,6 +13,7 @@ import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Config
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -54,11 +55,13 @@ class GraphMemgraphAutoConfiguration {
     companion object : KLogging()
 
     /**
-     * Memgraph Driver 빈. 이미 등록된 Driver 빈이 있으면 재사용한다.
-     * Memgraph는 Neo4j Bolt 프로토콜 호환이므로 Neo4j `GraphDatabase.driver()`를 사용한다.
+     * Memgraph driver bean.
+     *
+     * Memgraph uses the Neo4j Bolt-compatible Java driver. Only a bean explicitly named
+     * `memgraphDriver` is reused, because a generic [Driver] bean may belong to a Neo4j backend.
      */
     @Bean(name = ["memgraphDriver"], destroyMethod = "close")
-    @ConditionalOnMissingBean(Driver::class)
+    @ConditionalOnMissingBean(name = ["memgraphDriver"])
     fun memgraphDriver(props: MemgraphGraphProperties): Driver {
         val auth = if (props.username.isBlank() || props.password.isBlank()) AuthTokens.none()
                    else AuthTokens.basic(props.username, props.password)
@@ -76,7 +79,10 @@ class GraphMemgraphAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(GraphOperations::class)
-    fun graphOperations(driver: Driver, props: MemgraphGraphProperties): GraphOperations =
+    fun graphOperations(
+        @Qualifier("memgraphDriver") driver: Driver,
+        props: MemgraphGraphProperties,
+    ): GraphOperations =
         MemgraphGraphOperations(driver, props.database)
 
     /**
@@ -90,7 +96,10 @@ class GraphMemgraphAutoConfiguration {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun graphSuspendOperations(driver: Driver, props: MemgraphGraphProperties): GraphSuspendOperations =
+    fun graphSuspendOperations(
+        @Qualifier("memgraphDriver") driver: Driver,
+        props: MemgraphGraphProperties,
+    ): GraphSuspendOperations =
         MemgraphGraphSuspendOperations(driver, props.database)
 
     /**
@@ -119,7 +128,9 @@ class GraphMemgraphAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        fun memgraphHealthIndicator(driver: Driver): org.springframework.boot.health.contributor.HealthIndicator =
+        fun memgraphHealthIndicator(
+            @Qualifier("memgraphDriver") driver: Driver,
+        ): org.springframework.boot.health.contributor.HealthIndicator =
             org.springframework.boot.health.contributor.HealthIndicator {
                 try {
                     driver.verifyConnectivity()

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
@@ -46,7 +46,12 @@ import java.util.concurrent.TimeUnit
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(Driver::class, Neo4jGraphOperations::class)
+@ConditionalOnClass(
+    name = [
+        "org.neo4j.driver.Driver",
+        "io.bluetape4k.graph.neo4j.Neo4jGraphOperations",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "neo4j")
 @EnableConfigurationProperties(Neo4jGraphProperties::class)
 class GraphNeo4jAutoConfiguration {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Configuration
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(TinkerGraphOperations::class)
+@ConditionalOnClass(name = ["io.bluetape4k.graph.tinkerpop.TinkerGraphOperations"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.graph",
     name = ["backend"],

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfigurationClasspathTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfigurationClasspathTest.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.graph.spring.boot.autoconfigure
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GraphAutoConfigurationClasspathTest {
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                GraphAutoConfiguration::class.java,
+                GraphAgeAutoConfiguration::class.java,
+                GraphFalkorDBAutoConfiguration::class.java,
+                GraphMemgraphAutoConfiguration::class.java,
+                GraphNeo4jAutoConfiguration::class.java,
+                GraphTinkerGraphAutoConfiguration::class.java,
+            )
+        )
+
+    @Test
+    fun `missing optional AGE backend classes back off without startup failure`() {
+        runner
+            .withClassLoader(FilteredClassLoader("io.bluetape4k.graph.age"))
+            .withPropertyValues("bluetape4k.graph.backend=age")
+            .run { ctx ->
+                ctx.startupFailure.shouldBeNull()
+                ctx.containsBean("graphOperations").shouldBeFalse()
+            }
+    }
+
+    @Test
+    fun `missing optional Memgraph backend classes back off without startup failure`() {
+        runner
+            .withClassLoader(FilteredClassLoader("io.bluetape4k.graph.memgraph"))
+            .withPropertyValues("bluetape4k.graph.backend=memgraph")
+            .run { ctx ->
+                ctx.startupFailure.shouldBeNull()
+                ctx.containsBean("graphOperations").shouldBeFalse()
+            }
+    }
+}

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.mockk
+import org.neo4j.driver.Driver
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -34,6 +36,13 @@ class GraphMemgraphAutoConfigurationTest {
             "bluetape4k.graph.memgraph.password=",
         )
 
+    private val localMemgraphProperties = arrayOf(
+        "bluetape4k.graph.backend=memgraph",
+        "bluetape4k.graph.memgraph.uri=bolt://localhost:7687",
+        "bluetape4k.graph.memgraph.username=",
+        "bluetape4k.graph.memgraph.password=",
+    )
+
     @Test
     fun `backend=memgraph 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues(*memgraphProperties)
@@ -41,6 +50,19 @@ class GraphMemgraphAutoConfigurationTest {
                 ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
                 ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
                 ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `unrelated Driver bean 이 있어도 memgraphDriver 를 별도로 등록한다`() {
+        runner
+            .withBean("neo4jDriver", Driver::class.java, { mockk(relaxed = true) })
+            .withPropertyValues(*localMemgraphProperties)
+            .run { ctx ->
+                ctx.getBean("neo4jDriver", Driver::class.java).shouldNotBeNull()
+                ctx.getBean("memgraphDriver", Driver::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
             }
     }
 


### PR DESCRIPTION
## Summary
- Added reciprocal README language switches to paired graph-io README files for core, csv, jackson2, jackson3, and graphml.
- Preserved the existing README content and added only the required navigation lines directly below each title.

Fixes #329
Stack Base: #352

## Validation
- `rg -n 'English \| \[한국어\]|\[English\]\(README.md\) \| 한국어|\[English\]\(README.md\) \| \[한국어\]' graph-io/*/README*.md`
- `git diff --check -- graph-io`

## DoD Status
- [x] Issue #329 implementation completed.
- [x] PR assignee, label, and milestone mirror the issue metadata.
- [x] Markdown switch scan and whitespace validation passed.
- [x] Full repository test passed on stack head #366: `./gradlew test --no-daemon --continue --no-configuration-cache`.

