### PR TITLE
ci: fail empty Kover coverage aggregation

### DIFF
--- a/.github/scripts/aggregate-kover-coverage.py
+++ b/.github/scripts/aggregate-kover-coverage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Kover XML 리포트를 집계해서 GitHub Step Summary 에 모듈별 coverage 표를 출력한다.
+Aggregate Kover XML reports and print a module coverage table to GitHub Step Summary.
 
 Usage:
     aggregate-kover-coverage.py <coverage-root>
@@ -95,6 +95,9 @@ def main() -> int:
         with open(summary_path, "a", encoding="utf-8") as fp:
             fp.write(output)
     print(output)
+    if not rows:
+        print(f"error: no Kover XML reports found under {root_dir}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/.github/scripts/test_aggregate_kover_coverage.py
+++ b/.github/scripts/test_aggregate_kover_coverage.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("aggregate-kover-coverage.py")
+
+
+class AggregateKoverCoverageTest(unittest.TestCase):
+    def run_script(self, root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), str(root)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_empty_coverage_root_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.run_script(Path(tmp))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("_No coverage reports found._", result.stdout)
+        self.assertIn("error: no Kover XML reports found", result.stderr)
+
+    def test_report_xml_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            report = Path(tmp) / "coverage-core" / "graph" / "graph-core" / "build" / "reports" / "kover"
+            report.mkdir(parents=True)
+            (report / "report.xml").write_text(
+                textwrap.dedent(
+                    """\
+                    <report>
+                      <counter type="INSTRUCTION" missed="2" covered="8"/>
+                    </report>
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_script(Path(tmp))
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("| `graph-core` | 8 | 2 | 80.00% |", result.stdout)
+        self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,7 +732,6 @@ jobs:
           pattern: coverage-*
           path: coverage-artifacts
           merge-multiple: false
-        continue-on-error: true
 
       - name: Aggregate Kover coverage summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Opened the `0.6.0` development line after the `0.5.0` stable release.
-- Aligned the local `bluetape4k-bom` reference to `1.11.0-SNAPSHOT`.
+- Aligned the local `bluetape4k-bom` reference to `1.11.1-SNAPSHOT`.
 - Documented backend-native graph-io bulk loader feasibility and deferred
   backend-specific fast paths from the `0.6.0` implementation lane
   ([#234](https://github.com/bluetape4k/bluetape4k-graph/issues/234)).

--- a/README.ko.md
+++ b/README.ko.md
@@ -65,7 +65,7 @@ graph/
   graph-neo4j      # Neo4j Java Driver 구현
   graph-memgraph   # Memgraph (Neo4j 프로토콜 호환) 구현
   graph-tinkerpop  # Apache TinkerPop / TinkerGraph 인메모리 구현
-  graph-falkordb   # FalkorDB (Redis 기반) 구현 — jfalkordb 0.7.0
+  graph-falkordb   # FalkorDB (Redis 기반) 구현 - jfalkordb 0.8.0
 graph-io/
   core             # 공유 계약·모델·옵션·헬퍼
   csv              # CSV 벌크 임포트/익스포트 (Sync / VirtualThread / Coroutine)
@@ -325,7 +325,7 @@ driver.close()
 |------|-----------|-------------|----------------|-----------------|----------------|
 | 쿼리 언어 | Cypher-over-SQL | Cypher | Cypher | Gremlin | openCypher (부분집합) |
 | 인프라 | PostgreSQL + AGE | Neo4j | Memgraph | JVM 인메모리 | Redis 모듈 |
-| 드라이버 | JDBC + Exposed | Neo4j Java Driver | Neo4j Java Driver (호환) | TinkerPop | jfalkordb 0.7.0 |
+| 드라이버 | JDBC + Exposed | Neo4j Java Driver | Neo4j Java Driver (호환) | TinkerPop | jfalkordb 0.8.0 |
 | 테스트 컨테이너 | `apache/age:PG16_latest` | `neo4j:5` | `memgraph/memgraph:latest` | 불필요 | `falkordb/falkordb:v4.18.1` |
 | 가장 강한 로컬 역할 | PostgreSQL-native graph | 성숙한 graph server | low-latency Cypher server | unit/integration tests | Redis-backed graph service |
 
@@ -338,8 +338,8 @@ driver.close()
 ./gradlew test
 
 # 특정 모듈 테스트
-./gradlew :graph-neo4j:test
-./gradlew :graph-age:test
+./gradlew :bluetape4k-graph-neo4j:test
+./gradlew :bluetape4k-graph-age:test
 ./gradlew :code-graph-examples:test
 ./gradlew :linkedin-graph-examples:test
 ./gradlew :fraud-detection-examples:test
@@ -353,7 +353,7 @@ driver.close()
 ./gradlew :security-attack-path-examples:test
 
 # 특정 클래스
-./gradlew :graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
+./gradlew :bluetape4k-graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
 ```
 
 GitHub Actions는 전용 `Examples` workflow도 실행한다. 이 workflow는 매일 한 번, 그리고 example, graph, graph-io, Ktor, Gradle, workflow 파일 변경 시 실행된다. 예제 검증은 Nightly에서 제외해 backend/integration smoke coverage와 별도 신호로 관리한다.
@@ -391,19 +391,19 @@ GitHub Actions는 전용 `Examples` workflow도 실행한다. 이 workflow는 �
 ## 요구 사항
 
 - Java 21 (preview 기능 활성화)
-- Kotlin 2.3
+- Kotlin 2.4.0
 - Docker (통합 테스트용)
 
 ## 기술 스택
 
-- **Kotlin** 2.3 + Coroutines 1.10
+- **Kotlin** 2.4.0 + Coroutines 1.11.0
 - **Neo4j Java Driver** 5.x
 - **JetBrains Exposed** (Apache AGE용 JDBC)
 - **Apache TinkerPop** (Gremlin)
 - **Ktor** 3.x (ApplicationPlugin integration)
-- **jfalkordb** 0.7.0 (FalkorDB / Redis 모듈 그래프)
+- **jfalkordb** 0.8.0 (FalkorDB / Redis 모듈 그래프)
 - **Testcontainers** (통합 테스트)
-- **bluetape4k** 1.7.x (공통 유틸리티)
+- **bluetape4k** 1.11.1-SNAPSHOT (공통 유틸리티)
 
 ## 문서
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ graph/
   graph-neo4j      # Neo4j Java Driver implementation
   graph-memgraph   # Memgraph (Neo4j protocol compatible) implementation
   graph-tinkerpop  # Apache TinkerPop / TinkerGraph in-memory implementation
-  graph-falkordb   # FalkorDB (Redis-based) implementation — jfalkordb 0.7.0
+  graph-falkordb   # FalkorDB (Redis-based) implementation - jfalkordb 0.8.0
 graph-io/
   core             # Shared contracts, models, options, and helpers for bulk I/O
   csv              # CSV bulk import/export (Sync / VirtualThread / Coroutine)
@@ -326,7 +326,7 @@ driver.close()
 |------|-----------|-------------|----------------|-----------------|----------------|
 | Query Language | Cypher-over-SQL | Cypher | Cypher | Gremlin | openCypher (subset) |
 | Infrastructure | PostgreSQL + AGE | Neo4j | Memgraph | JVM in-memory | Redis module |
-| Driver | JDBC + Exposed | Neo4j Java Driver | Neo4j Java Driver (compatible) | TinkerPop | jfalkordb 0.7.0 |
+| Driver | JDBC + Exposed | Neo4j Java Driver | Neo4j Java Driver (compatible) | TinkerPop | jfalkordb 0.8.0 |
 | Test Container | `apache/age:PG16_latest` | `neo4j:5` | `memgraph/memgraph:latest` | not required | `falkordb/falkordb:v4.18.1` |
 | Strongest local role | PostgreSQL-native graph | Mature graph server | Low-latency Cypher server | Unit/integration tests | Redis-backed graph service |
 
@@ -339,8 +339,8 @@ Tests automatically launch Docker containers via Testcontainers. Docker is requi
 ./gradlew test
 
 # Specific module tests
-./gradlew :graph-neo4j:test
-./gradlew :graph-age:test
+./gradlew :bluetape4k-graph-neo4j:test
+./gradlew :bluetape4k-graph-age:test
 ./gradlew :code-graph-examples:test
 ./gradlew :linkedin-graph-examples:test
 ./gradlew :fraud-detection-examples:test
@@ -354,7 +354,7 @@ Tests automatically launch Docker containers via Testcontainers. Docker is requi
 ./gradlew :security-attack-path-examples:test
 
 # Specific class
-./gradlew :graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
+./gradlew :bluetape4k-graph-neo4j:test --tests "io.bluetape4k.graph.neo4j.Neo4jGraphOperationsTest"
 ```
 
 GitHub Actions also runs a dedicated `Examples` workflow daily and on changes to example, graph, graph-io, Ktor, Gradle, or workflow files. The examples are intentionally excluded from the Nightly workflow so the daily example signal stays separate from backend/integration smoke coverage.
@@ -392,19 +392,19 @@ Concrete classes only need to implement `ops` (`GraphOperations` or `GraphSuspen
 ## Requirements
 
 - Java 21 (with preview features enabled)
-- Kotlin 2.3
+- Kotlin 2.4.0
 - Docker (for integration tests)
 
 ## Tech Stack
 
-- **Kotlin** 2.3 + Coroutines 1.10
+- **Kotlin** 2.4.0 + Coroutines 1.11.0
 - **Neo4j Java Driver** 5.x
 - **JetBrains Exposed** (JDBC for Apache AGE)
 - **Apache TinkerPop** (Gremlin)
 - **Ktor** 3.x (ApplicationPlugin integration)
-- **jfalkordb** 0.7.0 (FalkorDB / Redis-module graph)
+- **jfalkordb** 0.8.0 (FalkorDB / Redis-module graph)
 - **Testcontainers** (integration tests)
-- **bluetape4k** 1.7.x (common utilities)
+- **bluetape4k** 1.11.1-SNAPSHOT (common utilities)
 
 ## Documentation
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,21 +1,54 @@
 # WIP - bluetape4k-graph
 
-Snapshot: 2026-06-26 KST
+Snapshot: 2026-07-04 KST
 Scope: open GitHub issues assigned to `debop`.
-Open count after merging the issue #233/#234 PRs: 2 issues.
+Open assigned issue count: 35 issues.
 
 ## Current Direction
 
 The `0.5.0` stable line has been published and consumed by
-`bluetape4k-dependencies` `1.2.0`. Development now moves to `0.6.0` with
-`snapshotVersion=` kept empty for workflow-injected snapshot publication.
+`bluetape4k-dependencies`. Development is now on `0.6.0`; this WIP queue tracks
+the current 7-Tier review train plus older backlog items that remain open.
 
 ## Active Queue
 
-| Priority | Issue | Milestone | Notes |
-|---|---|---|---|
-| P3 | [#215](https://github.com/bluetape4k/bluetape4k-graph/issues/215) research: revalidate Amazon Neptune backend feasibility | backlog | Required before reviving #30. |
-| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) [Epic] Amazon Neptune 그래프 DB 백엔드 구현 (graph-neptune) | backlog | Keep blocked while marked `invalid`/research; do not implement against mocks only. |
+| Priority | Issue | Milestone | Labels | Notes |
+|---|---|---|---|---|
+| P0 | [#319](https://github.com/bluetape4k/bluetape4k-graph/issues/319) bug(graph-ktor): do not close caller-owned backend resources | 0.6.0 | bug | PR #343 open; stack root. |
+| P0 | [#320](https://github.com/bluetape4k/bluetape4k-graph/issues/320) bug(graph-spring-boot): qualify Memgraph Driver beans | 0.6.0 | bug | PR #344 open. |
+| P0 | [#321](https://github.com/bluetape4k/bluetape4k-graph/issues/321) bug(graph-spring-boot): guard optional auto-config classpath boundaries | 0.6.0 | bug | PR #345 open. |
+| P0 | [#322](https://github.com/bluetape4k/bluetape4k-graph/issues/322) bug(graph-io-okio): abort atomic writes when wrapper setup fails | 0.6.0 | bug | PR #346 open. |
+| P0 | [#323](https://github.com/bluetape4k/bluetape4k-graph/issues/323) bug(graph-io-ndjson): stream suspend imports and capture envelope validation failures | 0.6.0 | bug | PR #347 open. |
+| P1 | [#324](https://github.com/bluetape4k/bluetape4k-graph/issues/324) refactor(graph-io): keep suspend graph operations off Dispatchers.IO in CSV and GraphML | 0.6.0 | refactoring | PR #348 open. |
+| P0 | [#325](https://github.com/bluetape4k/bluetape4k-graph/issues/325) bug(graph-io-graphml): report invalid typed GraphML values | 0.6.0 | bug | PR #349 open. |
+| P1 | [#326](https://github.com/bluetape4k/bluetape4k-graph/issues/326) refactor(graph-tinkerpop): replace synchronized graph critical sections | 0.6.0 | refactoring | PR #350 open. |
+| P1 | [#327](https://github.com/bluetape4k/bluetape4k-graph/issues/327) test(examples): make suspend cleanup and lifecycle patterns consistent | 0.6.0 | test, example | PR #351 open. |
+| P1 | [#328](https://github.com/bluetape4k/bluetape4k-graph/issues/328) test(graph): migrate exception assertions to bluetape4k helpers | 0.6.0 | test, refactoring | PR #352 open. |
+| P2 | [#329](https://github.com/bluetape4k/bluetape4k-graph/issues/329) docs(graph-io): add README language switches | 0.6.0 | documentation | PR #353 open. |
+| P2 | [#330](https://github.com/bluetape4k/bluetape4k-graph/issues/330) docs(graph-spring-boot): fix README switch and English public KDoc | 0.6.0 | documentation | PR #354 open. |
+| P0 | [#331](https://github.com/bluetape4k/bluetape4k-graph/issues/331) bug(graph-backends): do not mask traversal and cycle-detection failures | 0.6.0 | bug | PR #355 open. |
+| P0 | [#332](https://github.com/bluetape4k/bluetape4k-graph/issues/332) bug(graph-backends): do not report graphExists=false on infrastructure failures | 0.6.0 | bug | PR #356 open. |
+| P0 | [#333](https://github.com/bluetape4k/bluetape4k-graph/issues/333) bug(graph-age): narrow createGraph duplicate handling | 0.6.0 | bug | PR #357 open. |
+| P0 | [#334](https://github.com/bluetape4k/bluetape4k-graph/issues/334) bug(graph-core): enforce nonblank GraphElementId invariant | 0.6.0 | bug | PR #358 open. |
+| P1 | [#335](https://github.com/bluetape4k/bluetape4k-graph/issues/335) test(graph-falkordb): move raw GenericContainer fixture behind shared launcher | 0.6.0 | test, refactoring | PR #359 open. |
+| P2 | [#336](https://github.com/bluetape4k/bluetape4k-graph/issues/336) docs(graph-core): convert public API KDoc to English | 0.6.0 | documentation | PR #360 open. |
+| P2 | [#337](https://github.com/bluetape4k/bluetape4k-graph/issues/337) docs(repo): refresh README commands and version references | 0.6.0 | documentation | PR #361 open. |
+| P2 | [#338](https://github.com/bluetape4k/bluetape4k-graph/issues/338) docs(repo): refresh WIP issue queue from live GitHub state | 0.6.0 | documentation | Current WIP refresh. |
+| P1 | [#339](https://github.com/bluetape4k/bluetape4k-graph/issues/339) ci(graph): fail coverage aggregation when expected Kover reports are missing | 0.6.0 | bug, ci | Next CI hardening item. |
+| P1 | [#340](https://github.com/bluetape4k/bluetape4k-graph/issues/340) ci(graph): include graph-io Kover XML tasks in nightly coverage | 0.6.0 | ci | Follow #339 coverage signal work. |
+| P1 | [#341](https://github.com/bluetape4k/bluetape4k-graph/issues/341) ci(benchmark): render all benchmark JSON outputs with chart artifacts | 0.6.0 | performance, ci | Benchmark artifact polish. |
+| P1 | [#342](https://github.com/bluetape4k/bluetape4k-graph/issues/342) build(repo): remove duplicated centrally governed catalog versions | 0.6.0 | build, dependencies | Catalog governance cleanup. |
+| P3 | [#298](https://github.com/bluetape4k/bluetape4k-graph/issues/298) ci: harden gitleaks release asset install | backlog | ci, github_actions | Older CI backlog. |
+| P3 | [#310](https://github.com/bluetape4k/bluetape4k-graph/issues/310) feat(graph-io): add checkpoint and resume support for large imports | backlog | enhancement, performance | Future graph-io feature. |
+| P3 | [#311](https://github.com/bluetape4k/bluetape4k-graph/issues/311) feat(graph-io): add bulk I/O progress listeners and Micrometer bridge | backlog | enhancement, performance | Future graph-io observability feature. |
+| P3 | [#312](https://github.com/bluetape4k/bluetape4k-graph/issues/312) feat(graph-io): define backend-native bulk loader SPI | backlog | enhancement, performance | Needs separate SPI design. |
+| P3 | [#313](https://github.com/bluetape4k/bluetape4k-graph/issues/313) feat(graph-io): add streaming import reader parity across formats | backlog | enhancement, performance | Future graph-io parity item. |
+| P3 | [#314](https://github.com/bluetape4k/bluetape4k-graph/issues/314) test(graph): add cross-backend conformance suite for graph capabilities | backlog | enhancement, test | Future conformance suite. |
+| P3 | [#315](https://github.com/bluetape4k/bluetape4k-graph/issues/315) feat(graph-core): add schema drift planner for indexes and constraints | backlog | enhancement | Future schema planning feature. |
+| P3 | [#316](https://github.com/bluetape4k/bluetape4k-graph/issues/316) feat(spring-boot): add Actuator graph management endpoint | backlog | enhancement | Future Spring management surface. |
+| P3 | [#317](https://github.com/bluetape4k/bluetape4k-graph/issues/317) feat(graph-io): add multi-source import workflow for distributed graph datasets | backlog | enhancement, performance | Future graph-io workflow feature. |
+| P3 | [#215](https://github.com/bluetape4k/bluetape4k-graph/issues/215) research: revalidate Amazon Neptune backend feasibility | backlog | enhancement, research | Required before reviving #30. |
+| P3 | [#30](https://github.com/bluetape4k/bluetape4k-graph/issues/30) [Epic] Amazon Neptune graph DB backend implementation (graph-neptune) | backlog | invalid, Epic, research | Keep blocked while marked invalid/research; do not implement against mocks only. |
 
 ## Recently Completed
 
@@ -31,26 +64,24 @@ The `0.5.0` stable line has been published and consumed by
 - [#233](https://github.com/bluetape4k/bluetape4k-graph/issues/233)
   chunked graph export cursor API is implemented with a TinkerGraph reference
   path and Jackson3 NDJSON exporter proof.
-- Root README English/Korean module lists and example test commands already
-  include the 0.5.0 example modules.
-- Aligned Ktor examples with shared bluetape4k-ktor-core modules.
+- Root README English/Korean module lists and example test commands have been
+  refreshed for the current Gradle project names and version catalog.
 
 ## Verification Evidence
 
-- GitHub milestone `0.5.0`: open issues `0`, closed issues `35`.
-- Open PRs: none.
-- CI: `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305940`
-  succeeded on commit `8e4abdd`.
-- Examples: `https://github.com/bluetape4k/bluetape4k-graph/actions/runs/26733305942`
-  succeeded on commit `8e4abdd`.
-- Maven Central release check:
-  `io.github.bluetape4k.graph:bluetape4k-graph-bom:0.5.0` is published and
-  managed by `bluetape4k-dependencies` `1.2.0`.
+- Source command:
+  `gh issue list --repo bluetape4k/bluetape4k-graph --state open --assignee debop --json number,title,milestone,labels,assignees`
+- Live open assigned issues: 35.
+- Live `0.6.0` review issues: #319 through #342.
+- Live open stacked PRs: #343 through #361.
+- `gh milestone` is unavailable in this environment; milestone titles were read
+  from GitHub issue JSON.
 
 ## Release Notes
 
-- Use `0.6.0` for graph-io streaming and backend-native bulk loader work.
-- Keep backend-native loader work research-only for `0.6.0` unless a separate
-  backend-native SPI is designed and scoped after issue #233.
+- Use `0.6.0` for the current 7-Tier review train and near-term CI/build
+  hardening work.
+- Keep backend-native loader SPI and large-import workflow items in backlog
+  unless separately designed and scoped.
 - Keep Neptune work in backlog until local or reliable integration testability
   is proven.

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphSuspendTest.kt
@@ -12,7 +12,9 @@ import io.bluetape4k.logging.debug
 import kotlinx.coroutines.flow.toList
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractCodeGraphSuspendTest {
 
     companion object : KLogging()

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/AbstractCodeGraphTest.kt
@@ -10,7 +10,9 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractCodeGraphTest {
 
     companion object : KLogging()

--- a/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphSuspendTest.kt
+++ b/examples/code-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/code/FalkorDBCodeGraphSuspendTest.kt
@@ -3,8 +3,8 @@ package io.bluetape4k.graph.examples.code
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -23,7 +23,7 @@ class FalkorDBCodeGraphSuspendTest : AbstractCodeGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionBackendTests.kt
+++ b/examples/fraud-detection-examples/src/test/kotlin/io/bluetape4k/graph/examples/fraud/FraudDetectionBackendTests.kt
@@ -14,11 +14,11 @@ import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -173,7 +173,7 @@ class FalkorDBFraudDetectionSuspendTest : AbstractFraudDetectionSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphBackendTests.kt
+++ b/examples/knowledge-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/knowledge/KnowledgeGraphBackendTests.kt
@@ -14,11 +14,11 @@ import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -173,7 +173,7 @@ class FalkorDBKnowledgeGraphSuspendTest : AbstractKnowledgeGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphSuspendTest.kt
@@ -13,7 +13,9 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractLinkedInGraphSuspendTest {
 
     companion object : KLoggingChannel()

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/AbstractLinkedInGraphTest.kt
@@ -11,7 +11,9 @@ import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractLinkedInGraphTest {
 
     companion object : KLogging()

--- a/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphSuspendTest.kt
+++ b/examples/linkedin-graph-examples/src/test/kotlin/io/bluetape4k/graph/examples/linkedin/FalkorDBLinkedInGraphSuspendTest.kt
@@ -3,8 +3,8 @@ package io.bluetape4k.graph.examples.linkedin
 import com.falkordb.FalkorDB
 import io.bluetape4k.graph.falkordb.FalkorDBGraphSuspendOperations
 import io.bluetape4k.graph.falkordb.FalkorDBServer
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
-import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.util.UUID
@@ -23,7 +23,7 @@ class FalkorDBLinkedInGraphSuspendTest : AbstractLinkedInGraphSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationBackendTests.kt
+++ b/examples/recommendation-examples/src/test/kotlin/io/bluetape4k/graph/examples/recommendation/RecommendationBackendTests.kt
@@ -14,11 +14,11 @@ import io.bluetape4k.graph.neo4j.Neo4jGraphOperations
 import io.bluetape4k.graph.neo4j.Neo4jGraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.warn
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -173,7 +173,7 @@ class FalkorDBRecommendationSuspendTest : AbstractRecommendationSuspendTest() {
 
     @AfterAll
     fun stopServer() {
-        runCatching { runBlocking { ops.dropGraph(graphName) } }
+        runCatching { runSuspendIO { ops.dropGraph(graphName) } }
             .onFailure { log.warn(it) { "Failed to drop graph $graphName" } }
         driver.close()
     }

--- a/graph-io/core/README.ko.md
+++ b/graph-io/core/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-core
 
+[English](README.md) | 한국어
+
 `graph-io` 계열의 벌크 임포터/익스포터가 공유하는 계약(contract), 모델, 옵션, 리포트, I/O 헬퍼.
 
 ## 개요

--- a/graph-io/core/README.md
+++ b/graph-io/core/README.md
@@ -1,5 +1,7 @@
 # graph-io-core
 
+English | [한국어](README.ko.md)
+
 Shared contracts, models, options, reports, and I/O helpers for the `graph-io` family of bulk importers and exporters.
 
 ## Overview

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/model/GraphIoRecordTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/model/GraphIoRecordTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.model
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -8,14 +8,14 @@ class GraphIoRecordTest {
 
     @Test
     fun `vertex record requires non-blank externalId`() {
-        invoking { GraphIoVertexRecord(externalId = " ", label = "Person") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphIoVertexRecord(externalId = " ", label = "Person") }
     }
 
     @Test
     fun `edge record requires non-blank label and endpoints`() {
-        invoking { GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2") } shouldThrow IllegalArgumentException::class
-        invoking { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2") } shouldThrow IllegalArgumentException::class
-        invoking { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2") }
+        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2") }
+        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ") }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphExportOptionsTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphExportOptionsTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.options
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -16,12 +16,12 @@ class GraphExportOptionsTest {
 
     @Test
     fun `vertexLabels must not contain blank strings`() {
-        invoking { GraphExportOptions(vertexLabels = setOf("Person", " ")) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphExportOptions(vertexLabels = setOf("Person", " ")) }
     }
 
     @Test
     fun `edgeLabels must not contain blank strings`() {
-        invoking { GraphExportOptions(edgeLabels = setOf("KNOWS", "")) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphExportOptions(edgeLabels = setOf("KNOWS", "")) }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphImportOptionsTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/options/GraphImportOptionsTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.options
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -20,23 +20,23 @@ class GraphImportOptionsTest {
 
     @Test
     fun `batchSize must be positive`() {
-        invoking { GraphImportOptions(batchSize = 0) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportOptions(batchSize = -1) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(batchSize = 0) }
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(batchSize = -1) }
     }
 
     @Test
     fun `maxEdgeBufferSize must be positive`() {
-        invoking { GraphImportOptions(maxEdgeBufferSize = 0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(maxEdgeBufferSize = 0) }
     }
 
     @Test
     fun `defaultVertexLabel must not be blank`() {
-        invoking { GraphImportOptions(defaultVertexLabel = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(defaultVertexLabel = " ") }
     }
 
     @Test
     fun `defaultEdgeLabel must not be blank`() {
-        invoking { GraphImportOptions(defaultEdgeLabel = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(defaultEdgeLabel = " ") }
     }
 
     @Test
@@ -47,6 +47,6 @@ class GraphImportOptionsTest {
 
     @Test
     fun `preserveExternalIdProperty must not be blank when set`() {
-        invoking { GraphImportOptions(preserveExternalIdProperty = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportOptions(preserveExternalIdProperty = " ") }
     }
 }

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.graph.io.report
 
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -10,7 +10,7 @@ class GraphIoReportTest {
 
     @Test
     fun `GraphIoFailure requires non-blank message`() {
-        invoking { GraphIoFailure(phase = GraphIoPhase.READ_VERTEX, message = " ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphIoFailure(phase = GraphIoPhase.READ_VERTEX, message = " ") }
     }
 
     @Test
@@ -52,20 +52,20 @@ class GraphIoReportTest {
 
     @Test
     fun `GraphImportReport rejects negative counts`() {
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) }
     }
 
     @Test
     fun `GraphExportReport rejects negative counts`() {
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
-        invoking { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoExternalIdMapTest.kt
@@ -2,7 +2,7 @@ package io.bluetape4k.graph.io.support
 
 import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
 import io.bluetape4k.graph.model.GraphElementId
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class GraphIoExternalIdMapTest {
     fun `duplicate under FAIL policy throws`() {
         val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
         map.putFirstOrFail("v1", GraphElementId("a"))
-        invoking { map.putFirstOrFail("v1", GraphElementId("b")) } shouldThrow IllegalStateException::class
+        assertFailsWith<IllegalStateException> { map.putFirstOrFail("v1", GraphElementId("b")) }
     }
 
     @Test
@@ -68,7 +68,7 @@ class GraphIoExternalIdMapTest {
     @Test
     fun `put without putFirstOrFail throws IllegalStateException`() {
         val map = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
-        invoking { map.put("never-registered", GraphElementId("real")) } shouldThrow IllegalStateException::class
+        assertFailsWith<IllegalStateException> { map.put("never-registered", GraphElementId("real")) }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/VirtualThreadGraphBulkAdapterTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/VirtualThreadGraphBulkAdapterTest.kt
@@ -10,10 +10,10 @@ import io.bluetape4k.graph.io.report.GraphIoFormat
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.testsupport.FakeGraphOperations
 import io.bluetape4k.graph.repository.GraphOperations
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.Duration
 import java.util.concurrent.ExecutionException
 
@@ -64,7 +64,7 @@ class VirtualThreadGraphBulkAdapterTest {
         val boom = RuntimeException("boom")
         val importer = stubImporter { _, _, _ -> throw boom }
         val vt = VirtualThreadGraphBulkAdapter.wrapImporter(importer)
-        val ee = assertThrows<ExecutionException> {
+        val ee = assertFailsWith<ExecutionException> {
             vt.importGraphAsync("x", FakeGraphOperations(), GraphImportOptions()).get()
         }
         ee.cause shouldBeInstanceOf RuntimeException::class
@@ -92,7 +92,7 @@ class VirtualThreadGraphBulkAdapterTest {
         val boom = RuntimeException("export boom")
         val exporter = stubExporter { _, _, _ -> throw boom }
         val vt = VirtualThreadGraphBulkAdapter.wrapExporter(exporter)
-        val ee = assertThrows<ExecutionException> {
+        val ee = assertFailsWith<ExecutionException> {
             vt.exportGraphAsync("sink", FakeGraphOperations(), GraphExportOptions()).get()
         }
         ee.cause shouldBeInstanceOf RuntimeException::class

--- a/graph-io/csv/README.ko.md
+++ b/graph-io/csv/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-csv
 
+[English](README.md) | 한국어
+
 **bluetape4k-graph** 을 위한 CSV 포맷 벌크 임포터/익스포터. 그래프 정점과 간선을 CSV 파일로 원활하게 내보낼 수 있으며, 동기, 가상 스레드, Kotlin 코루틴 기반 suspend의 세 가지 실행 모델을 지원합니다.
 
 ## 기능

--- a/graph-io/csv/README.md
+++ b/graph-io/csv/README.md
@@ -1,5 +1,7 @@
 # graph-io-csv
 
+English | [한국어](README.ko.md)
+
 CSV format bulk importer/exporter for **bluetape4k-graph**. Seamlessly export graph vertices and edges to CSV files, with support for three execution models: synchronous, virtual thread-based, and Kotlin coroutine-based suspend operations.
 
 ## Features

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkExporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkExporter.kt
@@ -20,10 +20,10 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
 /**
- * CSV 코루틴(suspend) 벌크 익스포터.
+ * Coroutine bulk exporter for CSV graph data.
  *
- * suspend 방식으로 정점과 간선을 Flow로 수집하여 CSV 파일로 저장한다.
- * `Dispatchers.IO`에서 실행되며 Kotlin 코루틴 구조적 동시성을 활용한다.
+ * Graph reads stay in the caller coroutine context while blocking file writes
+ * are isolated on [Dispatchers.IO].
  *
  * ```kotlin
  * val exporter = SuspendCsvGraphBulkExporter()
@@ -34,7 +34,7 @@ import kotlinx.coroutines.withContext
  * val report = coroutineScope {
  *     exporter.exportGraphSuspending(sink, suspendOps, GraphExportOptions(vertexLabels = setOf("Person")))
  * }
- * println("exported ${report.verticesWritten} vertices — ${report.status}")
+ * println("exported ${report.verticesWritten} vertices - ${report.status}")
  * ```
  */
 class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink> {
@@ -50,7 +50,7 @@ class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink>
         operations: GraphSuspendOperations,
         options: GraphExportOptions = GraphExportOptions(),
         csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
-    ): GraphExportReport = withContext(Dispatchers.IO) {
+    ): GraphExportReport {
         log.debug { "Starting CSV export (suspend): vertexLabels=${options.vertexLabels}, edgeLabels=${options.edgeLabels}" }
         val watch = GraphIoStopwatch()
         val codec = CsvRecordCodec(csvOptions.propertyMode)
@@ -66,20 +66,22 @@ class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink>
         }
         val vHeader = codec.unionVertexHeader(allVertices)
         val prefix = (csvOptions.propertyMode as? CsvPropertyMode.PrefixedColumns)?.prefix ?: ""
-        GraphIoPaths.openWriter(sink.vertices).use { w ->
-            val csv = CsvRecordWriter(w)
-            csv.writeHeaders(vHeader)
-            for (v in allVertices) {
-                val row = buildList<Any?> {
-                    add(v.externalId)
-                    add(v.label)
-                    vHeader.drop(2).forEach { col ->
-                        val key = col.removePrefix(prefix)
-                        add(v.properties[key]?.toString() ?: "")
+        withContext(Dispatchers.IO) {
+            GraphIoPaths.openWriter(sink.vertices).use { w ->
+                val csv = CsvRecordWriter(w)
+                csv.writeHeaders(vHeader)
+                for (v in allVertices) {
+                    val row = buildList<Any?> {
+                        add(v.externalId)
+                        add(v.label)
+                        vHeader.drop(2).forEach { col ->
+                            val key = col.removePrefix(prefix)
+                            add(v.properties[key]?.toString() ?: "")
+                        }
                     }
+                    csv.writeRow(row)
+                    vWritten++
                 }
-                csv.writeRow(row)
-                vWritten++
             }
         }
 
@@ -90,27 +92,29 @@ class SuspendCsvGraphBulkExporter : GraphSuspendBulkExporter<CsvGraphExportSink>
             }
         }
         val eHeader = codec.unionEdgeHeader(allEdges)
-        GraphIoPaths.openWriter(sink.edges).use { w ->
-            val csv = CsvRecordWriter(w)
-            csv.writeHeaders(eHeader)
-            for (ed in allEdges) {
-                val row = buildList<Any?> {
-                    add(ed.externalId ?: "")
-                    add(ed.label)
-                    add(ed.fromExternalId)
-                    add(ed.toExternalId)
-                    eHeader.drop(4).forEach { col ->
-                        val key = col.removePrefix(prefix)
-                        add(ed.properties[key]?.toString() ?: "")
+        withContext(Dispatchers.IO) {
+            GraphIoPaths.openWriter(sink.edges).use { w ->
+                val csv = CsvRecordWriter(w)
+                csv.writeHeaders(eHeader)
+                for (ed in allEdges) {
+                    val row = buildList<Any?> {
+                        add(ed.externalId ?: "")
+                        add(ed.label)
+                        add(ed.fromExternalId)
+                        add(ed.toExternalId)
+                        eHeader.drop(4).forEach { col ->
+                            val key = col.removePrefix(prefix)
+                            add(ed.properties[key]?.toString() ?: "")
+                        }
                     }
+                    csv.writeRow(row)
+                    eWritten++
                 }
-                csv.writeRow(row)
-                eWritten++
             }
         }
 
         val status = if (failures.isEmpty()) GraphIoStatus.COMPLETED else GraphIoStatus.PARTIAL
-        GraphExportReport(
+        return GraphExportReport(
             status = status,
             format = GraphIoFormat.CSV,
             verticesWritten = vWritten,

--- a/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkImporter.kt
+++ b/graph-io/csv/src/main/kotlin/io/bluetape4k/graph/io/csv/SuspendCsvGraphBulkImporter.kt
@@ -25,10 +25,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * CSV 코루틴(suspend) 벌크 임포터.
+ * Coroutine bulk importer for CSV graph data.
  *
- * [SuspendCsvRecordReader]로 정점과 간선을 Flow로 스트리밍하여 처리하는 2-패스 방식이다.
- * Kotlin 코루틴 구조적 동시성을 활용하며 `Dispatchers.IO`에서 실행된다.
+ * The CSV reader performs blocking file reads on [Dispatchers.IO]. Batched
+ * graph writes stay in the caller coroutine context so backend implementations
+ * keep control over their own dispatcher policy.
  *
  * ```kotlin
  * val importer = SuspendCsvGraphBulkImporter()
@@ -37,7 +38,7 @@ import kotlinx.coroutines.withContext
  *     edges    = GraphImportSource.PathSource(Paths.get("edges.csv")),
  * )
  * val report = importer.importGraphSuspending(source, suspendOps, GraphImportOptions())
- * println("imported ${report.verticesCreated} vertices — ${report.status}")
+ * println("imported ${report.verticesCreated} vertices - ${report.status}")
  * ```
  */
 class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSource> {
@@ -53,7 +54,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
         operations: GraphSuspendOperations,
         options: GraphImportOptions = GraphImportOptions(),
         csvOptions: CsvGraphIoOptions = CsvGraphIoOptions(),
-    ): GraphImportReport = withContext(Dispatchers.IO) {
+    ): GraphImportReport {
         log.debug { "Starting CSV import (suspend): defaultVertexLabel=${options.defaultVertexLabel}, defaultEdgeLabel=${options.defaultEdgeLabel}" }
         val watch = GraphIoStopwatch()
         val codec = CsvRecordCodec(csvOptions.propertyMode)
@@ -70,7 +71,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
 
         // --- 정점 패스 ---
         SuspendCsvRecordReader().read(
-            GraphIoPaths.openInputStream(source.vertices),
+            withContext(Dispatchers.IO) { GraphIoPaths.openInputStream(source.vertices) },
             skipHeaders = true,
         ) { it }.collect { record ->
             if (status == GraphIoStatus.FAILED) return@collect
@@ -110,7 +111,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
 
         if (status == GraphIoStatus.FAILED) {
             log.warn { "CSV import (suspend) failed during vertex pass: vertices=$verticesCreated/$verticesRead, elapsed=${watch.elapsed()}" }
-            return@withContext buildReport(
+            return buildReport(
                 watch, failures, GraphIoStatus.FAILED,
                 verticesRead, verticesCreated, edgesRead, edgesCreated, skippedVertices, skippedEdges
             )
@@ -120,7 +121,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
 
         // --- 엣지 패스 ---
         SuspendCsvRecordReader().read(
-            GraphIoPaths.openInputStream(source.edges),
+            withContext(Dispatchers.IO) { GraphIoPaths.openInputStream(source.edges) },
             skipHeaders = true,
         ) { it }.collect { record ->
             if (status == GraphIoStatus.FAILED) return@collect
@@ -170,7 +171,7 @@ class SuspendCsvGraphBulkImporter : GraphSuspendBulkImporter<CsvGraphImportSourc
             edgesCreated += batchWriter.flushEdges()
         }
 
-        buildReport(
+        return buildReport(
             watch, failures, status,
             verticesRead, verticesCreated, edgesRead, edgesCreated, skippedVertices, skippedEdges
         ).also {

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvGraphIoOptionsTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvGraphIoOptionsTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.graph.io.csv
 
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -18,11 +18,11 @@ class CsvGraphIoOptionsTest {
 
     @Test
     fun `prefixed prefix must not be blank`() {
-        invoking { CsvPropertyMode.PrefixedColumns(" ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CsvPropertyMode.PrefixedColumns(" ") }
     }
 
     @Test
     fun `raw json column name must not be blank`() {
-        invoking { CsvPropertyMode.RawJsonColumn(" ") } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CsvPropertyMode.RawJsonColumn(" ") }
     }
 }

--- a/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvSuspendRoundTripTest.kt
+++ b/graph-io/csv/src/test/kotlin/io/bluetape4k/graph/io/csv/CsvSuspendRoundTripTest.kt
@@ -5,13 +5,23 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.model.BatchEdge
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import java.util.Collections
+import java.util.concurrent.Executors
 
 class CsvSuspendRoundTripTest {
 
@@ -45,5 +55,84 @@ class CsvSuspendRoundTripTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend csv graph operations stay on caller dispatcher`(@TempDir dir: Path) {
+        val dispatcher = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "csv-graph-caller")
+        }.asCoroutineDispatcher()
+
+        try {
+            runBlocking(dispatcher) {
+                val vOut = dir.resolve("caller-v.csv")
+                val eOut = dir.resolve("caller-e.csv")
+
+                val sourceOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations())
+                val alice = sourceOps.createVertex("Person", mapOf("name" to "Alice"))
+                val bob = sourceOps.createVertex("Person", mapOf("name" to "Bob"))
+                sourceOps.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to "2024"))
+                sourceOps.clear()
+
+                SuspendCsvGraphBulkExporter().exportGraphSuspending(
+                    CsvGraphExportSink(GraphExportSink.PathSink(vOut), GraphExportSink.PathSink(eOut)),
+                    sourceOps,
+                    GraphExportOptions(vertexLabels = setOf("Person"), edgeLabels = setOf("KNOWS")),
+                )
+
+                sourceOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                sourceOps.recordedThreads.all { it.startsWith("csv-graph-caller") }.shouldBeTrue()
+
+                val targetOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations())
+                SuspendCsvGraphBulkImporter().importGraphSuspending(
+                    CsvGraphImportSource(GraphImportSource.PathSource(vOut), GraphImportSource.PathSource(eOut)),
+                    targetOps,
+                    GraphImportOptions(),
+                )
+
+                targetOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                targetOps.recordedThreads.all { it.startsWith("csv-graph-caller") }.shouldBeTrue()
+            }
+        } finally {
+            dispatcher.close()
+        }
+    }
+
+    private class ThreadRecordingSuspendOperations(
+        private val delegate: GraphSuspendOperations,
+    ): GraphSuspendOperations by delegate {
+
+        val recordedThreads: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+        fun clear() {
+            recordedThreads.clear()
+        }
+
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
+            record()
+            return delegate.findVerticesByLabel(label, filter)
+        }
+
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> {
+            record()
+            return delegate.findEdgesByLabel(label, filter)
+        }
+
+        override suspend fun createVertices(
+            label: String,
+            propertiesList: List<Map<String, Any?>>,
+        ): List<GraphVertex> {
+            record()
+            return delegate.createVertices(label, propertiesList)
+        }
+
+        override suspend fun createEdges(label: String, edges: List<BatchEdge>): List<GraphEdge> {
+            record()
+            return delegate.createEdges(label, edges)
+        }
+
+        private fun record() {
+            recordedThreads.add(Thread.currentThread().name)
+        }
     }
 }

--- a/graph-io/graphml/README.ko.md
+++ b/graph-io/graphml/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-graphml
 
+[English](README.md) | 한국어
+
 StAX 스트리밍 파서를 이용한 GraphML (XML) 대량 임포터 및 익스포터.
 
 ## 개요

--- a/graph-io/graphml/README.md
+++ b/graph-io/graphml/README.md
@@ -1,5 +1,7 @@
 # graph-io-graphml
 
+English | [한국어](README.ko.md)
+
 GraphML (XML) bulk importer and exporter using StAX streaming parser for efficient memory usage and performance.
 
 ## Overview

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkExporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkExporter.kt
@@ -20,11 +20,10 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 
 /**
- * GraphML 코루틴(suspend) 벌크 익스포터.
- * Flow로 정점/간선을 수집한 뒤 StAX 라이터로 XML 파일에 기록한다.
- */
-/**
  * Coroutine bulk exporter for GraphML.
+ *
+ * Graph reads stay in the caller coroutine context while blocking StAX writes
+ * are isolated on [Dispatchers.IO].
  *
  * Example:
  *
@@ -57,7 +56,7 @@ class SuspendGraphMlBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
         operations: GraphSuspendOperations,
         options: GraphExportOptions = GraphExportOptions(),
         graphMlOptions: GraphMlExportOptions = GraphMlExportOptions(),
-    ): GraphExportReport = withContext(Dispatchers.IO) {
+    ): GraphExportReport {
         log.debug { "Starting GRAPHML suspend export" }
         val watch = GraphIoStopwatch()
         val failures = mutableListOf<GraphIoFailure>()
@@ -73,11 +72,13 @@ class SuspendGraphMlBulkExporter : GraphSuspendBulkExporter<GraphExportSink> {
             }
         }
 
-        GraphIoPaths.openOutputStream(sink).use { output ->
-            writer.write(output, vertices, edges, graphMlOptions)
+        withContext(Dispatchers.IO) {
+            GraphIoPaths.openOutputStream(sink).use { output ->
+                writer.write(output, vertices, edges, graphMlOptions)
+            }
         }
 
-        GraphExportReport(
+        return GraphExportReport(
             status = if (failures.isEmpty()) GraphIoStatus.COMPLETED else GraphIoStatus.PARTIAL,
             format = GraphIoFormat.GRAPHML,
             verticesWritten = vertices.size.toLong(),

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/SuspendGraphMlBulkImporter.kt
@@ -27,8 +27,9 @@ import kotlinx.coroutines.withContext
 /**
  * Coroutine bulk importer for GraphML.
  *
- * StAX parsing runs on [Dispatchers.IO], and vertex/edge creation is delegated
- * to the provided suspend graph operations.
+ * StAX parsing runs on [Dispatchers.IO]. Vertex and edge creation stays in the
+ * caller coroutine context so backend implementations keep control over their
+ * own dispatcher policy.
  *
  * Example:
  *
@@ -61,11 +62,13 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
         operations: GraphSuspendOperations,
         options: GraphImportOptions = GraphImportOptions(),
         graphMlOptions: GraphMlImportOptions = GraphMlImportOptions(),
-    ): GraphImportReport = withContext(Dispatchers.IO) {
+    ): GraphImportReport {
         log.debug { "Starting GRAPHML suspend import" }
         val watch = GraphIoStopwatch()
 
-        val parsed = GraphIoPaths.openInputStream(source).use { reader.read(it, graphMlOptions) }
+        val parsed = withContext(Dispatchers.IO) {
+            GraphIoPaths.openInputStream(source).use { reader.read(it, graphMlOptions) }
+        }
 
         val idMap = GraphIoExternalIdMap(options.onDuplicateVertexId)
         val batchWriter = SuspendGraphIoBatchWriter(operations, options.batchSize)
@@ -84,7 +87,7 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
         }
 
         if (status == GraphIoStatus.FAILED) {
-            return@withContext GraphImportReport(
+            return GraphImportReport(
                 status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures
             )
         }
@@ -153,7 +156,7 @@ class SuspendGraphMlBulkImporter : GraphSuspendBulkImporter<GraphImportSource> {
             ec += batchWriter.flushEdges()
         }
 
-        GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
+        return GraphImportReport(status, GraphIoFormat.GRAPHML, vr, vc, er, ec, sv, se, watch.elapsed(), failures)
             .also { log.debug { "Suspend import completed: vertices=$vc/$vr, edges=$ec/$er, status=$status" } }
     }
 

--- a/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
+++ b/graph-io/graphml/src/main/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReader.kt
@@ -123,13 +123,22 @@ internal class StaxGraphMlReader {
 
         var label = options.defaultVertexLabel
         val props = mutableMapOf<String, Any?>()
-        for ((keyId, rawValue) in dataMap) {
+        for ((keyId, data) in dataMap) {
             val attrName = keyIdToName[keyId] ?: keyId
             val attrType = keyIdToType[keyId] ?: GraphMlAttrType.STRING
             if (attrName == options.labelAttrName) {
-                label = rawValue
+                label = data.value
             } else {
-                props[attrName] = attrType.coerce(rawValue)
+                coerceDataValue(
+                    attrType = attrType,
+                    rawValue = data.value,
+                    phase = GraphIoPhase.READ_VERTEX,
+                    elementName = "node",
+                    recordId = nodeId,
+                    columnName = attrName,
+                    location = data.location,
+                    failures = failures,
+                )?.let { props[attrName] = it }
             }
         }
         vertices += GraphIoVertexRecord(externalId = nodeId, label = label, properties = props)
@@ -169,13 +178,22 @@ internal class StaxGraphMlReader {
 
         var label = options.defaultEdgeLabel
         val props = mutableMapOf<String, Any?>()
-        for ((keyId, rawValue) in dataMap) {
+        for ((keyId, data) in dataMap) {
             val attrName = keyIdToName[keyId] ?: keyId
             val attrType = keyIdToType[keyId] ?: GraphMlAttrType.STRING
             if (attrName == options.labelAttrName) {
-                label = rawValue
+                label = data.value
             } else {
-                props[attrName] = attrType.coerce(rawValue)
+                coerceDataValue(
+                    attrType = attrType,
+                    rawValue = data.value,
+                    phase = GraphIoPhase.READ_EDGE,
+                    elementName = "edge",
+                    recordId = edgeId,
+                    columnName = attrName,
+                    location = data.location,
+                    failures = failures,
+                )?.let { props[attrName] = it }
             }
         }
         edges += GraphIoEdgeRecord(
@@ -187,21 +205,51 @@ internal class StaxGraphMlReader {
         )
     }
 
+    private fun coerceDataValue(
+        attrType: GraphMlAttrType,
+        rawValue: String,
+        phase: GraphIoPhase,
+        elementName: String,
+        recordId: String?,
+        columnName: String,
+        location: String?,
+        failures: MutableList<GraphIoFailure>,
+    ): Any? {
+        val coerced = attrType.coerce(rawValue)
+        if (attrType != GraphMlAttrType.STRING && coerced == rawValue) {
+            failures += GraphIoFailure(
+                phase = phase,
+                severity = GraphIoFailureSeverity.ERROR,
+                location = location,
+                fileRole = GraphIoFileRole.UNIFIED,
+                recordId = recordId,
+                columnName = columnName,
+                elementName = elementName,
+                message = "Invalid GraphML ${attrType.xmlName} value for '$columnName': $rawValue",
+            )
+            return null
+        }
+        return coerced
+    }
+
     /** 현재 요소의 `<data key="...">text</data>` 자식들을 읽어 keyId→value 맵으로 반환한다. */
     private fun readDataChildren(
         reader: XMLStreamReader,
         parentLocalName: String,
         options: GraphMlImportOptions,
         failures: MutableList<GraphIoFailure>,
-    ): Map<String, String> {
-        val result = mutableMapOf<String, String>()
+    ): Map<String, GraphMlDataValue> {
+        val result = mutableMapOf<String, GraphMlDataValue>()
         while (reader.hasNext()) {
             when (reader.next()) {
                 XMLStreamConstants.START_ELEMENT -> {
                     if (reader.localName == "data") {
                         val key = reader.getAttributeValue(null, "key") ?: continue
+                        val location = reader.location.lineNumber
+                            .takeIf { it > 0 }
+                            ?.let { "line:$it" }
                         val value = reader.elementText ?: ""
-                        result[key] = value
+                        result[key] = GraphMlDataValue(value, location)
                     } else {
                         when (reader.localName) {
                             "graph" -> recordUnsupportedElement(
@@ -219,6 +267,11 @@ internal class StaxGraphMlReader {
         }
         return result
     }
+
+    private data class GraphMlDataValue(
+        val value: String,
+        val location: String?,
+    )
 
     private fun skipElement(reader: XMLStreamReader, localName: String) {
         var depth = 1

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlSuspendTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/GraphMlSuspendTest.kt
@@ -5,13 +5,23 @@ import io.bluetape4k.graph.io.options.GraphImportOptions
 import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
+import io.bluetape4k.graph.model.BatchEdge
+import io.bluetape4k.graph.model.GraphEdge
+import io.bluetape4k.graph.model.GraphVertex
+import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphOperations
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import java.util.Collections
+import java.util.concurrent.Executors
 
 class GraphMlSuspendTest {
 
@@ -44,5 +54,83 @@ class GraphMlSuspendTest {
         importReport.status shouldBeEqualTo GraphIoStatus.COMPLETED
         importReport.verticesCreated shouldBeEqualTo 2L
         importReport.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend graphml graph operations stay on caller dispatcher`(@TempDir dir: Path) {
+        val dispatcher = Executors.newSingleThreadExecutor { task ->
+            Thread(task, "graphml-graph-caller")
+        }.asCoroutineDispatcher()
+
+        try {
+            runBlocking(dispatcher) {
+                val out = dir.resolve("caller.graphml")
+
+                val sourceOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations())
+                val alice = sourceOps.createVertex("Product", mapOf("name" to "Widget"))
+                val bob = sourceOps.createVertex("Product", mapOf("name" to "Gadget"))
+                sourceOps.createEdge(alice.id, bob.id, "SIMILAR", mapOf("score" to 0.8))
+                sourceOps.clear()
+
+                SuspendGraphMlBulkExporter().exportGraphSuspending(
+                    GraphExportSink.PathSink(out),
+                    sourceOps,
+                    GraphExportOptions(vertexLabels = setOf("Product"), edgeLabels = setOf("SIMILAR")),
+                )
+
+                sourceOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                sourceOps.recordedThreads.all { it.startsWith("graphml-graph-caller") }.shouldBeTrue()
+
+                val targetOps = ThreadRecordingSuspendOperations(TinkerGraphSuspendOperations(TinkerGraphOperations()))
+                SuspendGraphMlBulkImporter().importGraphSuspending(
+                    GraphImportSource.PathSource(out),
+                    targetOps,
+                    GraphImportOptions(),
+                )
+
+                targetOps.recordedThreads.isNotEmpty().shouldBeTrue()
+                targetOps.recordedThreads.all { it.startsWith("graphml-graph-caller") }.shouldBeTrue()
+            }
+        } finally {
+            dispatcher.close()
+        }
+    }
+
+    private class ThreadRecordingSuspendOperations(
+        private val delegate: GraphSuspendOperations,
+    ): GraphSuspendOperations by delegate {
+
+        val recordedThreads: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+        fun clear() {
+            recordedThreads.clear()
+        }
+
+        override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphVertex> {
+            record()
+            return delegate.findVerticesByLabel(label, filter)
+        }
+
+        override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): Flow<GraphEdge> {
+            record()
+            return delegate.findEdgesByLabel(label, filter)
+        }
+
+        override suspend fun createVertices(
+            label: String,
+            propertiesList: List<Map<String, Any?>>,
+        ): List<GraphVertex> {
+            record()
+            return delegate.createVertices(label, propertiesList)
+        }
+
+        override suspend fun createEdges(label: String, edges: List<BatchEdge>): List<GraphEdge> {
+            record()
+            return delegate.createEdges(label, edges)
+        }
+
+        private fun record() {
+            recordedThreads.add(Thread.currentThread().name)
+        }
     }
 }

--- a/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
+++ b/graph-io/graphml/src/test/kotlin/io/bluetape4k/graph/io/graphml/internal/StaxGraphMlReaderWriterTest.kt
@@ -141,6 +141,57 @@ class StaxGraphMlReaderWriterTest {
     }
 
     @Test
+    fun `reader records errors for invalid typed data values`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <key id="age" for="node" attr.name="age" attr.type="int"/>
+  <key id="score" for="edge" attr.name="score" attr.type="double"/>
+  <graph id="G" edgedefault="directed">
+    <node id="n1"><data key="age">not-an-int</data></node>
+    <node id="n2"><data key="age">42</data></node>
+    <edge id="e1" source="n1" target="n2"><data key="score">not-a-double</data></edge>
+  </graph>
+</graphml>"""
+
+        val result = reader.read(ByteArrayInputStream(xml.toByteArray()))
+
+        result.vertices shouldHaveSize 2
+        result.edges shouldHaveSize 1
+        result.failures shouldHaveSize 2
+        result.failures.map { it.severity }.toSet() shouldBeEqualTo setOf(GraphIoFailureSeverity.ERROR)
+        result.failures.map { it.columnName } shouldContain "age"
+        result.failures.map { it.columnName } shouldContain "score"
+        result.failures.map { it.message } shouldContain "Invalid GraphML int value for 'age': not-an-int"
+        result.failures.map { it.message } shouldContain "Invalid GraphML double value for 'score': not-a-double"
+        result.vertices[0].properties.containsKey("age") shouldBeEqualTo false
+        result.vertices[1].properties["age"] shouldBeEqualTo 42
+        result.edges[0].properties.containsKey("score") shouldBeEqualTo false
+    }
+
+    @Test
+    fun `bulk importer fails before writes for invalid typed data values`() {
+        val xml = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/graphml">
+  <key id="age" for="node" attr.name="age" attr.type="int"/>
+  <graph id="G" edgedefault="directed">
+    <node id="n1"><data key="age">not-an-int</data></node>
+  </graph>
+</graphml>"""
+
+        val report = GraphMlBulkImporter().importGraph(
+            GraphImportSource.InputStreamSource(ByteArrayInputStream(xml.toByteArray()), closeInput = true),
+            TinkerGraphOperations(),
+            GraphImportOptions(),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.verticesRead shouldBeEqualTo 1L
+        report.verticesCreated shouldBeEqualTo 0L
+        report.failures shouldHaveSize 1
+        report.failures.single().columnName shouldBeEqualTo "age"
+    }
+
+    @Test
     fun `reader records warnings for unsupported graphml fixture with SKIP policy`() {
         val result = fixture("unsupported-constructs.graphml").use { reader.read(it) }
 

--- a/graph-io/jackson2/README.ko.md
+++ b/graph-io/jackson2/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-jackson2
 
+[English](README.md) | 한국어
+
 Jackson 2.x를 사용한 NDJSON(Newline-Delimited JSON) 그래프 데이터 벌크 임포터/익스포터.
 
 ## 개요

--- a/graph-io/jackson2/README.md
+++ b/graph-io/jackson2/README.md
@@ -1,5 +1,7 @@
 # graph-io-jackson2
 
+English | [한국어](README.ko.md)
+
 Jackson 2.x NDJSON (Newline-Delimited JSON) bulk importer and exporter for graph database operations.
 
 ## Overview

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
@@ -24,7 +24,11 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CancellationException
 
 /**
  * Coroutine NDJSON bulk importer backed by Jackson 2.
@@ -63,56 +67,98 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         var vr = 0L; var vc = 0L; var er = 0L; var ec = 0L; var sv = 0L; var se = 0L
         var status = GraphIoStatus.COMPLETED
 
-        val lines = withContext(Dispatchers.IO) {
-            GraphIoPaths.openReader(source).use { it.readLines() }
-        }
-
-        for ((index, raw) in lines.withIndex()) {
-            if (status == GraphIoStatus.FAILED) break
-            val lineNo = index + 1
-            val line = raw.trim().ifBlank { continue }
-            val env = runCatching { codec.parseLine(line) }.getOrElse { e ->
-                log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
-                failures += GraphIoFailure(
-                    phase = GraphIoPhase.READ_VERTEX,
-                    fileRole = GraphIoFileRole.UNIFIED,
-                    location = "line:$lineNo",
-                    message = "Malformed JSON: ${e.message}",
-                )
-                status = GraphIoStatus.FAILED
-                break
-            }
-            when (env.type) {
-                NdJsonEnvelope.TYPE_VERTEX -> {
-                    vr++
-                    val rec = codec.toVertex(env, options.defaultVertexLabel)
-                    val props = options.preserveExternalIdProperty
-                        ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
-                    when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
-                        GraphIoExternalIdMap.PutResult.CREATED -> {
-                            vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+        val coroutineContext = currentCoroutineContext()
+        val reader = withContext(Dispatchers.IO) { GraphIoPaths.openReader(source) }
+        try {
+            var lineNo = 0
+            while (status != GraphIoStatus.FAILED) {
+                coroutineContext.ensureActive()
+                val raw = withContext(Dispatchers.IO) { reader.readLine() } ?: break
+                lineNo++
+                val line = raw.trim().ifBlank { continue }
+                val env = try {
+                    codec.parseLine(line)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
+                    failures += GraphIoFailure(
+                        phase = GraphIoPhase.READ_VERTEX,
+                        fileRole = GraphIoFileRole.UNIFIED,
+                        location = "line:$lineNo",
+                        message = "Malformed JSON: ${e.message}",
+                    )
+                    status = GraphIoStatus.FAILED
+                    break
+                }
+                when (env.type) {
+                    NdJsonEnvelope.TYPE_VERTEX -> {
+                        val rec = try {
+                            codec.toVertex(env, options.defaultVertexLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_VERTEX,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid vertex envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
                         }
-                        GraphIoExternalIdMap.PutResult.SKIPPED -> {
-                            sv++
-                            status = GraphIoStatus.PARTIAL
+                        vr++
+                        val props = options.preserveExternalIdProperty
+                            ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
+                        when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
+                            GraphIoExternalIdMap.PutResult.CREATED -> {
+                                vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+                            }
+                            GraphIoExternalIdMap.PutResult.SKIPPED -> {
+                                sv++
+                                status = GraphIoStatus.PARTIAL
+                            }
                         }
                     }
-                }
-                NdJsonEnvelope.TYPE_EDGE -> {
-                    er++
-                    bufferedEdges += codec.toEdge(env, options.defaultEdgeLabel)
-                    if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                    NdJsonEnvelope.TYPE_EDGE -> {
+                        val rec = try {
+                            codec.toEdge(env, options.defaultEdgeLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid edge envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
+                        }
+                        er++
+                        bufferedEdges += rec
+                        if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}; " +
+                                    "verticesCreated=$vc remain in graph as partial state",
+                            )
+                            status = GraphIoStatus.FAILED
+                        }
+                    }
+                    else -> {
                         failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
+                            phase = GraphIoPhase.READ_VERTEX,
+                            severity = GraphIoFailureSeverity.WARN,
                             fileRole = GraphIoFileRole.UNIFIED,
                             location = "line:$lineNo",
-                            message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}",
+                            message = "Unknown envelope type=${env.type}",
                         )
-                        status = GraphIoStatus.FAILED
+                        status = GraphIoStatus.PARTIAL
                     }
                 }
-                else -> {}
             }
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) { reader.close() }
         }
 
         vc += batchWriter.flushVertices(idMap)
@@ -143,6 +189,13 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
                     MissingEndpointPolicy.SKIP_EDGE -> {
                         se++
                         status = GraphIoStatus.PARTIAL
+                        failures += GraphIoFailure(
+                            phase = GraphIoPhase.READ_EDGE,
+                            severity = GraphIoFailureSeverity.WARN,
+                            fileRole = GraphIoFileRole.UNIFIED,
+                            recordId = e.externalId,
+                            message = "Missing endpoint skipped from=${e.fromExternalId} to=${e.toExternalId}",
+                        )
                         continue
                     }
                 }

--- a/graph-io/jackson2/src/test/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2SuspendTest.kt
+++ b/graph-io/jackson2/src/test/kotlin/io/bluetape4k/graph/io/jackson2/Jackson2SuspendTest.kt
@@ -6,10 +6,12 @@ import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 
 class Jackson2SuspendTest {
@@ -38,5 +40,21 @@ class Jackson2SuspendTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend importer reports invalid vertex envelope`(@TempDir dir: Path) = runTest {
+        val input = dir.resolve("invalid-vertex.ndjson")
+        Files.writeString(input, """{"type":"vertex","label":"Person"}""" + "\n")
+
+        val report = SuspendJackson2NdJsonBulkImporter().importGraphSuspending(
+            GraphImportSource.PathSource(input),
+            TinkerGraphSuspendOperations(),
+            GraphImportOptions(),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.failures.single().location shouldBeEqualTo "line:1"
+        report.failures.single().message shouldContain "missing id"
     }
 }

--- a/graph-io/jackson3/README.ko.md
+++ b/graph-io/jackson3/README.ko.md
@@ -1,5 +1,7 @@
 # graph-io-jackson3
 
+[English](README.md) | 한국어
+
 Bluetape4k 그래프 연산을 위한 Jackson 3.x 기반 NDJSON 벌크 임포터/익스포터.
 
 ## 개요

--- a/graph-io/jackson3/README.md
+++ b/graph-io/jackson3/README.md
@@ -1,5 +1,7 @@
 # graph-io-jackson3
 
+English | [한국어](README.ko.md)
+
 Jackson 3.x based NDJSON bulk importer and exporter for Bluetape4k graph operations.
 
 ## Overview

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
@@ -24,7 +24,11 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CancellationException
 
 /**
  * Coroutine NDJSON bulk importer backed by Jackson 3.
@@ -63,56 +67,98 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         var vr = 0L; var vc = 0L; var er = 0L; var ec = 0L; var sv = 0L; var se = 0L
         var status = GraphIoStatus.COMPLETED
 
-        val lines = withContext(Dispatchers.IO) {
-            GraphIoPaths.openReader(source).use { it.readLines() }
-        }
-
-        for ((index, raw) in lines.withIndex()) {
-            if (status == GraphIoStatus.FAILED) break
-            val lineNo = index + 1
-            val line = raw.trim().ifBlank { continue }
-            val env = runCatching { codec.parseLine(line) }.getOrElse { e ->
-                log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
-                failures += GraphIoFailure(
-                    phase = GraphIoPhase.READ_VERTEX,
-                    fileRole = GraphIoFileRole.UNIFIED,
-                    location = "line:$lineNo",
-                    message = "Malformed JSON: ${e.message}",
-                )
-                status = GraphIoStatus.FAILED
-                break
-            }
-            when (env.type) {
-                NdJsonEnvelope.TYPE_VERTEX -> {
-                    vr++
-                    val rec = codec.toVertex(env, options.defaultVertexLabel)
-                    val props = options.preserveExternalIdProperty
-                        ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
-                    when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
-                        GraphIoExternalIdMap.PutResult.CREATED -> {
-                            vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+        val coroutineContext = currentCoroutineContext()
+        val reader = withContext(Dispatchers.IO) { GraphIoPaths.openReader(source) }
+        try {
+            var lineNo = 0
+            while (status != GraphIoStatus.FAILED) {
+                coroutineContext.ensureActive()
+                val raw = withContext(Dispatchers.IO) { reader.readLine() } ?: break
+                lineNo++
+                val line = raw.trim().ifBlank { continue }
+                val env = try {
+                    codec.parseLine(line)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
+                    failures += GraphIoFailure(
+                        phase = GraphIoPhase.READ_VERTEX,
+                        fileRole = GraphIoFileRole.UNIFIED,
+                        location = "line:$lineNo",
+                        message = "Malformed JSON: ${e.message}",
+                    )
+                    status = GraphIoStatus.FAILED
+                    break
+                }
+                when (env.type) {
+                    NdJsonEnvelope.TYPE_VERTEX -> {
+                        val rec = try {
+                            codec.toVertex(env, options.defaultVertexLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_VERTEX,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid vertex envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
                         }
-                        GraphIoExternalIdMap.PutResult.SKIPPED -> {
-                            sv++
-                            status = GraphIoStatus.PARTIAL
+                        vr++
+                        val props = options.preserveExternalIdProperty
+                            ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
+                        when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
+                            GraphIoExternalIdMap.PutResult.CREATED -> {
+                                vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
+                            }
+                            GraphIoExternalIdMap.PutResult.SKIPPED -> {
+                                sv++
+                                status = GraphIoStatus.PARTIAL
+                            }
                         }
                     }
-                }
-                NdJsonEnvelope.TYPE_EDGE -> {
-                    er++
-                    bufferedEdges += codec.toEdge(env, options.defaultEdgeLabel)
-                    if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                    NdJsonEnvelope.TYPE_EDGE -> {
+                        val rec = try {
+                            codec.toEdge(env, options.defaultEdgeLabel)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Invalid edge envelope: ${e.message}",
+                            )
+                            status = GraphIoStatus.FAILED
+                            break
+                        }
+                        er++
+                        bufferedEdges += rec
+                        if (bufferedEdges.size > options.maxEdgeBufferSize) {
+                            failures += GraphIoFailure(
+                                phase = GraphIoPhase.READ_EDGE,
+                                fileRole = GraphIoFileRole.UNIFIED,
+                                location = "line:$lineNo",
+                                message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}; " +
+                                    "verticesCreated=$vc remain in graph as partial state",
+                            )
+                            status = GraphIoStatus.FAILED
+                        }
+                    }
+                    else -> {
                         failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
+                            phase = GraphIoPhase.READ_VERTEX,
+                            severity = GraphIoFailureSeverity.WARN,
                             fileRole = GraphIoFileRole.UNIFIED,
                             location = "line:$lineNo",
-                            message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}",
+                            message = "Unknown envelope type=${env.type}",
                         )
-                        status = GraphIoStatus.FAILED
+                        status = GraphIoStatus.PARTIAL
                     }
                 }
-                else -> {}
             }
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) { reader.close() }
         }
 
         vc += batchWriter.flushVertices(idMap)
@@ -143,6 +189,13 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
                     MissingEndpointPolicy.SKIP_EDGE -> {
                         se++
                         status = GraphIoStatus.PARTIAL
+                        failures += GraphIoFailure(
+                            phase = GraphIoPhase.READ_EDGE,
+                            severity = GraphIoFailureSeverity.WARN,
+                            fileRole = GraphIoFileRole.UNIFIED,
+                            recordId = e.externalId,
+                            message = "Missing endpoint skipped from=${e.fromExternalId} to=${e.toExternalId}",
+                        )
                         continue
                     }
                 }

--- a/graph-io/jackson3/src/test/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3SuspendTest.kt
+++ b/graph-io/jackson3/src/test/kotlin/io/bluetape4k/graph/io/jackson3/Jackson3SuspendTest.kt
@@ -6,10 +6,12 @@ import io.bluetape4k.graph.io.report.GraphIoStatus
 import io.bluetape4k.graph.io.source.GraphExportSink
 import io.bluetape4k.graph.io.source.GraphImportSource
 import io.bluetape4k.graph.tinkerpop.TinkerGraphSuspendOperations
-import kotlinx.coroutines.test.runTest
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldBeEqualTo
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 
 class Jackson3SuspendTest {
@@ -38,5 +40,21 @@ class Jackson3SuspendTest {
         report.status shouldBeEqualTo GraphIoStatus.COMPLETED
         report.verticesCreated shouldBeEqualTo 2L
         report.edgesCreated shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `suspend importer reports invalid vertex envelope`(@TempDir dir: Path) = runTest {
+        val input = dir.resolve("invalid-vertex.ndjson")
+        Files.writeString(input, """{"type":"vertex","label":"Person"}""" + "\n")
+
+        val report = SuspendJackson3NdJsonBulkImporter().importGraphSuspending(
+            GraphImportSource.PathSource(input),
+            TinkerGraphSuspendOperations(),
+            GraphImportOptions(),
+        )
+
+        report.status shouldBeEqualTo GraphIoStatus.FAILED
+        report.failures.single().location shouldBeEqualTo "line:1"
+        report.failures.single().message shouldContain "missing id"
     }
 }

--- a/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
+++ b/graph-io/okio/src/main/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPaths.kt
@@ -89,17 +89,24 @@ object GraphIoOkioPaths : KLogging() {
      * @throws IOException when the path cannot be opened for writing
      */
     @Throws(IOException::class)
-    fun openSink(sink: OkioGraphExportSink): BufferedSink = when (sink) {
+    fun openSink(sink: OkioGraphExportSink): BufferedSink =
+        openSinkHandle(sink).sink
+
+    private fun openSinkHandle(sink: OkioGraphExportSink): OpenedSink = when (sink) {
         is OkioGraphExportSink.PathSink -> openPathSink(sink)
 
         is OkioGraphExportSink.SinkBased ->
-            if (sink.ownsSink) sink.sink.buffer()
-            else nonClosingSink(sink.sink).buffer()
+            OpenedSink(
+                if (sink.ownsSink) sink.sink.buffer()
+                else nonClosingSink(sink.sink).buffer()
+            )
 
         is OkioGraphExportSink.OutputStreamBased -> {
             val rawSink = sink.outputStream.sink()
-            if (sink.ownsStream) rawSink.buffer()
-            else nonClosingSink(rawSink).buffer()
+            OpenedSink(
+                if (sink.ownsStream) rawSink.buffer()
+                else nonClosingSink(rawSink).buffer()
+            )
         }
     }
 
@@ -192,10 +199,12 @@ object GraphIoOkioPaths : KLogging() {
      */
     @Throws(IOException::class)
     fun openGzipSink(sink: OkioGraphExportSink): BufferedSink {
-        val bs = openSink(sink)
+        val opened = openSinkHandle(sink)
+        val bs = opened.sink
         return try {
             openCompressedSink(bs, Compressor.GZIP)
         } catch (e: Throwable) {
+            opened.abort()
             try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip init failure" } }
             throw e
         }
@@ -213,10 +222,12 @@ object GraphIoOkioPaths : KLogging() {
         chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
         associatedData: ByteArray = ByteArray(0),
     ): BufferedSink {
-        val bs = openSink(sink)
+        val opened = openSinkHandle(sink)
+        val bs = opened.sink
         return try {
             openDaeadEncryptedSink(bs, daead, chunkSize, associatedData)
         } catch (e: Throwable) {
+            opened.abort()
             try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after DAEAD init failure" } }
             throw e
         }
@@ -234,11 +245,13 @@ object GraphIoOkioPaths : KLogging() {
         chunkSize: Int = DEFAULT_DAEAD_CHUNK_SIZE,
         associatedData: ByteArray = ByteArray(0),
     ): BufferedSink {
-        val bs = openSink(sink)
+        val opened = openSinkHandle(sink)
+        val bs = opened.sink
         return try {
             val encrypted = openDaeadEncryptedSink(bs, daead, chunkSize, associatedData)
             openCompressedSink(encrypted, Compressor.GZIP)
         } catch (e: Throwable) {
+            opened.abort()
             try { bs.close() } catch (ce: Throwable) { log.warn(ce) { "Failed to close sink after gzip+DAEAD init failure" } }
             throw e
         }
@@ -311,7 +324,7 @@ object GraphIoOkioPaths : KLogging() {
 
     /** Opens a [OkioGraphExportSink.PathSink] and applies the atomic-write strategy when requested. */
     @Throws(IOException::class)
-    private fun openPathSink(sink: OkioGraphExportSink.PathSink): BufferedSink {
+    private fun openPathSink(sink: OkioGraphExportSink.PathSink): OpenedSink {
         val fs = sink.fileSystem
         val target = sink.path
 
@@ -326,7 +339,7 @@ object GraphIoOkioPaths : KLogging() {
         }
 
         if (!sink.atomicWrite) {
-            return fs.sink(target, mustCreate = false).buffer()
+            return OpenedSink(fs.sink(target, mustCreate = false).buffer())
         }
 
         // atomicWrite=true: temporary path, then atomicMove.
@@ -335,7 +348,11 @@ object GraphIoOkioPaths : KLogging() {
             ?: ("${target}.tmp.${UUID.randomUUID()}".toPath())
 
         val rawSink = fs.sink(tmpPath, mustCreate = false)
-        return AtomicMoveSink(rawSink, tmpPath, target, fs).buffer()
+        val atomicSink = AtomicMoveSink(rawSink, tmpPath, target, fs)
+        return OpenedSink(
+            sink = atomicSink.buffer(),
+            abort = atomicSink::abort,
+        )
     }
 
     /** Wrapper that does not close the underlying caller-owned source. */
@@ -372,6 +389,15 @@ object GraphIoOkioPaths : KLogging() {
         }
     }
 
+    private data class OpenedSink(
+        val sink: BufferedSink,
+        private val abort: (() -> Unit)? = null,
+    ) {
+        fun abort() {
+            abort?.invoke()
+        }
+    }
+
     /**
      * Sink wrapper that atomically moves a temporary file to the target path on close.
      *
@@ -385,6 +411,10 @@ object GraphIoOkioPaths : KLogging() {
     ) : ForwardingSink(delegate) {
         @Volatile
         private var failed = false
+
+        fun abort() {
+            failed = true
+        }
 
         override fun write(source: Buffer, byteCount: Long) {
             try {

--- a/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
+++ b/graph-io/okio/src/test/kotlin/io/bluetape4k/graph/io/okio/GraphIoOkioPathsTest.kt
@@ -167,6 +167,24 @@ class GraphIoOkioPathsTest {
     }
 
     @Test
+    fun `atomicWrite DAEAD setup failure leaves target unchanged and deletes tmp`() {
+        ensureTmpDir()
+        val path = "/tmp/graph-setup-fail.enc".toPath()
+        fakeFs.write(path) { writeUtf8("ORIGINAL") }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoOkioPaths.openDaeadEncryptedSink(
+                sink = OkioGraphExportSink.PathSink(path, fakeFs, atomicWrite = true),
+                daead = TinkDaeads.AES256_SIV,
+                chunkSize = 0,
+            )
+        }
+
+        fakeFs.read(path) { readUtf8() } shouldBeEqualTo "ORIGINAL"
+        tempFilesFor(path) shouldBeEqualTo emptyList()
+    }
+
+    @Test
     fun `gzip DAEAD chunk round trip with FakeFileSystem`() {
         ensureTmpDir()
         val path = "/tmp/graph.ndjson.gz.enc".toPath()
@@ -186,6 +204,24 @@ class GraphIoOkioPathsTest {
         ).use { bs -> bs.readUtf8() }
 
         result shouldBeEqualTo data.repeat(100)
+    }
+
+    @Test
+    fun `atomicWrite gzip DAEAD setup failure leaves target unchanged and deletes tmp`() {
+        ensureTmpDir()
+        val path = "/tmp/graph-setup-fail.ndjson.gz.enc".toPath()
+        fakeFs.write(path) { writeUtf8("ORIGINAL") }
+
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoOkioPaths.openGzipDaeadEncryptedSink(
+                sink = OkioGraphExportSink.PathSink(path, fakeFs, atomicWrite = true),
+                daead = TinkDaeads.AES256_SIV,
+                chunkSize = 0,
+            )
+        }
+
+        fakeFs.read(path) { readUtf8() } shouldBeEqualTo "ORIGINAL"
+        tempFilesFor(path) shouldBeEqualTo emptyList()
     }
 
     @Test
@@ -274,4 +310,8 @@ class GraphIoOkioPathsTest {
 
         result shouldBeEqualTo data
     }
+
+    private fun tempFilesFor(path: okio.Path): List<okio.Path> =
+        fakeFs.list(path.parent ?: "/".toPath())
+            .filter { it.segments.last().startsWith("${path.segments.last()}.tmp.") }
 }

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeCreateGraphFailures.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeCreateGraphFailures.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.graph.age
+
+import io.bluetape4k.graph.GraphQueryException
+import java.sql.SQLException
+
+private val duplicateGraphSqlStates = setOf(
+    "42710", // duplicate_object
+    "42P04", // duplicate_database
+)
+
+internal fun Throwable.isDuplicateGraphFailure(): Boolean {
+    val sqlStateMatches = generateSequence(this) { it.cause }
+        .filterIsInstance<SQLException>()
+        .mapNotNull { it.sqlState }
+        .any { it in duplicateGraphSqlStates }
+    if (sqlStateMatches) return true
+
+    val diagnosticText = generateSequence(this) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(" ")
+        .lowercase()
+
+    return "graph" in diagnosticText && "already exists" in diagnosticText
+}
+
+internal fun Throwable.asCreateGraphFailure(name: String): GraphQueryException =
+    this as? GraphQueryException
+        ?: GraphQueryException("AGE createGraph failed: graph=$name", this)

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphOperations.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphOperations.kt
@@ -105,8 +105,11 @@ class AgeGraphOperations(
             try {
                 exec(AgeSql.createGraph(name))
             } catch (e: Exception) {
-                // 이미 존재하는 경우 무시
-                log.debug("Graph '$name' may already exist: ${e.message}")
+                if (e.isDuplicateGraphFailure()) {
+                    log.debug("Graph '$name' already exists: ${e.message}")
+                } else {
+                    throw e.asCreateGraphFailure(name)
+                }
             }
         }
     }

--- a/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperations.kt
+++ b/graph/graph-age/src/main/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperations.kt
@@ -31,6 +31,7 @@ import io.bluetape4k.graph.schema.asSuspendSchemaManager
 import io.bluetape4k.graph.support.requireSafeIdentifier
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -129,9 +130,14 @@ class AgeGraphSuspendOperations(
         newSuspendedTransaction {
             try {
                 exec(AgeSql.createGraph(name))
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                // 이미 존재하는 경우 무시
-                log.debug("Graph '$name' may already exist: ${e.message}")
+                if (e.isDuplicateGraphFailure()) {
+                    log.debug("Graph '$name' already exists: ${e.message}")
+                } else {
+                    throw e.asCreateGraphFailure(name)
+                }
             }
         }
     }

--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeCreateGraphFailuresTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeCreateGraphFailuresTest.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.graph.age
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import org.junit.jupiter.api.Test
+import java.sql.SQLException
+
+class AgeCreateGraphFailuresTest {
+
+    @Test
+    fun `duplicate graph SQLState is treated as compatibility duplicate`() {
+        SQLException("ERROR: graph already exists", "42710")
+            .isDuplicateGraphFailure()
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `duplicate graph message is treated as compatibility duplicate`() {
+        IllegalStateException("ERROR: graph 'test_graph' already exists")
+            .isDuplicateGraphFailure()
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `permission failures are not treated as duplicates`() {
+        SQLException("ERROR: permission denied for schema ag_catalog", "42501")
+            .isDuplicateGraphFailure()
+            .shouldBeFalse()
+    }
+
+    @Test
+    fun `non duplicate createGraph failure keeps context`() {
+        val cause = SQLException("ERROR: permission denied for schema ag_catalog", "42501")
+        val ex = cause.asCreateGraphFailure("test_graph")
+
+        ex.message shouldContain "AGE createGraph failed"
+        ex.cause shouldBeInstanceOf SQLException::class
+    }
+}

--- a/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperationsTest.kt
+++ b/graph/graph-age/src/test/kotlin/io/bluetape4k/graph/age/AgeGraphSuspendOperationsTest.kt
@@ -81,6 +81,14 @@ class AgeGraphSuspendOperationsTest {
 
     @Test
     @Order(11)
+    fun `이미 존재하는 그래프 생성은 호환성 duplicate로 허용한다`() = runSuspendIO {
+        ops.createGraph(graphName)
+
+        ops.graphExists(graphName).shouldBeTrue()
+    }
+
+    @Test
+    @Order(12)
     fun `그래프를 삭제하면 존재 여부가 false 반환`() = runSuspendIO {
         ops.dropGraph(graphName)
         ops.graphExists(graphName).shouldBeFalse()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/CompletableFutureNullableSupport.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/concurrent/virtualthread/CompletableFutureNullableSupport.kt
@@ -3,20 +3,20 @@ package io.bluetape4k.concurrent.virtualthread
 import java.util.concurrent.CompletableFuture
 
 /**
- * nullable 결과를 반환하는 block을 Virtual Thread 위에서 비동기로 실행하고 [CompletableFuture]를 반환합니다.
+ * Runs a nullable-result block asynchronously on a virtual thread and returns a [CompletableFuture].
  *
- * [virtualFutureOf]와 달리 `V` 타입에 `Any` 제약이 없어 nullable 반환 타입에 사용할 수 있습니다.
+ * Unlike [virtualFutureOf], `V` is not bounded by `Any`, so nullable result types are supported.
  *
  * ```kotlin
  * val future: CompletableFuture<GraphVertex?> = virtualFutureOfNullable {
- *     repository.findVertexById(label, id)  // GraphVertex? 반환
+ *     repository.findVertexById(label, id)  // returns GraphVertex?
  * }
  * val result: GraphVertex? = future.join()
  * ```
  *
- * @param V 작업 결과 타입 (nullable 허용)
- * @param block 비동기로 수행할 작업
- * @return Virtual Thread 위에서 [block]을 실행하는 [CompletableFuture] 인스턴스
+ * @param V task result type, including nullable values.
+ * @param block task to run asynchronously.
+ * @return [CompletableFuture] that runs [block] on a virtual thread.
  */
 inline fun <V> virtualFutureOfNullable(
     crossinline block: () -> V?,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/GraphExceptions.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/GraphExceptions.kt
@@ -1,15 +1,15 @@
 package io.bluetape4k.graph
 
 /**
- * Graph 모듈 최상위 예외.
+ * Base exception for the graph module.
  *
  * ```kotlin
  * try {
  *     ops.createGraph("existing")
  * } catch (e: GraphAlreadyExistsException) {
- *     // 이미 존재하는 그래프 처리
+ *     // Handle an existing graph.
  * } catch (e: GraphQueryException) {
- *     // Cypher/SQL 실행 오류 처리
+ *     // Handle Cypher/SQL execution errors.
  * }
  * ```
  */
@@ -21,7 +21,7 @@ open class GraphException: RuntimeException {
 }
 
 /**
- * 지정한 그래프를 찾을 수 없을 때 발생하는 예외.
+ * Thrown when a graph cannot be found.
  *
  * ```kotlin
  * throw GraphNotFoundException("social")
@@ -35,7 +35,7 @@ class GraphNotFoundException: GraphException {
 }
 
 /**
- * 동일한 이름의 그래프가 이미 존재할 때 발생하는 예외.
+ * Thrown when a graph with the same name already exists.
  *
  * ```kotlin
  * throw GraphAlreadyExistsException("social")
@@ -49,7 +49,7 @@ class GraphAlreadyExistsException: GraphException {
 }
 
 /**
- * 그래프 쿼리 실행 실패 시 발생하는 예외.
+ * Thrown when graph query execution fails.
  *
  * ```kotlin
  * throw GraphQueryException("Failed to create vertex: Person")
@@ -63,7 +63,7 @@ class GraphQueryException: GraphException {
 }
 
 /**
- * 그래프가 초기화되지 않은 상태에서 접근할 때 발생하는 예외.
+ * Thrown when a graph is accessed before initialization.
  *
  * ```kotlin
  * throw GraphNotInitializedException("social graph is not initialized")

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/AStarRunner.kt
@@ -11,17 +11,17 @@ import io.bluetape4k.logging.warn
 import java.util.*
 
 /**
- * A* 알고리즘으로 휴리스틱 유도 최단 경로를 계산한다.
+ * Computes a heuristic-guided shortest path with the A* algorithm.
  *
- * ## 설계 결정
- * - [heuristic]은 동기 함수만 허용한다 (`suspend` 불가). 코루틴 컨텍스트 내에서도 동기 호출.
- * - 허용 가능(admissible) 휴리스틱: `h(n) <= 실제_비용(n, goal)`. 위반 시 최적성 보장 불가.
- * - tie-break은 DijkstraRunner와 동일하게 vertexId 사전순.
+ * ## Design decisions
+ * - [heuristic] is synchronous only; suspend heuristics are not supported.
+ * - Admissible heuristic: `h(n) <= actualCost(n, goal)`. Violating this loses optimality guarantees.
+ * - Tie-breaks use the same lexicographic vertex ID ordering as [DijkstraRunner].
  *
- * ### 사용 예제
+ * ### Usage
  *
  * ```kotlin
- * // 좌표 기반 유클리드 휴리스틱 — 2D 격자에서 admissible
+ * // Coordinate-based Euclidean heuristic, admissible on a 2D grid.
  * val coords: Map<String, Pair<Double, Double>> = ...
  * val goalId = "C"
  *
@@ -42,9 +42,9 @@ import java.util.*
  * )
  * ```
  *
- * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수.
- * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
- * @param heuristic 목표 정점까지의 예상 비용 함수. 반드시 허용 가능해야 한다.
+ * @param fetchEdges vertex ID to adjacent edges lookup.
+ * @param fetchVertex vertex ID to [GraphVertex] lookup.
+ * @param heuristic estimated cost to the target vertex. It must be admissible.
  */
 class AStarRunner(
     private val fetchEdges: (GraphElementId) -> List<GraphEdge>,
@@ -53,7 +53,7 @@ class AStarRunner(
 ) {
     companion object : KLogging()
 
-    /** PriorityQueue 엔트리 — Triple 대비 박싱 2회 절감 */
+    /** PriorityQueue entry; avoids two boxing operations compared with Triple. */
     private data class AStarNode(val f: Double, val g: Double, val id: GraphElementId) : Comparable<AStarNode> {
         override fun compareTo(other: AStarNode): Int {
             val cmp = f.compareTo(other.f)
@@ -62,13 +62,13 @@ class AStarRunner(
     }
 
     /**
-     * A* 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.
-     *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (weightProperty, missingWeightPolicy, maxVisited).
-     * @return 최단 [GraphPath], 경로가 없으면 `null`.
-     * @throws IllegalArgumentException [PathOptions.weightProperty]가 null인 경우.
+     * Computes the shortest path from [fromId] to [toId] with the A* algorithm.
+	*
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options (`weightProperty`, `missingWeightPolicy`, `maxVisited`).
+     * @return shortest [GraphPath], or `null` when no path exists.
+     * @throws IllegalArgumentException when [PathOptions.weightProperty] is null.
      */
     fun run(
         fromId: GraphElementId,
@@ -80,7 +80,7 @@ class AStarRunner(
         }
         val extractor = WeightExtractor(weightProperty, options.missingWeightPolicy)
 
-        // f = g + h; AStarNode: Comparable — Comparator 불필요
+        // f = g + h; AStarNode is Comparable, so no Comparator is needed.
         val pq = PriorityQueue<AStarNode>()
         val gScore = mutableMapOf<GraphElementId, Double>()
         val cameFrom = mutableMapOf<GraphElementId, Pair<GraphVertex, GraphEdge>>()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/DijkstraRunner.kt
@@ -11,15 +11,15 @@ import io.bluetape4k.logging.warn
 import java.util.*
 
 /**
- * Dijkstra 알고리즘으로 단일 출발지 최단 경로를 계산한다.
+ * Computes a single-source shortest path with Dijkstra's algorithm.
  *
- * ## 설계 결정
- * - **JVM 단일 구현**: 모든 백엔드(Neo4j/AGE/FalkorDB/TinkerPop)가 이 구현에 위임한다.
- * - **결정적 tie-break**: 동일 비용 정점은 ID 사전순으로 정렬해 비결정적 동작을 방지한다.
- * - **maxVisited 보호**: 무한 그래프에서의 무한 확장을 방지한다.
- * - **Direction 지원**: OUTGOING, INCOMING, BOTH 모두 지원한다.
+ * ## Design decisions
+ * - **Single JVM implementation**: Neo4j, AGE, FalkorDB, and TinkerPop delegate here.
+ * - **Deterministic tie-break**: equal-cost vertices are ordered lexicographically by ID.
+ * - **maxVisited guard**: protects against unbounded expansion in infinite graphs.
+ * - **Direction support**: OUTGOING, INCOMING, and BOTH are all supported.
  *
- * ### 사용 예제
+ * ### Usage
  *
  * ```kotlin
  * val runner = DijkstraRunner(
@@ -37,11 +37,11 @@ import java.util.*
  *     ),
  * )
  *
- * path?.let { println("총 비용=${it.totalWeight}, 경로 길이=${it.steps.size}") }
+ * path?.let { println("totalCost=${it.totalWeight}, pathLength=${it.steps.size}") }
  * ```
  *
- * @param fetchEdges 정점 ID → 인접 간선 목록 조회 함수. `Direction`은 호출 전 적용되어야 한다.
- * @param fetchVertex 정점 ID → [GraphVertex] 조회 함수.
+ * @param fetchEdges vertex ID to adjacent edges lookup. `Direction` must be applied before calling.
+ * @param fetchVertex vertex ID to [GraphVertex] lookup.
  */
 class DijkstraRunner(
     private val fetchEdges: (GraphElementId) -> List<GraphEdge>,
@@ -58,13 +58,13 @@ class DijkstraRunner(
     }
 
     /**
-     * Dijkstra 알고리즘으로 [fromId] → [toId] 최단 경로를 계산한다.
-     *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (weightProperty, missingWeightPolicy, maxVisited).
-     * @return 최단 [GraphPath], 경로가 없으면 `null`.
-     * @throws IllegalArgumentException [PathOptions.weightProperty]가 null인 경우.
+     * Computes the shortest path from [fromId] to [toId] with Dijkstra's algorithm.
+	*
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options (`weightProperty`, `missingWeightPolicy`, `maxVisited`).
+     * @return shortest [GraphPath], or `null` when no path exists.
+     * @throws IllegalArgumentException when [PathOptions.weightProperty] is null.
      */
     fun run(
         fromId: GraphElementId,
@@ -108,7 +108,7 @@ class DijkstraRunner(
 
             for (edge in edges) {
                 val neighborId = neighbourId(currentId, edge, options.direction) ?: continue
-                val w = extractor.extract(edge) ?: continue // Skip 정책
+                val w = extractor.extract(edge) ?: continue // Skip policy
 
                 val newCost = cost + w
                 if (newCost < (dist[neighborId] ?: Double.MAX_VALUE)) {

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/GraphAlgoUtils.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/GraphAlgoUtils.kt
@@ -5,12 +5,12 @@ import io.bluetape4k.graph.model.GraphEdge
 import io.bluetape4k.graph.model.GraphElementId
 
 /**
- * DijkstraRunner와 AStarRunner가 공유하는 이웃 정점 ID 계산 함수.
+ * Computes the neighboring vertex ID shared by [DijkstraRunner] and [AStarRunner].
  *
- * @param currentId 현재 탐색 중인 정점 ID.
- * @param edge 검사할 간선.
- * @param direction 탐색 방향.
- * @return 이웃 정점 ID. 방향 조건 미충족 시 null.
+ * @param currentId currently visited vertex ID.
+ * @param edge edge to inspect.
+ * @param direction traversal direction.
+ * @return neighboring vertex ID, or `null` when the edge does not match [direction].
  */
 internal fun neighbourId(
     currentId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/PathReconstructor.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/PathReconstructor.kt
@@ -11,16 +11,16 @@ import io.bluetape4k.logging.warn
 private val log = KotlinLogging.logger {}
 
 /**
- * 탐색 완료 후 predecessor 맵에서 [GraphPath]를 역추적하여 재구성한다.
+ * Reconstructs a [GraphPath] by walking a predecessor map after traversal completes.
  *
- * Dijkstra/A* 탐색이 끝난 뒤 `cameFrom` 테이블에서 경로를 역추적한다.
- * `totalWeight`는 탐색 과정에서 계산된 누적 비용을 그대로 사용한다.
+ * Dijkstra/A* runners fill `cameFrom`; this function walks it backward and preserves
+ * the already computed [totalWeight].
  *
- * @param targetId 도착 정점 ID.
- * @param cameFrom 정점 ID → (부모 정점, 연결 간선) 맵.
- * @param vertexLookup 정점 ID → [GraphVertex] 조회 함수.
- * @param totalWeight 경로의 총 가중치.
- * @return 재구성된 [GraphPath]. 경로가 없으면 `null`.
+ * @param targetId target vertex ID.
+ * @param cameFrom vertex ID to parent vertex and connecting edge map.
+ * @param vertexLookup vertex ID to [GraphVertex] lookup.
+ * @param totalWeight total path weight.
+ * @return reconstructed [GraphPath], or `null` when no path exists.
  */
 internal fun reconstructPath(
     targetId: GraphElementId,
@@ -43,7 +43,7 @@ internal fun reconstructPath(
         currentId = parentVertex.id
     }
 
-    // 출발 정점 추가
+    // Add the source vertex.
     val startVertex = vertexLookup(currentId) ?: run {
         log.warn { "PathReconstructor: start vertex $currentId not found during reconstruction" }
         return null

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/ShortestPathFallback.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/ShortestPathFallback.kt
@@ -10,14 +10,14 @@ import io.bluetape4k.graph.repository.GraphEdgeRepository
 import io.bluetape4k.graph.repository.GraphOperations
 
 /**
- * JVM 구현 기반의 가중치 최단 경로 탐색 헬퍼 (동기 전용).
+ * JVM weighted shortest-path helper for synchronous backends.
  *
- * 모든 백엔드(Neo4j/Memgraph/AGE/TinkerPop/FalkorDB)의 동기 [GraphOperations]에서
- * Dijkstra/A* 최단 경로 계산에 사용된다.
+ * Synchronous [GraphOperations] implementations for Neo4j, Memgraph, AGE, TinkerPop, and FalkorDB
+ * use it for Dijkstra and A* shortest-path computation.
  *
- * ## 사용 패턴
+ * ## Usage pattern
  *
- * **동기 백엔드:**
+ * **Synchronous backend:**
  * ```kotlin
  * override fun shortestPath(...): GraphPath? =
  *     if (options.weightProperty != null) ShortestPathFallback.dijkstra(this, ...)
@@ -27,7 +27,7 @@ import io.bluetape4k.graph.repository.GraphOperations
  *     ShortestPathFallback.aStar(this, ...)
  * ```
  *
- * **코루틴 백엔드** (syncDelegate 위임):
+ * **Coroutine backend** (through a sync delegate):
  * ```kotlin
  * override suspend fun shortestPath(...): GraphPath? =
  *     if (options.weightProperty != null) withContext(Dispatchers.IO) {
@@ -35,15 +35,14 @@ import io.bluetape4k.graph.repository.GraphOperations
  *     } else ...
  * ```
  *
- * ## 인터페이스 기본 메서드를 사용하지 않는 이유
- * 탐색 알고리즘이 [GraphOperations] 전체(정점+간선 조회)를 필요로 하는데,
- * `GraphTraversalRepository` 인터페이스의 `this`는 해당 타입을 만족하지 않는다.
- * 따라서 각 백엔드 `override`에서 이 오브젝트를 직접 호출한다.
+ * ## Why this is not an interface default method
+ * The traversal algorithms need full [GraphOperations] access for vertex and edge lookup, but
+ * `GraphTraversalRepository.this` does not satisfy that type. Backend overrides call this object directly.
  */
 object ShortestPathFallback {
 
     /**
-     * [GraphOperations]를 사용해 Dijkstra 가중치 최단 경로를 계산한다.
+     * Computes a weighted Dijkstra shortest path using [GraphOperations].
      */
     fun dijkstra(
         ops: GraphOperations,
@@ -59,7 +58,7 @@ object ShortestPathFallback {
     }
 
     /**
-     * [GraphOperations]를 사용해 A* 가중치 최단 경로를 계산한다.
+     * Computes a weighted A* shortest path using [GraphOperations].
      */
     fun aStar(
         ops: GraphOperations,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/VirtualThreadAlgorithmAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/VirtualThreadAlgorithmAdapter.kt
@@ -18,18 +18,18 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /**
- * [GraphAlgorithmRepository] 의 모든 메서드를 Virtual Thread 위에서 실행하는 어댑터.
+ * Adapter that runs all [GraphAlgorithmRepository] methods on virtual threads.
  *
- * 단일 작업에는 `virtualFutureOf { }` 를 사용한다.
+ * Single operations use `virtualFutureOf { }`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val ops: GraphOperations = Neo4jGraphOperations(driver)
  * val vtOps = ops.asVirtualThread()
  * val scores = vtOps.pageRankAsync().join()
  * ```
  *
- * @param delegate 위임할 동기 [GraphAlgorithmRepository].
+ * @param delegate synchronous [GraphAlgorithmRepository] to delegate to.
  */
 class VirtualThreadAlgorithmAdapter(
     private val delegate: GraphAlgorithmRepository,
@@ -66,7 +66,7 @@ class VirtualThreadAlgorithmAdapter(
 }
 
 /**
- * [GraphAlgorithmRepository] 를 Virtual Thread 어댑터로 감싸는 확장 함수.
+ * Wraps [GraphAlgorithmRepository] in a virtual-thread adapter.
  *
  * ```kotlin
  * val vtOps = ops.asVirtualThread()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/WeightExtractor.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/WeightExtractor.kt
@@ -7,18 +7,18 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 
 /**
- * 간선 속성에서 가중치(Double)를 추출한다.
+ * Extracts a `Double` weight from edge properties.
  *
- * [MissingWeightPolicy]에 따라 결측 속성 처리 방식이 결정된다.
- * - [MissingWeightPolicy.Fail]: 결측 시 [MissingWeightException] 발생
- * - [MissingWeightPolicy.Skip]: `null` 반환 (호출자가 간선 건너뜀)
- * - [MissingWeightPolicy.UseDefault]: [MissingWeightPolicy.UseDefault.value] 반환
+ * [MissingWeightPolicy] controls missing property handling:
+ * - [MissingWeightPolicy.Fail]: throws [MissingWeightException].
+ * - [MissingWeightPolicy.Skip]: returns `null` so the caller can skip the edge.
+ * - [MissingWeightPolicy.UseDefault]: returns [MissingWeightPolicy.UseDefault.value].
  *
- * 속성이 존재하더라도 `NaN`, `Infinity`, 음수, 0.0인 경우 [IllegalArgumentException]을 발생시킨다.
+ * Existing values that are `NaN`, infinite, negative, or zero throw [IllegalArgumentException].
  *
  * ```kotlin
  * val extractor = WeightExtractor("cost", MissingWeightPolicy.UseDefault(1.0))
- * val weight = extractor.extract(edge)  // null이면 호출자가 skip
+ * val weight = extractor.extract(edge)  // caller skips when null
  * ```
  */
 class WeightExtractor(
@@ -28,11 +28,11 @@ class WeightExtractor(
     companion object : KLogging()
 
     /**
-     * [edge]에서 가중치를 추출한다.
-     *
-     * @return 가중치 값. [MissingWeightPolicy.Skip]이고 속성이 없으면 `null`.
-     * @throws MissingWeightException [MissingWeightPolicy.Fail]이고 속성이 없는 경우.
-     * @throws IllegalArgumentException 추출된 값이 유효하지 않은 경우 (NaN, Infinity, <= 0).
+     * Extracts the weight from [edge].
+	*
+     * @return weight value, or `null` when [MissingWeightPolicy.Skip] is active and the property is absent.
+     * @throws MissingWeightException when [MissingWeightPolicy.Fail] is active and the property is absent.
+     * @throws IllegalArgumentException when the extracted value is invalid (`NaN`, infinity, or <= 0).
      */
     fun extract(edge: GraphEdge): Double? {
         val raw = edge.properties[weightProperty]

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/BfsDfsRunner.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/BfsDfsRunner.kt
@@ -6,11 +6,11 @@ import io.bluetape4k.graph.model.TraversalVisit
 import java.util.ArrayDeque
 
 /**
- * 인접 리스트 기반 BFS/DFS JVM 폴백 러너.
+ * Adjacency-list BFS/DFS runner used as a JVM fallback.
  *
- * 백엔드 native 미지원 시 사용한다 (AGE 등).
+ * Used when the backend has no native traversal support.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val adjacency: Map<GraphElementId, List<GraphElementId>> = ...
  * val visits = BfsDfsRunner.bfs(start.id, adjacency, maxDepth = 3, maxVertices = 1000)
@@ -19,13 +19,13 @@ import java.util.ArrayDeque
 object BfsDfsRunner {
 
     /**
-     * BFS 방문 결과를 반환한다 (레벨 순).
-     *
-     * @param startId 시작 정점 ID.
-     * @param adjacency 인접 리스트 (out-edges).
-     * @param maxDepth 최대 탐색 깊이.
-     * @param maxVertices 반환할 최대 정점 수.
-     * @param vertexResolver 정점 ID → [GraphVertex] 변환기 (기본: 빈 properties 정점).
+     * Returns BFS visit results in level order.
+	*
+     * @param startId start vertex ID.
+     * @param adjacency adjacency list of out-edges.
+     * @param maxDepth maximum traversal depth.
+     * @param maxVertices maximum number of vertices to return.
+     * @param vertexResolver vertex ID to [GraphVertex] resolver, defaulting to empty-property vertices.
      */
     fun bfs(
         startId: GraphElementId,
@@ -56,7 +56,7 @@ object BfsDfsRunner {
     }
 
     /**
-     * DFS 방문 결과를 반환한다 (깊이 우선, pre-order).
+     * Returns DFS visit results in depth-first preorder.
      */
     fun dfs(
         startId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/CycleDetector.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/CycleDetector.kt
@@ -3,14 +3,14 @@ package io.bluetape4k.graph.algo.internal
 import io.bluetape4k.graph.model.GraphElementId
 
 /**
- * DFS 기반 단순 순환 탐지기 (JVM 폴백).
+ * DFS-based simple cycle detector used as a JVM fallback.
  *
- * 모든 정점에서 DFS 를 시작해 백엣지(back edge)를 탐지한다.
- * 동일 시작 정점에서 발생한 순환은 한 번만 보고된다.
+ * It starts DFS from every vertex and detects back edges. Cycles from the same start
+ * vertex are reported once.
  *
- * 반환되는 각 순환은 정점 ID 목록으로, 첫 번째와 마지막이 같다.
+ * Each returned cycle is a vertex ID list where the first and last IDs are equal.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val cycles = CycleDetector.findCycles(adjacency, maxDepth = 6, maxCycles = 50)
  * cycles.forEach { println("cycle: ${it.joinToString(" -> ")}") }
@@ -19,10 +19,10 @@ import io.bluetape4k.graph.model.GraphElementId
 object CycleDetector {
 
     /**
-     * @param adjacency 인접 리스트 (out-edges).
-     * @param maxDepth 순환 경로 최대 길이 (간선 수).
-     * @param maxCycles 반환할 최대 순환 수.
-     * @return 정점 ID 목록의 목록. 각 항목은 first == last.
+     * @param adjacency adjacency list of out-edges.
+     * @param maxDepth maximum cycle path length in edges.
+     * @param maxCycles maximum number of cycles to return.
+     * @return lists of vertex IDs, each with `first == last`.
      */
     fun findCycles(
         adjacency: Map<GraphElementId, List<GraphElementId>>,
@@ -50,11 +50,11 @@ object CycleDetector {
         result: MutableList<List<GraphElementId>>,
         seenSignatures: MutableSet<List<GraphElementId>>,
     ) {
-        // Frame: (정점, 아직 방문하지 않은 이웃 목록)
+        // Frame: current vertex and neighbors not yet visited from it.
         data class Frame(val vertex: GraphElementId, val remaining: ArrayDeque<GraphElementId>)
 
-        val path = ArrayList<GraphElementId>()  // 현재 탐색 경로 (= 원래 recursive dfs의 stack)
-        val onPath = HashSet<GraphElementId>()  // 경로 내 정점 집합 (빠른 조회용)
+        val path = ArrayList<GraphElementId>()  // Current traversal path, equivalent to recursive DFS stack.
+        val onPath = HashSet<GraphElementId>()  // Vertices on the current path for fast lookup.
 
         path.add(start)
         onPath.add(start)
@@ -65,11 +65,11 @@ object CycleDetector {
             if (result.size >= maxCycles) break
 
             val frame = callStack.last()
-            // 경로 깊이(간선 수) = callStack.size - 1
+            // Path depth in edges is callStack.size - 1.
             val depth = callStack.size - 1
 
             if (depth >= maxDepth || frame.remaining.isEmpty()) {
-                // 이 프레임 종료 — path/onPath에서 현재 정점 제거
+                // End this frame and remove the current vertex from path/onPath.
                 callStack.removeLast()
                 val popped = path.removeAt(path.size - 1)
                 onPath.remove(popped)
@@ -91,14 +91,14 @@ object CycleDetector {
 
             if (next in onPath) continue
 
-            // 새 프레임 push
+            // Push the next frame.
             path.add(next)
             onPath.add(next)
             callStack.addLast(Frame(next, ArrayDeque(adjacency[next].orEmpty())))
         }
     }
 
-    /** 회전 등가 순환을 동일 시그니처로 정규화 (가장 작은 회전 시작). */
+    /** Normalizes rotationally equivalent cycles to the same signature by starting at the smallest rotation. */
     private fun canonicalSignature(cycle: List<GraphElementId>): List<GraphElementId> {
         // cycle has first == last; drop the trailing duplicate
         val core = cycle.dropLast(1)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculator.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculator.kt
@@ -7,12 +7,12 @@ import kotlin.math.abs
 
 
 /**
- * 정규화된 PageRank 반복 계산기 (JVM 폴백).
+ * Normalized iterative PageRank calculator used as a JVM fallback.
  *
- * 결과 점수의 합 ≈ 1.0 으로 정규화된다.
- * dangling node (out-degree 0)의 질량은 다음 반복 시 모든 정점에 균등 분배된다.
+ * Result scores are normalized to a total near `1.0`. Dangling-node mass from out-degree-zero
+ * vertices is redistributed evenly to all vertices on the next iteration.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val scores = PageRankCalculator.compute(
  *     vertices = vertexIds,
@@ -28,14 +28,14 @@ object PageRankCalculator : KLogging() {
     private const val HASH_LOAD_FACTOR = 0.75
 
     /**
-     * 정규화된 PageRank 점수를 계산한다.
-     *
-     * @param vertices 전체 정점 ID 집합.
-     * @param outAdjacency out-edge 인접 리스트. 집합에 없는 정점을 참조해서는 안 된다.
-     * @param iterations 최대 반복 횟수. 양수여야 한다.
-     * @param dampingFactor 감쇠 계수. [0.0, 1.0] 범위. 보통 0.85.
-     * @param tolerance 조기 종료 L1-norm 허용치. 양수여야 한다.
-     * @return 정점별 PageRank 점수 맵. 합계 ≈ 1.0.
+     * Computes normalized PageRank scores.
+	*
+     * @param vertices complete vertex ID set.
+     * @param outAdjacency out-edge adjacency list. It must not reference vertices outside [vertices].
+     * @param iterations maximum iteration count. Must be positive.
+     * @param dampingFactor damping factor in the `[0.0, 1.0]` range, typically `0.85`.
+     * @param tolerance positive L1-norm threshold for early termination.
+     * @return vertex-to-PageRank score map, normalized to a total near `1.0`.
      */
     fun compute(
         vertices: Set<GraphElementId>,
@@ -51,13 +51,13 @@ object PageRankCalculator : KLogging() {
         if (vertices.isEmpty()) return emptyMap()
 
         val n = vertices.size
-        // HashMap rehash 방지: Double 나눗셈으로 정밀도 확보 (0.75f 는 n≥25M 에서 under-provision)
+        // Avoid HashMap rehashing; Double division preserves precision for very large graphs.
         val mapCapacity = ((n / HASH_LOAD_FACTOR) + 1).toInt()
         val initial = 1.0 / n
         var ranks = HashMap<GraphElementId, Double>(mapCapacity)
         vertices.forEach { ranks[it] = initial }
 
-        // dangling node 집합은 그래프 구조가 고정되므로 루프 밖에서 1회 계산
+        // The graph structure is fixed, so dangling nodes are computed once outside the loop.
         val danglingNodes = vertices.filter { outAdjacency[it].isNullOrEmpty() }
 
         repeat(iterations) {
@@ -75,7 +75,7 @@ object PageRankCalculator : KLogging() {
                 if (outs.isNotEmpty()) {
                     val share = dampingFactor * ranks.getOrDefault(src, 0.0) / outs.size
                     outs.forEach { dst ->
-                        // merge로 단일 해시 탐색으로 읽기+쓰기 처리 (이중 맵 조회 방지)
+                        // merge performs read+write with one hash lookup.
                         newRanks.merge(dst, share, Double::plus)
                     }
                 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/UnionFind.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/algo/internal/UnionFind.kt
@@ -3,16 +3,16 @@ package io.bluetape4k.graph.algo.internal
 /**
  * Path compression + union-by-rank Union-Find (Disjoint Set Union).
  *
- * Connected Components 폴백 알고리즘에서 사용한다.
+ * Union-find structure used by connected-components fallback algorithms.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val uf = UnionFind(listOf("a", "b", "c"))
  * uf.union("a", "b")
  * uf.connected("a", "b")  // true
  * ```
  *
- * @param elements 초기 원소 컬렉션.
+ * @param elements initial element collection.
  */
 class UnionFind<T>(elements: Iterable<T>) {
 
@@ -26,7 +26,7 @@ class UnionFind<T>(elements: Iterable<T>) {
         }
     }
 
-    /** 원소 [x] 가 속한 컴포넌트의 대표(루트) 원소를 반환한다. */
+    /** Returns the representative root element for the component containing [x]. */
     fun componentOf(x: T): T {
         var root = x
         while (parent[root] != root) {
@@ -42,7 +42,7 @@ class UnionFind<T>(elements: Iterable<T>) {
         return root
     }
 
-    /** 두 원소를 같은 컴포넌트로 병합한다. */
+    /** Merges two elements into the same component. */
     fun union(x: T, y: T) {
         val rx = componentOf(x)
         val ry = componentOf(y)
@@ -60,13 +60,13 @@ class UnionFind<T>(elements: Iterable<T>) {
         }
     }
 
-    /** 두 원소가 같은 컴포넌트인지 확인한다. */
+    /** Returns whether two elements belong to the same component. */
     fun connected(x: T, y: T): Boolean = componentOf(x) == componentOf(y)
 
-    /** 현재 컴포넌트 수. */
+    /** Current component count. */
     fun componentCount(): Int = parent.keys.map { componentOf(it) }.toSet().size
 
-    /** 대표 원소 → 컴포넌트 멤버 목록 매핑. */
+    /** Mapping from representative root element to component members. */
     fun groups(): Map<T, List<T>> =
         parent.keys.groupBy { componentOf(it) }
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/BatchEdge.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/BatchEdge.kt
@@ -3,16 +3,16 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 배치 간선 생성 입력 모델.
+ * Input model for batch edge creation.
  *
- * 하나의 [GraphEdgeRepository.createEdges][io.bluetape4k.graph.repository.GraphEdgeRepository.createEdges]
- * 호출은 동일한 간선 레이블을 공유하므로, 이 모델은 양 끝점과 행별 속성만 담는다.
+ * A single [GraphEdgeRepository.createEdges][io.bluetape4k.graph.repository.GraphEdgeRepository.createEdges]
+ * call shares one edge label, so this model carries only the endpoints and per-row properties.
  *
- * ## 동작/계약
+ * ## Contract
  *
- * - [fromId]와 [toId]는 이미 존재하는 정점의 ID여야 한다.
- * - [properties]는 생성할 간선에 저장할 속성 맵이다.
- * - 배치 insert는 merge/upsert가 아니므로 같은 입력을 여러 번 전달하면 중복 간선이 생성될 수 있다.
+ * - [fromId] and [toId] must identify existing vertices.
+ * - [properties] is the property map stored on the created edge.
+ * - Batch insert is not merge/upsert; repeated inputs can create duplicate edges.
  *
  * ```kotlin
  * val edge = BatchEdge(

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/DegreeResult.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/DegreeResult.kt
@@ -3,13 +3,13 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * Degree Centrality(연결 중심성) 결과.
+ * Degree centrality result.
  *
- * @property vertexId 측정 대상 정점 ID.
- * @property inDegree 들어오는 간선 수.
- * @property outDegree 나가는 간선 수.
+ * @property vertexId ID of the measured vertex.
+ * @property inDegree Number of incoming edges.
+ * @property outDegree Number of outgoing edges.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val degree = ops.degreeCentrality(alice.id)
  * println("in=${degree.inDegree} out=${degree.outDegree} total=${degree.total}")
@@ -20,7 +20,7 @@ data class DegreeResult(
     val inDegree: Int,
     val outDegree: Int,
 ): Serializable {
-    /** in + out 간선 수 합계. */
+    /** Sum of incoming and outgoing edges. */
     val total: Int get() = inDegree + outDegree
 
     companion object {

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/Direction.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/Direction.kt
@@ -1,24 +1,24 @@
 package io.bluetape4k.graph.model
 
 /**
- * 그래프 간선 탐색 방향.
+ * Graph edge traversal direction.
  *
  * ```kotlin
- * // OUTGOING: alice가 아는 사람들
+ * // OUTGOING: people Alice knows
  * val friends = ops.neighbors(alice.id, NeighborOptions(direction = Direction.OUTGOING, edgeLabel = "KNOWS"))
  *
- * // INCOMING: alice를 아는 사람들
+ * // INCOMING: people who know Alice
  * val followers = ops.neighbors(alice.id, NeighborOptions(direction = Direction.INCOMING, edgeLabel = "KNOWS"))
  *
- * // BOTH: 양방향
+ * // BOTH: both directions
  * val all = ops.neighbors(alice.id, NeighborOptions(direction = Direction.BOTH))
  * ```
  */
 enum class Direction {
-    /** 출발 정점 -> 도착 정점 방향 */
+    /** From start vertex to end vertex. */
     OUTGOING,
-    /** 도착 정점 -> 출발 정점 방향 */
+    /** From end vertex to start vertex. */
     INCOMING,
-    /** 양방향 */
+    /** Both directions. */
     BOTH,
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphAlgorithmOptions.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphAlgorithmOptions.kt
@@ -3,12 +3,12 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * Analytics 알고리즘 옵션의 공통 sealed 클래스.
+ * Base sealed class for analytics algorithm options.
  *
- * `maxDepth` 개념이 없는 알고리즘(PageRank / Degree / ConnectedComponents) 전용이다.
- * 탐색 깊이가 의미 있는 알고리즘은 [GraphTraversalOptions] 하위를 사용한다.
+ * Use this for algorithms without a `maxDepth` concept, such as PageRank, degree centrality,
+ * and connected components. Use [GraphTraversalOptions] for algorithms where traversal depth matters.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val opts: GraphAlgorithmOptions = PageRankOptions(iterations = 20)
  * ```
@@ -20,18 +20,18 @@ sealed class GraphAlgorithmOptions: Serializable {
 }
 
 /**
- * PageRank 옵션.
+ * PageRank options.
  *
- * @param vertexLabel `null` 이면 전체 정점 대상.
- * @param edgeLabel `null` 이면 모든 간선 포함.
- * @param iterations 반복 횟수 (기본 20).
- * @param dampingFactor 감쇠 인수 (기본 0.85). 백엔드별 지원 여부 상이.
- * @param tolerance 수렴 허용 오차 (기본 1e-4). 백엔드별 지원 여부 상이.
- * @param topK 상위 K개 결과만 반환. `Int.MAX_VALUE` = 전체 반환.
+ * @param vertexLabel Targets all vertices when `null`.
+ * @param edgeLabel Includes all edges when `null`.
+ * @param iterations Number of iterations. Defaults to `20`.
+ * @param dampingFactor Damping factor. Defaults to `0.85`; backend support varies.
+ * @param tolerance Convergence tolerance. Defaults to `1e-4`; backend support varies.
+ * @param topK Returns only the top K results. `Int.MAX_VALUE` returns all results.
  *
- * 결과 순서: score 내림차순 정렬 보장.
+ * Result order is guaranteed to be descending by score.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val opts = PageRankOptions(vertexLabel = "Person", iterations = 30, topK = 10)
  * val top10 = ops.pageRank(opts)
@@ -57,12 +57,12 @@ data class PageRankOptions(
 }
 
 /**
- * Degree Centrality 옵션.
+ * Degree centrality options.
  *
- * @param edgeLabel `null` 이면 모든 간선 포함.
- * @param direction 방향 (BOTH / OUTGOING / INCOMING).
+ * @param edgeLabel Includes all edges when `null`.
+ * @param direction Traversal direction: `BOTH`, `OUTGOING`, or `INCOMING`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val opts = DegreeOptions(edgeLabel = "KNOWS", direction = Direction.BOTH)
  * val degree = ops.degreeCentrality(alice.id, opts)
@@ -79,14 +79,14 @@ data class DegreeOptions(
 }
 
 /**
- * Connected Components 옵션.
+ * Connected components options.
  *
- * @param vertexLabel `null` 이면 전체 정점.
- * @param edgeLabel `null` 이면 모든 간선.
- * @param weakly `true` = Weakly Connected (방향 무시), `false` = Strongly Connected.
- * @param minSize 반환할 최소 컴포넌트 크기 (기본 1).
+ * @param vertexLabel Targets all vertices when `null`.
+ * @param edgeLabel Includes all edges when `null`.
+ * @param weakly `true` for weakly connected components, ignoring direction; `false` for strongly connected components.
+ * @param minSize Minimum component size to return. Defaults to `1`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val opts = ComponentOptions(weakly = true, minSize = 2)
  * val components = ops.connectedComponents(opts)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphComponent.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphComponent.kt
@@ -3,14 +3,14 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 연결 컴포넌트(Connected Component) 결과.
+ * Connected component result.
  *
- * 동일 [componentId] 를 갖는 정점 집합을 표현한다.
+ * Represents vertices that share the same [componentId].
  *
- * @property componentId 컴포넌트 식별자 (구현체별 임의 값, 동일 컴포넌트는 동일 ID).
- * @property vertices 컴포넌트에 속한 정점 목록.
+ * @property componentId Component identifier. The value is implementation-defined; vertices in the same component share it.
+ * @property vertices Vertices in the component.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val components = ops.connectedComponents(ComponentOptions(weakly = true))
  * components.forEach { println("${it.componentId}: size=${it.size}") }
@@ -20,7 +20,7 @@ data class GraphComponent(
     val componentId: String,
     val vertices: List<GraphVertex>,
 ): Serializable {
-    /** 컴포넌트 내 정점 수. */
+    /** Number of vertices in the component. */
     val size: Int get() = vertices.size
 
     companion object {

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphCycle.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphCycle.kt
@@ -3,14 +3,14 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 탐지된 그래프 순환(Cycle).
+ * Detected graph cycle.
  *
- * [path] 의 첫 번째 정점과 마지막 정점은 동일하다 (first == last 보장).
- * [length] 는 [path] 의 간선 수로 계산되는 computed property.
+ * The first and last vertices in [path] are the same (`first == last`).
+ * [length] is a computed property based on the number of edges in [path].
  *
- * @property path 순환 경로. 시작과 끝이 같은 [GraphPath].
+ * @property path Cyclic path whose start and end are the same.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val cycles = ops.detectCycles(CycleOptions(maxDepth = 5))
  * cycles.forEach { println("cycle length=${it.length}") }
@@ -19,7 +19,7 @@ import java.io.Serializable
 data class GraphCycle(
     val path: GraphPath,
 ): Serializable {
-    /** 순환 경로의 간선 수. */
+    /** Number of edges in the cycle path. */
     val length: Int get() = path.edges.size
 
     companion object {
@@ -28,10 +28,10 @@ data class GraphCycle(
 }
 
 /**
- * 이 경로를 [GraphCycle]로 변환한다.
+ * Converts this path to a [GraphCycle].
  *
- * 경로의 첫 번째 정점과 마지막 정점이 동일한 순환 경로를 표현할 때 사용한다.
- * 호출 전에 순환 여부를 직접 검증해야 한다 — 이 함수는 단순 래핑만 수행한다.
+ * Use this when the first and last vertices in the path are the same.
+ * Verify the cycle before calling this function; it only wraps the path.
  *
  * ```kotlin
  * val cycle = detectedPath.toCycle()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphEdge.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphEdge.kt
@@ -3,19 +3,19 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 그래프의 간선(Edge/Relationship).
+ * Graph edge or relationship.
  *
- * 두 정점 사이의 관계를 나타내는 불변 모델이다.
- * 방향 그래프에서는 [startId] → [endId] 방향으로 간선이 향한다.
- * `startId == endId`인 자기 참조(self-loop) 간선도 허용된다.
+ * Immutable model for a relationship between two vertices.
+ * In directed graphs, the edge points from [startId] to [endId].
+ * Self-loop edges with `startId == endId` are allowed.
  *
- * @property id 백엔드 독립적인 간선 ID.
- * @property label 관계의 타입을 나타내는 레이블 (예: `"KNOWS"`, `"WORKS_AT"`).
- * @property startId 간선의 시작 정점 ID.
- * @property endId 간선의 종료 정점 ID.
- * @property properties 간선에 첨부된 속성 맵. 값은 `null`을 포함할 수 있다.
+ * @property id Backend-independent edge ID.
+ * @property label Label that describes the relationship type, such as `"KNOWS"` or `"WORKS_AT"`.
+ * @property startId Start vertex ID.
+ * @property endId End vertex ID.
+ * @property properties Property map attached to the edge. Values may contain `null`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val edge = GraphEdge(
  *     id = GraphElementId.of("e-1"),

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphElementId.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphElementId.kt
@@ -23,6 +23,10 @@ import java.io.Serializable
  */
 @JvmInline
 value class GraphElementId(val value: String): Serializable {
+    init {
+        value.requireNotBlank("value")
+    }
+
     companion object {
         private const val serialVersionUID: Long = 1L
 
@@ -36,7 +40,6 @@ value class GraphElementId(val value: String): Serializable {
          * @param value ID 문자열 값.
          */
         fun of(value: String): GraphElementId {
-            value.requireNotBlank("value")
             return GraphElementId(value)
         }
 

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphElementId.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphElementId.kt
@@ -4,18 +4,17 @@ import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 
 /**
- * 그래프 요소(Vertex, Edge)의 백엔드 독립 ID.
+ * Backend-independent ID for graph elements: vertices and edges.
  *
- * 내부적으로 [String]을 감싸는 인라인 값 클래스이며, 다양한 그래프 백엔드의 ID 표현을
- * 단일 타입으로 통합한다.
+ * Inline value class that wraps a [String] and unifies ID representations across graph backends.
  *
- * - Apache AGE: `Long` 내부 ID → `GraphElementId("$longId")` 변환
- * - Neo4j: `elementId()` (String) → `GraphElementId` 직접 매핑
- * - TinkerGraph: 객체 ID → `toString()` 변환
+ * - Apache AGE: converts internal `Long` IDs to `GraphElementId("$longId")`.
+ * - Neo4j: maps `elementId()` strings directly to `GraphElementId`.
+ * - TinkerGraph: converts object IDs with `toString()`.
  *
- * @property value 실제 ID 문자열 값.
+ * @property value Actual ID string value.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val id1 = GraphElementId.of("node-abc")
  * val id2 = GraphElementId.of(42L)  // AGE Long ID
@@ -31,28 +30,28 @@ value class GraphElementId(val value: String): Serializable {
         private const val serialVersionUID: Long = 1L
 
         /**
-         * 문자열 값으로 [GraphElementId]를 생성한다.
+         * Creates a [GraphElementId] from a string value.
          *
          * ```kotlin
          * val id = GraphElementId.of("node-abc")
          * ```
          *
-         * @param value ID 문자열 값.
+         * @param value ID string value.
          */
         fun of(value: String): GraphElementId {
             return GraphElementId(value)
         }
 
         /**
-         * Long 숫자 ID를 [GraphElementId]로 변환한다.
+         * Converts a numeric [Long] ID to [GraphElementId].
          *
-         * Apache AGE처럼 내부 ID가 Long인 백엔드에서 사용한다.
+         * Use this for backends such as Apache AGE whose internal IDs are [Long] values.
          *
          * ```kotlin
-         * val id = GraphElementId.of(42L)  // AGE Long ID → "42"
+         * val id = GraphElementId.of(42L)  // AGE Long ID -> "42"
          * ```
          *
-         * @param value Long 형식의 숫자 ID.
+         * @param value Numeric [Long] ID.
          */
         fun of(value: Long): GraphElementId {
             return GraphElementId(value.toString())
@@ -61,19 +60,19 @@ value class GraphElementId(val value: String): Serializable {
 }
 
 /**
- * 임의 타입의 값을 [GraphElementId]로 변환한다.
+ * Converts a value of any type to [GraphElementId].
  *
- * - [GraphElementId]를 그대로 전달하면 새 인스턴스를 만들지 않고 반환한다.
- * - [Long]은 [GraphElementId.of] Long 오버로드로 위임한다.
- * - 그 외 타입은 `toString()` 결과를 ID 값으로 사용한다.
+ * - Returns [GraphElementId] values unchanged.
+ * - Delegates [Long] values to the [GraphElementId.of] overload.
+ * - Uses `toString()` as the ID value for other types.
  *
  * ```kotlin
  * graphElementIdOf("node-1")           // GraphElementId("node-1")
  * graphElementIdOf(42L)                // GraphElementId("42")
- * graphElementIdOf(GraphElementId("x")) // GraphElementId("x") — 이중 변환 없음
+ * graphElementIdOf(GraphElementId("x")) // GraphElementId("x") - no duplicate conversion
  * ```
  *
- * @param value ID로 변환할 값. `Any` 타입이지만 `toString()` 결과가 비어있어선 안 된다.
+ * @param value Value to convert to an ID. Its `toString()` result must not be blank.
  */
 fun graphElementIdOf(value: Any): GraphElementId = when (value) {
     is GraphElementId -> value

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphPath.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphPath.kt
@@ -3,9 +3,9 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 그래프 경로의 단계 (정점 또는 간선).
+ * Step in a graph path, either a vertex or an edge.
  *
- * 경로는 `[VertexStep, EdgeStep, VertexStep, ...]` 형태로 교차 배치된다.
+ * Paths alternate as `[VertexStep, EdgeStep, VertexStep, ...]`.
  *
  * ```kotlin
  * val step: PathStep = PathStep.VertexStep(vertex)
@@ -15,41 +15,41 @@ import java.io.Serializable
  */
 sealed class PathStep {
     /**
-     * 경로 내 정점 단계.
+     * Vertex step in a path.
      *
      * ```kotlin
      * val step = PathStep.VertexStep(GraphVertex(GraphElementId.of("v1"), "Person", mapOf("name" to "Alice")))
      * println(step.vertex.label)  // "Person"
      * ```
      *
-     * @property vertex 해당 단계의 정점.
+     * @property vertex Vertex for this step.
      */
     data class VertexStep(val vertex: GraphVertex): PathStep()
 
     /**
-     * 경로 내 간선 단계.
+     * Edge step in a path.
      *
      * ```kotlin
      * val step = PathStep.EdgeStep(edge)
      * println(step.edge.label)  // "KNOWS"
      * ```
      *
-     * @property edge 해당 단계의 간선.
+     * @property edge Edge for this step.
      */
     data class EdgeStep(val edge: GraphEdge): PathStep()
 }
 
 /**
- * 그래프 경로.
+ * Graph path.
  *
- * [PathStep] 목록으로 구성되며, `[VertexStep, EdgeStep, VertexStep, ...]`
- * 교차 순서를 따른다. 두 정점 사이의 최단 경로 또는 모든 경로 탐색 결과를 표현한다.
+ * Consists of [PathStep] values ordered as `[VertexStep, EdgeStep, VertexStep, ...]`.
+ * Represents a shortest path or all-paths traversal result between two vertices.
  *
- * @property steps 경로를 구성하는 단계 목록.
- * @property totalWeight 경로의 총 가중치. 비가중치 탐색 결과는 간선 수(hop count)가 기본값.
- *   Dijkstra/A* 결과에는 실제 누적 비용이 설정된다.
+ * @property steps Steps that make up the path.
+ * @property totalWeight Total path weight. Unweighted traversal defaults to edge count (hop count).
+ *   Dijkstra/A* results set the actual accumulated cost.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val v1 = GraphVertex(GraphElementId.of("1"), "Person")
  * val v2 = GraphVertex(GraphElementId.of("2"), "Person")
@@ -67,39 +67,39 @@ data class GraphPath(
     val steps: List<PathStep>,
     val totalWeight: Double = steps.filterIsInstance<PathStep.EdgeStep>().size.toDouble(),
 ): Serializable {
-    /** 경로 내 모든 정점을 순서대로 반환한다. */
+    /** Returns all vertices in path order. */
     val vertices: List<GraphVertex>
         get() = steps.filterIsInstance<PathStep.VertexStep>().map { it.vertex }
 
-    /** 경로 내 모든 간선을 순서대로 반환한다. */
+    /** Returns all edges in path order. */
     val edges: List<GraphEdge>
         get() = steps.filterIsInstance<PathStep.EdgeStep>().map { it.edge }
 
-    /** 경로의 길이 (간선 수). 정점만 있는 경로는 0이다. */
+    /** Path length as the number of edges. Vertex-only paths have length 0. */
     val length: Int
         get() = edges.size
 
-    /** 경로에 단계가 없으면 `true`를 반환한다. */
+    /** Returns `true` when the path has no steps. */
     val isEmpty: Boolean
         get() = steps.isEmpty()
 
     companion object {
         private const val serialVersionUID: Long = 1L
 
-        /** 단계가 없는 빈 경로. 탐색 결과가 없을 때 사용한다. */
+        /** Empty path with no steps. Use when traversal has no result. */
         val EMPTY = GraphPath(emptyList())
 
         /**
-         * 정점들만으로 구성된 경로를 만든다 (간선 없음).
+         * Creates a vertex-only path with no edges.
          *
-         * 주로 단일 정점 경로 또는 인접 정점 목록을 경로로 표현할 때 사용한다.
+         * Use this for a single-vertex path or to represent adjacent vertices as a path.
          *
          * ```kotlin
          * val path = GraphPath.of(alice, bob, carol)
          * println(path.length)  // 3
          * ```
          *
-         * @param vertices 경로에 포함할 정점들.
+         * @param vertices Vertices to include in the path.
          */
         fun of(vararg vertices: GraphVertex): GraphPath =
             GraphPath(vertices.map { PathStep.VertexStep(it) })
@@ -107,7 +107,7 @@ data class GraphPath(
 }
 
 /**
- * [PathStep] 목록으로 경로를 생성한다.
+ * Creates a path from [PathStep] values.
  *
  * ```kotlin
  * val path = graphPathOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1), PathStep.VertexStep(v2))
@@ -117,7 +117,7 @@ data class GraphPath(
 fun graphPathOf(vararg steps: PathStep): GraphPath = GraphPath(steps.toList())
 
 /**
- * [PathStep] 리스트로 경로를 생성한다.
+ * Creates a path from a [PathStep] list.
  *
  * ```kotlin
  * val path = graphPathOf(listOf(PathStep.VertexStep(v1), PathStep.EdgeStep(e1)))
@@ -127,18 +127,18 @@ fun graphPathOf(vararg steps: PathStep): GraphPath = GraphPath(steps.toList())
 fun graphPathOf(steps: List<PathStep>): GraphPath = GraphPath(steps)
 
 /**
- * 정점 목록으로 정점만 있는 경로를 생성한다 (간선 없음).
+ * Creates a vertex-only path from vertices, with no edges.
  *
  * ```kotlin
  * val path = graphPathOf(v1, v2, v3)
- * println(path.length) // 0 (간선 없음)
+ * println(path.length) // 0 (no edges)
  * ```
  */
 @JvmName("graphPathOfGraphVertices")
 fun graphPathOf(vararg vertices: GraphVertex): GraphPath = GraphPath(vertices.map { PathStep.VertexStep(it) })
 
 /**
- * 정점 리스트로 정점만 있는 경로를 생성한다 (간선 없음).
+ * Creates a vertex-only path from a vertex list, with no edges.
  *
  * ```kotlin
  * val path = graphPathOf(listOf(v1, v2, v3))
@@ -148,7 +148,7 @@ fun graphPathOf(vararg vertices: GraphVertex): GraphPath = GraphPath(vertices.ma
 fun graphPathOf(vertices: List<GraphVertex>): GraphPath = GraphPath(vertices.map { PathStep.VertexStep(it) })
 
 /**
- * 간선 목록으로 간선만 있는 경로를 생성한다 (정점 없음).
+ * Creates an edge-only path from edges, with no vertices.
  *
  * ```kotlin
  * val path = graphPathOf(e1, e2)
@@ -159,7 +159,7 @@ fun graphPathOf(vertices: List<GraphVertex>): GraphPath = GraphPath(vertices.map
 fun graphPathOf(vararg edges: GraphEdge): GraphPath = GraphPath(edges.map { PathStep.EdgeStep(it) })
 
 /**
- * 간선 리스트로 간선만 있는 경로를 생성한다 (정점 없음).
+ * Creates an edge-only path from an edge list, with no vertices.
  *
  * ```kotlin
  * val path = graphPathOf(listOf(e1, e2))
@@ -169,7 +169,7 @@ fun graphPathOf(vararg edges: GraphEdge): GraphPath = GraphPath(edges.map { Path
 fun graphPathOf(edges: List<GraphEdge>): GraphPath = GraphPath(edges.map { PathStep.EdgeStep(it) })
 
 /**
- * 빈 경로 ([GraphPath.EMPTY])를 반환한다.
+ * Returns the empty path ([GraphPath.EMPTY]).
  *
  * ```kotlin
  * val path = emptyGraphPath()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphSchemaModels.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphSchemaModels.kt
@@ -3,49 +3,49 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 그래프 스키마 객체가 적용되는 엔티티 종류.
+ * Entity type a graph schema object applies to.
  *
  * ```kotlin
  * val target = GraphSchemaEntityType.VERTEX
  * ```
  */
 enum class GraphSchemaEntityType {
-    /** 정점/노드 레이블에 적용되는 스키마 객체. */
+    /** Schema object for a vertex/node label. */
     VERTEX,
 
-    /** 간선/관계 타입에 적용되는 스키마 객체. */
+    /** Schema object for an edge/relationship type. */
     EDGE,
 
-    /** 백엔드 메타데이터에서 엔티티 종류를 판별할 수 없는 스키마 객체. */
+    /** Schema object whose entity type cannot be determined from backend metadata. */
     UNKNOWN,
 }
 
 /**
- * 그래프 제약조건 종류.
+ * Graph constraint type.
  *
  * ```kotlin
  * val type = GraphConstraintType.UNIQUE
  * ```
  */
 enum class GraphConstraintType {
-    /** 특정 레이블과 속성 조합의 값이 유일해야 함을 나타낸다. */
+    /** Requires unique values for a specific label and property combination. */
     UNIQUE,
 
-    /** 특정 속성이 반드시 존재해야 함을 나타낸다. */
+    /** Requires a specific property to exist. */
     EXISTS,
 
-    /** 백엔드 고유 제약조건이거나 아직 공통 타입으로 매핑하지 않은 종류. */
+    /** Backend-specific constraint, or one not yet mapped to a common type. */
     UNKNOWN,
 }
 
 /**
- * 그래프 백엔드에 정의된 인덱스 메타데이터.
+ * Index metadata defined in a graph backend.
  *
- * @property name 백엔드 인덱스 이름. 이름이 없는 백엔드는 안정적인 합성 이름을 사용할 수 있다.
- * @property label 인덱스가 적용되는 정점 레이블 또는 간선 타입.
- * @property property 인덱스 속성 이름. label-only 인덱스는 `null`일 수 있다.
- * @property entityType 인덱스 대상 엔티티 종류.
- * @property unique 인덱스가 유니크 제약조건을 뒷받침하는지 여부.
+ * @property name Backend index name. Backends without names may use a stable synthetic name.
+ * @property label Vertex label or edge type the index applies to.
+ * @property property Indexed property name. Label-only indexes may be `null`.
+ * @property entityType Target entity type for the index.
+ * @property unique Whether the index backs a unique constraint.
  *
  * ```kotlin
  * val index = GraphIndex(
@@ -68,13 +68,13 @@ data class GraphIndex(
 }
 
 /**
- * 그래프 백엔드에 정의된 제약조건 메타데이터.
+ * Constraint metadata defined in a graph backend.
  *
- * @property name 백엔드 제약조건 이름. 이름이 없는 백엔드는 안정적인 합성 이름을 사용할 수 있다.
- * @property label 제약조건이 적용되는 정점 레이블 또는 간선 타입.
- * @property property 제약조건 속성 이름.
- * @property type 공통 제약조건 종류.
- * @property entityType 제약조건 대상 엔티티 종류.
+ * @property name Backend constraint name. Backends without names may use a stable synthetic name.
+ * @property label Vertex label or edge type the constraint applies to.
+ * @property property Constraint property name.
+ * @property type Common constraint type.
+ * @property entityType Target entity type for the constraint.
  *
  * ```kotlin
  * val constraint = GraphConstraint(

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
@@ -3,39 +3,39 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 그래프 순회 옵션의 기반 sealed class.
+ * Base sealed class for graph traversal options.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
- * // 1단계 OUTGOING 이웃 탐색
+ * // Find OUTGOING neighbors one hop away.
  * val neighborOpts = NeighborOptions(edgeLabel = "KNOWS", direction = Direction.OUTGOING)
  *
- * // 최대 5홉의 최단/전체 경로 탐색
+ * // Find shortest or all paths up to five hops.
  * val pathOpts = PathOptions(edgeLabel = "KNOWS", maxDepth = 5)
  * ```
  */
 sealed class GraphTraversalOptions: Serializable {
     /**
-     * 최대 탐색 깊이. 서브클래스별 기본값이 다르다 ([NeighborOptions]: 1, [PathOptions]: 10).
+     * Maximum traversal depth. Defaults vary by subclass: [NeighborOptions] uses `1`, [PathOptions] uses `10`.
      *
      * ```kotlin
-     * val opts = NeighborOptions(maxDepth = 3)  // 3홉까지 탐색
+     * val opts = NeighborOptions(maxDepth = 3)  // Traverse up to 3 hops.
      * ```
      */
     abstract val maxDepth: Int
 }
 
 /**
- * `GraphTraversalRepository.neighbors` 호출 옵션.
+ * Options for `GraphTraversalRepository.neighbors`.
  *
  * ```kotlin
  * val opts = NeighborOptions(edgeLabel = "KNOWS", direction = Direction.OUTGOING, maxDepth = 2)
  * val friends = ops.neighbors(alice.id, opts)
  * ```
  *
- * @param edgeLabel 탐색할 엣지 레이블. null이면 모든 레이블 탐색.
- * @param direction 탐색 방향 (OUTGOING, INCOMING, BOTH)
- * @param maxDepth 최대 탐색 깊이 (기본값: 1)
+ * @param edgeLabel Edge label to traverse. `null` traverses all labels.
+ * @param direction Traversal direction: `OUTGOING`, `INCOMING`, or `BOTH`.
+ * @param maxDepth Maximum traversal depth. Defaults to `1`.
  */
 data class NeighborOptions(
     val edgeLabel: String? = null,
@@ -49,16 +49,16 @@ data class NeighborOptions(
 }
 
 /**
- * `GraphTraversalRepository.shortestPath` / `GraphTraversalRepository.allPaths` 호출 옵션.
+ * Options for `GraphTraversalRepository.shortestPath` and `GraphTraversalRepository.allPaths`.
  *
- * [weightProperty]를 지정하면 Dijkstra/A* 알고리즘으로 가중치 최단 경로를 탐색한다.
- * `null`(기본)이면 백엔드 네이티브 BFS 최단 경로를 사용한다.
+ * When [weightProperty] is set, weighted shortest-path search uses Dijkstra/A*.
+ * When it is `null` (default), backend-native BFS shortest-path search is used.
  *
  * ```kotlin
- * // 비가중치 최단 경로 (기본)
+ * // Unweighted shortest path (default).
  * val opts = PathOptions(edgeLabel = "KNOWS", maxDepth = 5)
  *
- * // 가중치 최단 경로 (Dijkstra)
+ * // Weighted shortest path (Dijkstra).
  * val opts = PathOptions(
  *     edgeLabel = "ROAD",
  *     weightProperty = "distance",
@@ -68,12 +68,12 @@ data class NeighborOptions(
  * )
  * ```
  *
- * @param edgeLabel 탐색할 엣지 레이블. null이면 모든 레이블 탐색.
- * @param maxDepth 최대 탐색 깊이 (기본값: 10).
- * @param weightProperty 간선의 가중치 속성 키. null이면 비가중치 탐색.
- * @param missingWeightPolicy [weightProperty]가 없는 간선에 대한 처리 정책 (기본: [MissingWeightPolicy.Fail]).
- * @param direction 탐색 방향. [weightProperty]가 지정된 경우에만 적용 (기본: [Direction.OUTGOING]).
- * @param maxVisited 가중치 탐색 시 최대 방문 정점 수. 무한 그래프 보호 (기본: 100_000).
+ * @param edgeLabel Edge label to traverse. `null` traverses all labels.
+ * @param maxDepth Maximum traversal depth. Defaults to `10`.
+ * @param weightProperty Edge weight property key. `null` uses unweighted traversal.
+ * @param missingWeightPolicy Policy for edges missing [weightProperty]. Defaults to [MissingWeightPolicy.Fail].
+ * @param direction Traversal direction. Applies only when [weightProperty] is set. Defaults to [Direction.OUTGOING].
+ * @param maxVisited Maximum visited vertices during weighted traversal. Protects against unbounded graphs. Defaults to `100_000`.
  */
 data class PathOptions(
     val edgeLabel: String? = null,
@@ -94,9 +94,9 @@ data class PathOptions(
 }
 
 /**
- * `GraphTraversalRepository.bfs` / `GraphTraversalRepository.dfs` 호출 옵션.
+ * Options for `GraphTraversalRepository.bfs` and `GraphTraversalRepository.dfs`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val opts = BfsDfsOptions(edgeLabel = "KNOWS", maxDepth = 3, maxVertices = 1_000)
  * val visits = ops.bfs(alice.id, opts)
@@ -119,12 +119,12 @@ data class BfsDfsOptions(
 }
 
 /**
- * `GraphTraversalRepository.detectCycles` 호출 옵션.
+ * Options for `GraphTraversalRepository.detectCycles`.
  *
- * @param vertexLabel 탐색할 정점 레이블. null이면 모든 레이블 탐색.
- * @param edgeLabel 탐색할 엣지 레이블. null이면 모든 레이블 탐색.
- * @param maxDepth 최대 탐색 깊이 (기본값: 10)
- * @param maxCycles 반환할 최대 순환 개수 (기본값: 100)
+ * @param vertexLabel Vertex label to traverse. `null` traverses all labels.
+ * @param edgeLabel Edge label to traverse. `null` traverses all labels.
+ * @param maxDepth Maximum traversal depth. Defaults to `10`.
+ * @param maxCycles Maximum number of cycles to return. Defaults to `100`.
  */
 data class CycleOptions(
     val vertexLabel: String? = null,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphVertex.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphVertex.kt
@@ -3,16 +3,15 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 그래프의 정점(Vertex/Node).
+ * Graph vertex or node.
  *
- * 모든 그래프 백엔드(AGE, Neo4j, Memgraph, TinkerGraph)에서 공통으로 사용하는
- * 불변 정점 모델이다.
+ * Immutable vertex model shared by all graph backends: AGE, Neo4j, Memgraph, and TinkerGraph.
  *
- * @property id 백엔드 독립적인 정점 ID.
- * @property label 정점의 타입을 나타내는 레이블 (예: `"Person"`, `"Company"`).
- * @property properties 정점에 첨부된 속성 맵. 값은 `null`을 포함할 수 있다.
+ * @property id Backend-independent vertex ID.
+ * @property label Label that describes the vertex type, such as `"Person"` or `"Company"`.
+ * @property properties Property map attached to the vertex. Values may contain `null`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val person = GraphVertex(
  *     id = GraphElementId.of("v-1"),
@@ -33,32 +32,32 @@ data class GraphVertex(
 }
 
 /**
- * [GraphElementId]와 레이블로 정점을 생성한다.
+ * Creates a vertex from a [GraphElementId] and label.
  *
  * ```kotlin
  * val v = graphVertexOf(GraphElementId.of("v-1"), "Person", mapOf("name" to "Alice"))
  * ```
  *
- * @param id 정점 ID.
- * @param label 정점 레이블.
- * @param properties 정점 속성 맵. 기본값은 빈 맵.
+ * @param id Vertex ID.
+ * @param label Vertex label.
+ * @param properties Vertex property map. Defaults to an empty map.
  */
 fun graphVertexOf(id: GraphElementId, label: String, properties: Map<String, Any?> = emptyMap()) =
     GraphVertex(id, label, properties)
 
 /**
- * 임의 타입의 ID 값으로 정점을 생성한다.
+ * Creates a vertex from an ID value of any type.
  *
- * ID 변환에 [graphElementIdOf]를 사용하므로 [GraphElementId]를 그대로 전달해도 이중 변환이 발생하지 않는다.
+ * Uses [graphElementIdOf] for ID conversion, so passing a [GraphElementId] does not convert it again.
  *
  * ```kotlin
  * val v = graphVertexOf("v-1", "Person")
  * val v2 = graphVertexOf(42L, "Item", mapOf("name" to "Foo"))
  * ```
  *
- * @param id 정점 ID. [GraphElementId], [Long], 또는 `toString()` 결과를 사용하는 임의 타입.
- * @param label 정점 레이블.
- * @param properties 정점 속성 맵. 기본값은 빈 맵.
+ * @param id Vertex ID. Accepts [GraphElementId], [Long], or any type whose `toString()` result is used.
+ * @param label Vertex label.
+ * @param properties Vertex property map. Defaults to an empty map.
  */
 fun graphVertexOf(id: Any, label: String, properties: Map<String, Any?> = emptyMap()): GraphVertex =
     graphVertexOf(graphElementIdOf(id), label, properties)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/MissingWeightPolicy.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/MissingWeightPolicy.kt
@@ -3,54 +3,54 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * 가중치 최단 경로 탐색 시 간선에 weight 속성이 없을 때의 처리 정책.
+ * Policy for edges that lack a weight property during weighted shortest-path search.
  *
- * [PathOptions.weightProperty]가 지정되었으나 해당 간선에 속성이 없을 때 적용된다.
+ * Applies when [PathOptions.weightProperty] is set but an edge lacks that property.
  *
  * ```kotlin
- * // 결측 시 예외 (기본)
+ * // Throw on missing weights (default).
  * val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.Fail)
  *
- * // 결측 간선 건너뜀
+ * // Skip edges with missing weights.
  * val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.Skip)
  *
- * // 결측 시 기본값 1.0 사용
+ * // Use default weight 1.0 for missing weights.
  * val opts = PathOptions(weightProperty = "cost", missingWeightPolicy = MissingWeightPolicy.UseDefault(1.0))
  * ```
  */
 sealed class MissingWeightPolicy : Serializable {
 
     /**
-     * 결측 시 [MissingWeightException]을 던진다 (기본 정책).
+     * Throws [MissingWeightException] when a weight is missing. This is the default policy.
      *
-     * 데이터 무결성이 중요하고 모든 간선에 weight가 있어야 하는 경우에 사용한다.
+     * Use this when data integrity matters and every edge must have a weight.
      */
     data object Fail : MissingWeightPolicy() {
         private const val serialVersionUID: Long = 1L
     }
 
     /**
-     * weight 속성이 없는 간선을 경로에서 제외한다.
+     * Excludes edges without the weight property from the path.
      *
-     * 일부 간선에만 weight가 있는 스파스 그래프에서 유용하다.
+     * Useful for sparse graphs where only some edges have weights.
      */
     data object Skip : MissingWeightPolicy() {
         private const val serialVersionUID: Long = 1L
     }
 
     /**
-     * weight 속성이 없는 간선에 [value]를 기본 비용으로 적용한다.
+     * Applies [value] as the default cost for edges without the weight property.
      *
-     * [value]는 반드시 `> 0.0`이고 유한한 값이어야 한다.
-     * `0.0`은 허용하지 않는다 — zero-cost 간선이 있으면 무한 확장 위험이 있어 [PathOptions.maxVisited] 한도를 초과할 수 있다.
+     * [value] must be finite and `> 0.0`.
+     * `0.0` is not allowed because zero-cost edges can expand indefinitely and exceed [PathOptions.maxVisited].
      *
      * ```kotlin
-     * MissingWeightPolicy.UseDefault(1.0) // 결측 간선 비용 = 1.0
+     * MissingWeightPolicy.UseDefault(1.0) // Missing edge cost = 1.0
      * MissingWeightPolicy.UseDefault(0.0) // IllegalArgumentException
      * ```
      *
-     * @param value 결측 간선에 적용할 기본 비용 (> 0.0, finite).
-     * @throws IllegalArgumentException value가 0 이하이거나 무한대/NaN인 경우.
+     * @param value Default cost for missing edge weights. Must be finite and `> 0.0`.
+     * @throws IllegalArgumentException if value is non-positive, infinite, or NaN.
      */
     data class UseDefault(val value: Double) : MissingWeightPolicy() {
         companion object {
@@ -70,12 +70,12 @@ sealed class MissingWeightPolicy : Serializable {
 }
 
 /**
- * [MissingWeightPolicy.Fail] 정책 적용 시 weight 속성이 없는 간선에서 발생하는 예외.
+ * Exception thrown for an edge without a weight when [MissingWeightPolicy.Fail] is used.
  *
- * [IllegalStateException]의 하위 타입으로 로그 집계 및 모니터링 알림 설정에 활용할 수 있다.
+ * Subtype of [IllegalStateException] for log aggregation and monitoring alerts.
  *
- * @param edgeId weight가 없는 간선 ID.
- * @param key 조회한 weight 속성 키.
+ * @param edgeId ID of the edge without a weight.
+ * @param key Weight property key that was queried.
  */
 class MissingWeightException(
     val edgeId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/PageRankScore.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/PageRankScore.kt
@@ -3,15 +3,15 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * PageRank 점수 한 개를 나타내는 결과 모델.
+ * Result model for one PageRank score.
  *
- * 결과 목록은 score 내림차순 정렬이 보장된다.
- * `Flow<PageRankScore>` 도 동일 순서로 emit 된다.
+ * Result lists are ordered by descending score.
+ * `Flow<PageRankScore>` emits values in the same order.
  *
- * @property vertex 점수를 가진 정점.
- * @property score 정점의 PageRank 점수 (0.0 이상).
+ * @property vertex Vertex that owns the score.
+ * @property score PageRank score for the vertex, at least `0.0`.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val scores = ops.pageRank(PageRankOptions(iterations = 20))
  * val top = scores.first()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/TraversalVisit.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/TraversalVisit.kt
@@ -3,15 +3,15 @@ package io.bluetape4k.graph.model
 import java.io.Serializable
 
 /**
- * BFS / DFS 방문 이벤트.
+ * BFS / DFS visit event.
  *
- * 탐색 시점의 정점, 깊이, 부모 정점을 표현한다.
+ * Represents the visited vertex, depth, and parent vertex at traversal time.
  *
- * @property vertex 방문한 정점.
- * @property depth 시작 정점으로부터의 깊이 (시작 정점 = 0).
- * @property parentId 직전 정점의 ID. 시작 정점은 `null`.
+ * @property vertex Visited vertex.
+ * @property depth Depth from the start vertex. The start vertex is depth `0`.
+ * @property parentId Previous vertex ID. `null` for the start vertex.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val visits = ops.bfs(start.id, BfsDfsOptions(maxDepth = 3))
  * visits.forEach { println("d=${it.depth} v=${it.vertex.label}") }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphAlgorithmRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphAlgorithmRepository.kt
@@ -13,18 +13,18 @@ import io.bluetape4k.graph.model.PageRankScore
 import io.bluetape4k.graph.model.TraversalVisit
 
 /**
- * 그래프 분석(Analytics) 알고리즘 저장소 (동기 방식).
+ * Graph analytics algorithm repository for the blocking API.
  *
- * 결과 순서 계약:
- * - [pageRank]: score 내림차순 정렬.
- * - [connectedComponents]: componentId 오름차순. 내부 정점은 임의 순서.
- * - [bfs]: BFS 방문 순서 (레벨 순).
- * - [dfs]: DFS 방문 순서 (깊이 우선).
- * - [detectCycles]: 임의 순서.
+ * Result ordering contract:
+ * - [pageRank]: sorted by descending score.
+ * - [connectedComponents]: ascending componentId; vertices inside each component are unordered.
+ * - [bfs]: BFS visit order, level by level.
+ * - [dfs]: DFS visit order, depth first.
+ * - [detectCycles]: arbitrary order.
  *
- * 백엔드 미지원 알고리즘은 `UnsupportedOperationException` 을 던질 수 있다.
+ * Backend implementations may throw `UnsupportedOperationException` for unsupported algorithms.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val ops: GraphOperations = TinkerGraphOperations()
  * val top10 = ops.pageRank(PageRankOptions(topK = 10))
@@ -32,25 +32,25 @@ import io.bluetape4k.graph.model.TraversalVisit
  * val visits = ops.bfs(start.id, BfsDfsOptions(maxDepth = 3))
  * ```
  *
- * @see GraphSuspendAlgorithmRepository 코루틴 방식
+ * @see GraphSuspendAlgorithmRepository coroutine API
  */
 interface GraphAlgorithmRepository {
 
     /**
-     * PageRank 알고리즘을 실행해 점수 목록을 반환한다.
+     * Runs PageRank and returns the score list.
      *
-     * 반환 결과는 score 내림차순으로 정렬된다.
+     * Results are sorted by descending score.
      *
-     * @param options PageRank 옵션.
-     * @return [PageRankScore] 목록.
+     * @param options PageRank options.
+     * @return list of [PageRankScore] values.
      */
     fun pageRank(options: PageRankOptions = PageRankOptions.Default): List<PageRankScore>
 
     /**
-     * 단일 정점의 Degree Centrality 를 계산한다.
+     * Computes degree centrality for one vertex.
      *
-     * @param vertexId 측정 대상 정점 ID.
-     * @param options Degree 옵션.
+     * @param vertexId target vertex ID.
+     * @param options degree options.
      * @return [DegreeResult].
      */
     fun degreeCentrality(
@@ -59,21 +59,21 @@ interface GraphAlgorithmRepository {
     ): DegreeResult
 
     /**
-     * 연결 컴포넌트를 탐지한다.
+     * Detects connected components.
      *
-     * @param options Component 옵션.
-     * @return [GraphComponent] 목록 (componentId 오름차순).
+     * @param options component options.
+     * @return list of [GraphComponent] values, sorted by ascending componentId.
      */
     fun connectedComponents(
         options: ComponentOptions = ComponentOptions.Default,
     ): List<GraphComponent>
 
     /**
-     * BFS 탐색을 실행한다.
+     * Runs BFS traversal.
      *
-     * @param startId 시작 정점 ID.
-     * @param options BFS 옵션.
-     * @return [TraversalVisit] 목록 (방문 순서).
+     * @param startId start vertex ID.
+     * @param options BFS options.
+     * @return list of [TraversalVisit] values in visit order.
      */
     fun bfs(
         startId: GraphElementId,
@@ -81,11 +81,11 @@ interface GraphAlgorithmRepository {
     ): List<TraversalVisit>
 
     /**
-     * DFS 탐색을 실행한다.
+     * Runs DFS traversal.
      *
-     * @param startId 시작 정점 ID.
-     * @param options DFS 옵션.
-     * @return [TraversalVisit] 목록 (방문 순서).
+     * @param startId start vertex ID.
+     * @param options DFS options.
+     * @return list of [TraversalVisit] values in visit order.
      */
     fun dfs(
         startId: GraphElementId,
@@ -93,10 +93,10 @@ interface GraphAlgorithmRepository {
     ): List<TraversalVisit>
 
     /**
-     * 순환을 탐지한다.
+     * Detects cycles.
      *
-     * @param options Cycle 옵션.
-     * @return [GraphCycle] 목록.
+     * @param options cycle options.
+     * @return list of [GraphCycle] values.
      */
     fun detectCycles(
         options: CycleOptions = CycleOptions.Default,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphBatchValidation.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphBatchValidation.kt
@@ -5,16 +5,17 @@ import io.bluetape4k.graph.support.requireSafeIdentifier
 import io.bluetape4k.support.requireNotBlank
 
 /**
- * 배치 insert API가 모든 백엔드에서 공유하는 입력 검증 규칙.
+ * Shared input validation rules for backend batch insert APIs.
  *
- * 백엔드 구현체는 쿼리 문자열이나 Gremlin traversal을 만들기 전에 이 검증을 먼저 호출해야 한다.
+ * Backend implementations should call this validator before building query strings
+ * or Gremlin traversals.
  */
 object GraphBatchValidation {
 
     /**
-     * 정점 배치 입력을 검증한다.
+     * Validates vertex batch input.
      *
-     * @return 검증된 입력 그대로의 [propertiesList].
+     * @return the validated [propertiesList] unchanged.
      */
     fun validateVertexBatch(
         label: String,
@@ -26,9 +27,9 @@ object GraphBatchValidation {
     }
 
     /**
-     * 간선 배치 입력을 검증한다.
+     * Validates edge batch input.
      *
-     * @return 검증된 입력 그대로의 [edges].
+     * @return the validated [edges] unchanged.
      */
     fun validateEdgeBatch(
         label: String,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphEdgeRepository.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.graph.model.GraphEdge
 import io.bluetape4k.graph.model.GraphElementId
 
 /**
- * 그래프 간선(Edge) CRUD 저장소 (동기 방식).
+ * Synchronous graph edge CRUD repository.
  *
  * ```kotlin
  * val edge = ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024))
@@ -15,17 +15,17 @@ import io.bluetape4k.graph.model.GraphElementId
  */
 interface GraphEdgeRepository {
     /**
-     * 두 정점 사이에 새 간선을 생성하고 반환한다.
+     * Creates and returns a new edge between two vertices.
      *
      * ```kotlin
      * val edge = ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024))
      * ```
      *
-     * @param fromId 시작 정점 ID.
-     * @param toId 종료 정점 ID.
-     * @param label 간선 레이블 (예: `"KNOWS"`, `"WORKS_AT"`).
-     * @param properties 간선에 저장할 속성 맵. 기본값은 빈 맵.
-     * @return 백엔드에서 생성된 [GraphEdge] (ID가 채워진 상태).
+     * @param fromId start vertex ID.
+     * @param toId end vertex ID.
+     * @param label edge label, such as `"KNOWS"` or `"WORKS_AT"`.
+     * @param properties properties to store on the edge; defaults to an empty map.
+     * @return backend-created [GraphEdge] with its ID populated.
      */
     fun createEdge(
         fromId: GraphElementId,
@@ -35,14 +35,14 @@ interface GraphEdgeRepository {
     ): GraphEdge
 
     /**
-     * 같은 레이블의 간선을 여러 개 생성하고 입력 순서와 같은 순서로 반환한다.
-     *
-     * ## 동작/계약
-     *
-     * - 빈 입력은 백엔드를 호출하지 않고 `emptyList()`를 반환한다.
-     * - 기본 구현은 [createEdge]를 순차 호출하는 호환성 fallback이다.
-     * - 기본 구현은 중간 실패 시 앞서 생성된 간선이 남을 수 있다.
-     * - 성능 및 all-or-fail 의미가 필요한 프로덕션 백엔드는 이 메서드를 override해야 한다.
+     * Creates multiple edges with the same label and returns them in input order.
+	*
+     * ## Contract
+	*
+     * - Empty input returns `emptyList()` without calling the backend.
+     * - The default implementation is a compatibility fallback that calls [createEdge] sequentially.
+     * - If the default implementation fails mid-batch, previously created edges may remain.
+     * - Production backends that need performance or all-or-fail semantics should override this method.
      *
      * ```kotlin
      * val edges = ops.createEdges(
@@ -51,9 +51,9 @@ interface GraphEdgeRepository {
      * )
      * ```
      *
-     * @param label 간선 레이블.
-     * @param edges 간선 endpoint와 속성 목록.
-     * @return 백엔드에서 생성된 [GraphEdge] 목록.
+     * @param label edge label.
+     * @param edges edge endpoints and property rows.
+     * @return backend-created [GraphEdge] values.
      */
     fun createEdges(
         label: String,
@@ -65,16 +65,16 @@ interface GraphEdgeRepository {
     }
 
     /**
-     * 레이블과 속성 필터로 간선 목록을 조회한다.
+     * Finds edges by label and property filter.
      *
      * ```kotlin
      * val all    = ops.findEdgesByLabel("KNOWS")
      * val recent = ops.findEdgesByLabel("KNOWS", mapOf("since" to 2024))
      * ```
      *
-     * @param label 조회할 간선 레이블.
-     * @param filter 속성 이름→값 조건 맵. 빈 맵이면 레이블 전체를 반환.
-     * @return 조건에 맞는 [GraphEdge] 목록.
+     * @param label edge label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @return matching [GraphEdge] values.
      */
     fun findEdgesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): List<GraphEdge>
 
@@ -106,46 +106,46 @@ interface GraphEdgeRepository {
         findEdgesByLabel(label, filter).asGraphExportChunks(chunkSize)
 
     /**
-     * 특정 정점에서 출발하는 간선 목록을 조회한다.
-     *
-     * Dijkstra/A* 알고리즘의 인접 간선 수집에 사용된다.
+     * Finds edges that start at a specific vertex.
+	*
+     * Used to collect adjacent edges for Dijkstra/A* algorithms.
      *
      * ```kotlin
      * val outEdges = ops.findEdgesByStartId(alice.id)
      * val typed    = ops.findEdgesByStartId(alice.id, edgeLabel = "KNOWS")
      * ```
      *
-     * @param startId 시작 정점 ID.
-     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
-     * @return 해당 정점에서 출발하는 [GraphEdge] 목록.
+     * @param startId start vertex ID.
+     * @param edgeLabel optional edge-label filter; `null` returns all labels.
+     * @return [GraphEdge] values that start at the vertex.
      */
     fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String? = null): List<GraphEdge>
 
     /**
-     * 특정 정점으로 도착하는 간선 목록을 조회한다.
-     *
-     * `Direction.INCOMING` / `Direction.BOTH` 탐색에 사용된다.
+     * Finds edges that end at a specific vertex.
+	*
+     * Used for `Direction.INCOMING` and `Direction.BOTH` traversal.
      *
      * ```kotlin
      * val inEdges = ops.findEdgesByEndId(alice.id)
      * ```
      *
-     * @param endId 종료 정점 ID.
-     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
-     * @return 해당 정점으로 도착하는 [GraphEdge] 목록.
+     * @param endId end vertex ID.
+     * @param edgeLabel optional edge-label filter; `null` returns all labels.
+     * @return [GraphEdge] values that end at the vertex.
      */
     fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String? = null): List<GraphEdge>
 
     /**
-     * 간선을 삭제한다.
+     * Deletes an edge.
      *
      * ```kotlin
      * val deleted = ops.deleteEdge("KNOWS", edge.id)  // true
      * ```
      *
-     * @param label 간선 레이블.
-     * @param id 삭제할 간선 ID.
-     * @return 삭제 성공이면 `true`, 해당 ID가 없으면 `false`.
+     * @param label edge label.
+     * @param id edge ID to delete.
+     * @return `true` when deleted, or `false` when the ID is absent.
      */
     fun deleteEdge(label: String, id: GraphElementId): Boolean
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphGenericRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphGenericRepository.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 순회(traversal) + 분석(algorithm) 을 묶은 동기 합성 인터페이스.
+ * Synchronous composite interface for traversal and algorithm operations.
  *
- * [GraphOperations] 의존성을 좁히고 싶을 때 이 타입을 직접 주입할 수 있다.
+ * Inject this type directly when callers need a narrower dependency than [GraphOperations].
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * fun analyze(repo: GraphGenericRepository) {
  *     val path = repo.shortestPath(a, b)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphMergeOperations.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphMergeOperations.kt
@@ -7,15 +7,15 @@ import io.bluetape4k.graph.support.requireSafeIdentifier
 import io.bluetape4k.support.requireNotBlank
 
 /**
- * 검증을 통과한 merge/upsert 속성 묶음.
+ * Validated merge/upsert property bundle.
  *
- * `matchProperties`는 요소를 찾는 안정적인 식별자이고, `setProperties`는 생성되었거나
- * 이미 존재하는 요소에 적용할 갱신 속성이다.
+ * `matchProperties` are stable identifiers used to find an element, while `setProperties`
+ * are updates applied to a newly created or existing element.
  *
- * ## 동작/계약
- * - `matchProperties`의 값은 `null`일 수 없다. null identity key는 backend별 query 의미가
- *   달라질 수 있기 때문이다.
- * - `setProperties`는 `matchProperties`와 같은 key를 덮어쓸 수 없다.
+ * ## Contract
+ * - `matchProperties` values must not be `null`; null identity values can have
+ *   backend-specific query semantics.
+ * - `setProperties` must not overwrite keys from `matchProperties`.
  *
  * ```kotlin
  * val props = GraphMergeValidation.validateVertex(
@@ -31,14 +31,14 @@ data class GraphMergeProperties(
 )
 
 /**
- * merge/upsert API가 모든 백엔드에서 공유하는 입력 검증 규칙.
+ * Shared input validation rules for backend merge/upsert APIs.
  *
- * 백엔드 구현체는 쿼리 문자열을 만들기 전에 이 검증을 먼저 호출해야 한다.
+ * Backend implementations should call this validator before building query strings.
  *
- * ## 동작/계약
- * - label과 property key는 backend query에 안전한 identifier여야 한다.
- * - vertex merge는 [validateVertex]에서 non-empty `matchProperties`를 요구한다.
- * - edge merge는 endpoint id와 label이 identity를 이루므로 empty `matchProperties`를 허용한다.
+ * ## Contract
+ * - Labels and property keys must be backend-query-safe identifiers.
+ * - Vertex merges require non-empty `matchProperties` through [validateVertex].
+ * - Edge merges allow empty `matchProperties` because endpoint IDs and label form the identity.
  *
  * ```kotlin
  * val validated = GraphMergeValidation.validateEdge(
@@ -53,10 +53,10 @@ data class GraphMergeProperties(
 object GraphMergeValidation {
 
     /**
-     * 정점 merge 입력을 검증한다.
+     * Validates vertex merge input.
      *
-     * 정점은 레이블만으로 merge 하면 여러 기존 정점이 매칭될 수 있으므로
-     * `matchProperties`가 비어 있으면 거부한다.
+     * Vertices reject empty `matchProperties` because merging by label alone can match
+     * multiple existing vertices.
      */
     fun validateVertex(
         label: String,
@@ -71,10 +71,10 @@ object GraphMergeValidation {
     }
 
     /**
-     * 간선 merge 입력을 검증한다.
+     * Validates edge merge input.
      *
-     * 간선은 시작 정점 ID, 종료 정점 ID, 레이블이 기본 식별자이므로
-     * `matchProperties`가 비어 있어도 허용한다.
+     * Edges allow empty `matchProperties` because start vertex ID, end vertex ID,
+     * and label form the primary identity.
      */
     fun validateEdge(
         fromId: GraphElementId,
@@ -117,15 +117,16 @@ object GraphMergeValidation {
 }
 
 /**
- * 동기 그래프 구현체가 merge/upsert 기능을 제공할 때 구현하는 capability interface.
+ * Capability interface for synchronous graph implementations that support merge/upsert.
  *
- * [GraphOperations] 자체에 멤버를 추가하지 않아 기존 구현체와 테스트 fake의 source compatibility를 유지한다.
+ * This keeps source compatibility for existing implementations and test fakes by
+ * avoiding new members on [GraphOperations].
  *
- * ## 동작/계약
- * - 구현체는 [GraphMergeValidation]으로 입력을 검증한 뒤 backend-native `MERGE` 또는
- *   transactional match/update/create path를 사용해야 한다.
- * - unsupported backend는 이 interface를 구현하지 않고 extension function에서
- *   [UnsupportedOperationException]으로 fail fast 하도록 둔다.
+ * ## Contract
+ * - Implementations should validate input with [GraphMergeValidation], then use a
+ *   backend-native `MERGE` or transactional match/update/create path.
+ * - Unsupported backends should not implement this interface; extension functions
+ *   then fail fast with [UnsupportedOperationException].
  *
  * ```kotlin
  * val alice = ops.mergeVertex(
@@ -138,7 +139,7 @@ object GraphMergeValidation {
 interface GraphMergeOperations {
 
     /**
-     * `matchProperties`로 정점을 찾고, 없으면 생성한 뒤 `setProperties`를 적용해 반환한다.
+     * Finds a vertex by `matchProperties`, creates it when absent, applies `setProperties`, and returns it.
      */
     fun mergeVertex(
         label: String,
@@ -147,8 +148,8 @@ interface GraphMergeOperations {
     ): GraphVertex
 
     /**
-     * 시작/종료 정점, 간선 레이블, `matchProperties`로 간선을 찾고, 없으면 생성한 뒤
-     * `setProperties`를 적용해 반환한다.
+     * Finds an edge by endpoints, label, and `matchProperties`, creates it when absent,
+     * applies `setProperties`, and returns it.
      */
     fun mergeEdge(
         fromId: GraphElementId,
@@ -160,11 +161,11 @@ interface GraphMergeOperations {
 }
 
 /**
- * 코루틴 그래프 구현체가 merge/upsert 기능을 제공할 때 구현하는 capability interface.
+ * Capability interface for coroutine graph implementations that support merge/upsert.
  *
- * ## 동작/계약
- * - [GraphMergeOperations]와 같은 identity/set semantics를 suspend API로 제공한다.
- * - cancellation은 backend implementation에서 삼키지 않아야 한다.
+ * ## Contract
+ * - Provides the same identity/set semantics as [GraphMergeOperations] through suspend APIs.
+ * - Backend implementations must not swallow cancellation.
  *
  * ```kotlin
  * val alice = suspendOps.mergeVertex(
@@ -176,14 +177,14 @@ interface GraphMergeOperations {
  */
 interface GraphSuspendMergeOperations {
 
-    /** `matchProperties`로 정점을 찾고, 없으면 생성한 뒤 `setProperties`를 적용해 반환한다. */
+    /** Finds a vertex by `matchProperties`, creates it when absent, applies `setProperties`, and returns it. */
     suspend fun mergeVertex(
         label: String,
         matchProperties: Map<String, Any?>,
         setProperties: Map<String, Any?> = emptyMap(),
     ): GraphVertex
 
-    /** 시작/종료 정점, 간선 레이블, `matchProperties`로 간선을 찾고, 없으면 생성한 뒤 `setProperties`를 적용한다. */
+    /** Finds or creates an edge by endpoints, label, and `matchProperties`, then applies `setProperties`. */
     suspend fun mergeEdge(
         fromId: GraphElementId,
         toId: GraphElementId,
@@ -194,10 +195,10 @@ interface GraphSuspendMergeOperations {
 }
 
 /**
- * [GraphOperations]에서 정점 merge/upsert를 실행한다.
+ * Executes vertex merge/upsert on [GraphOperations].
  *
- * 구현체가 [GraphMergeOperations]를 구현하지 않으면 read-then-write fallback을 사용하지 않고
- * 명시적으로 [UnsupportedOperationException]을 던진다.
+ * If the implementation does not implement [GraphMergeOperations], this function
+ * explicitly throws [UnsupportedOperationException] instead of using a read-then-write fallback.
  *
  * ```kotlin
  * import io.bluetape4k.graph.repository.mergeVertex
@@ -222,9 +223,10 @@ fun GraphOperations.mergeVertex(
 }
 
 /**
- * [GraphOperations]에서 간선 merge/upsert를 실행한다.
+ * Executes edge merge/upsert on [GraphOperations].
  *
- * 구현체가 [GraphMergeOperations]를 구현하지 않으면 명시적으로 [UnsupportedOperationException]을 던진다.
+ * If the implementation does not implement [GraphMergeOperations], this function
+ * explicitly throws [UnsupportedOperationException].
  *
  * ```kotlin
  * import io.bluetape4k.graph.repository.mergeEdge
@@ -252,7 +254,7 @@ fun GraphOperations.mergeEdge(
 }
 
 /**
- * [GraphSuspendOperations]에서 코루틴 정점 merge/upsert를 실행한다.
+ * Executes coroutine vertex merge/upsert on [GraphSuspendOperations].
  *
  * ```kotlin
  * import io.bluetape4k.graph.repository.mergeVertex
@@ -276,7 +278,7 @@ suspend fun GraphSuspendOperations.mergeVertex(
 }
 
 /**
- * [GraphSuspendOperations]에서 코루틴 간선 merge/upsert를 실행한다.
+ * Executes coroutine edge merge/upsert on [GraphSuspendOperations].
  *
  * ```kotlin
  * import io.bluetape4k.graph.repository.mergeEdge

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphOperations.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphOperations.kt
@@ -1,14 +1,14 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 그래프 데이터베이스의 통합 Facade (동기 방식).
- * AGE, Neo4j 등 각 백엔드가 이 인터페이스를 구현한다.
+ * Unified graph database facade for the blocking API.
+ * Backends such as AGE and Neo4j implement this interface.
  *
- * @see GraphSuspendOperations 코루틴(suspend + Flow) 방식
+ * @see GraphSuspendOperations coroutine API with suspend functions and Flow
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
- * // ops는 AgeGraphOperations, Neo4jGraphOperations, TinkerGraphOperations 등
+ * // ops can be AgeGraphOperations, Neo4jGraphOperations, TinkerGraphOperations, and so on.
  * val ops: GraphOperations = TinkerGraphOperations()
  *
  * ops.createGraph("social")

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSession.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSession.kt
@@ -1,51 +1,51 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 그래프 데이터베이스 세션 관리 (동기 방식).
+ * Manages graph database sessions with the blocking API.
  *
- * 소유권: 외부에서 주입된 Database/Driver를 [close]에서 닫지 않는다.
- * 연결 풀/드라이버 생명주기는 Spring 컨테이너 또는 호출자가 관리한다.
+ * Ownership: [close] does not close externally supplied databases or drivers.
+ * The Spring container or caller owns connection pool and driver lifecycles.
  *
  * ```kotlin
- * ops.createGraph("social")          // 그래프 생성
+ * ops.createGraph("social")          // create graph
  * ops.graphExists("social")          // true
- * ops.dropGraph("social")            // 삭제
+ * ops.dropGraph("social")            // drop graph
  * ops.graphExists("social")          // false
  * ```
  */
 interface GraphSession : AutoCloseable {
     /**
-     * 지정한 이름의 그래프를 생성한다.
+     * Creates the graph with the given name.
      *
-     * 이미 존재하는 그래프에 대해 호출하면 [io.bluetape4k.graph.GraphAlreadyExistsException]을
-     * 발생시키거나 백엔드 구현에 따라 무시할 수 있다.
+     * Calling this for an existing graph may throw [io.bluetape4k.graph.GraphAlreadyExistsException]
+     * or may be ignored by the backend implementation.
      *
      * ```kotlin
      * ops.createGraph("social")
      * ops.graphExists("social")  // true
      * ```
      *
-     * @param name 생성할 그래프 이름.
+     * @param name graph name to create.
      */
     fun createGraph(name: String)
 
     /**
-     * 지정한 이름의 그래프를 삭제한다.
+     * Drops the graph with the given name.
      *
-     * 존재하지 않는 그래프에 대해 호출하면 [io.bluetape4k.graph.GraphNotFoundException]을
-     * 발생시키거나 백엔드 구현에 따라 무시할 수 있다.
+     * Calling this for a missing graph may throw [io.bluetape4k.graph.GraphNotFoundException]
+     * or may be ignored by the backend implementation.
      *
      * ```kotlin
      * ops.dropGraph("social")
      * ops.graphExists("social")  // false
      * ```
      *
-     * @param name 삭제할 그래프 이름.
+     * @param name graph name to drop.
      */
     fun dropGraph(name: String)
 
     /**
-     * 지정한 이름의 그래프가 존재하는지 확인한다.
+     * Checks whether the graph with the given name exists.
      *
      * ```kotlin
      * ops.createGraph("social")
@@ -54,8 +54,8 @@ interface GraphSession : AutoCloseable {
      * ops.graphExists("social")  // false
      * ```
      *
-     * @param name 확인할 그래프 이름.
-     * @return 그래프가 존재하면 `true`, 그렇지 않으면 `false`.
+     * @param name graph name to check.
+     * @return `true` when the graph exists, otherwise `false`.
      */
     fun graphExists(name: String): Boolean
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendAlgorithmRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendAlgorithmRepository.kt
@@ -14,12 +14,12 @@ import io.bluetape4k.graph.model.TraversalVisit
 import kotlinx.coroutines.flow.Flow
 
 /**
- * 그래프 분석(Analytics) 알고리즘 저장소 (코루틴/Flow 방식).
+ * Graph analytics algorithm repository for the coroutine and Flow API.
  *
- * Flow 순서 계약은 [GraphAlgorithmRepository] 와 동일하다.
- * [pageRank] Flow 는 score 내림차순으로 emit 된다.
+ * Flow ordering matches [GraphAlgorithmRepository].
+ * The [pageRank] Flow emits scores in descending order.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * runBlocking {
  *     val top10 = ops.pageRank(PageRankOptions(topK = 10)).toList()
@@ -28,17 +28,17 @@ import kotlinx.coroutines.flow.Flow
  * }
  * ```
  *
- * @see GraphAlgorithmRepository 동기 방식
+ * @see GraphAlgorithmRepository blocking API
  */
 interface GraphSuspendAlgorithmRepository {
 
     /**
-     * PageRank 점수를 Flow 로 emit 한다 (score 내림차순).
+     * Emits PageRank scores as a Flow in descending score order.
      */
     fun pageRank(options: PageRankOptions = PageRankOptions.Default): Flow<PageRankScore>
 
     /**
-     * 단일 정점의 Degree Centrality 를 계산한다.
+     * Computes degree centrality for one vertex.
      */
     suspend fun degreeCentrality(
         vertexId: GraphElementId,
@@ -46,14 +46,14 @@ interface GraphSuspendAlgorithmRepository {
     ): DegreeResult
 
     /**
-     * 연결 컴포넌트를 Flow 로 emit 한다.
+     * Emits connected components as a Flow.
      */
     fun connectedComponents(
         options: ComponentOptions = ComponentOptions.Default,
     ): Flow<GraphComponent>
 
     /**
-     * BFS 방문 이벤트를 Flow 로 emit 한다.
+     * Emits BFS visit events as a Flow.
      */
     fun bfs(
         startId: GraphElementId,
@@ -61,7 +61,7 @@ interface GraphSuspendAlgorithmRepository {
     ): Flow<TraversalVisit>
 
     /**
-     * DFS 방문 이벤트를 Flow 로 emit 한다.
+     * Emits DFS visit events as a Flow.
      */
     fun dfs(
         startId: GraphElementId,
@@ -69,7 +69,7 @@ interface GraphSuspendAlgorithmRepository {
     ): Flow<TraversalVisit>
 
     /**
-     * 탐지된 순환을 Flow 로 emit 한다.
+     * Emits detected cycles as a Flow.
      */
     fun detectCycles(
         options: CycleOptions = CycleOptions.Default,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendEdgeRepository.kt
@@ -6,9 +6,9 @@ import io.bluetape4k.graph.model.GraphElementId
 import kotlinx.coroutines.flow.Flow
 
 /**
- * 그래프 간선(Edge) CRUD 저장소 (코루틴 방식).
+ * Coroutine graph edge CRUD repository.
  *
- * 컬렉션 반환은 [Flow]로 제공하여 대량 데이터 스트리밍을 지원한다.
+ * Collection-returning operations expose [Flow] so large result sets can stream.
  *
  * ```kotlin
  * runBlocking {
@@ -18,21 +18,21 @@ import kotlinx.coroutines.flow.Flow
  * }
  * ```
  *
- * @see GraphEdgeRepository 동기(blocking) 방식
+ * @see GraphEdgeRepository synchronous blocking variant
  */
 interface GraphSuspendEdgeRepository {
     /**
-     * 두 정점 사이에 새 간선을 생성하고 반환한다.
+     * Creates and returns a new edge between two vertices.
      *
      * ```kotlin
      * val edge = ops.createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024))
      * ```
      *
-     * @param fromId 시작 정점 ID.
-     * @param toId 종료 정점 ID.
-     * @param label 간선 레이블 (예: `"KNOWS"`, `"WORKS_AT"`).
-     * @param properties 간선에 저장할 속성 맵. 기본값은 빈 맵.
-     * @return 백엔드에서 생성된 [GraphEdge] (ID가 채워진 상태).
+     * @param fromId start vertex ID.
+     * @param toId end vertex ID.
+     * @param label edge label, such as `"KNOWS"` or `"WORKS_AT"`.
+     * @param properties properties to store on the edge; defaults to an empty map.
+     * @return backend-created [GraphEdge] with its ID populated.
      */
     suspend fun createEdge(
         fromId: GraphElementId,
@@ -42,18 +42,18 @@ interface GraphSuspendEdgeRepository {
     ): GraphEdge
 
     /**
-     * 같은 레이블의 간선을 여러 개 생성하고 입력 순서와 같은 순서로 반환한다.
+     * Creates multiple edges with the same label and returns them in input order.
      *
-     * ## 동작/계약
+     * ## Contract
      *
-     * - 빈 입력은 백엔드를 호출하지 않고 `emptyList()`를 반환한다.
-     * - 기본 구현은 [createEdge]를 순차 호출하는 호환성 fallback이다.
-     * - 기본 구현은 중간 실패 시 앞서 생성된 간선이 남을 수 있다.
-     * - 성능 및 all-or-fail 의미가 필요한 프로덕션 백엔드는 이 메서드를 override해야 한다.
+     * - Empty input returns `emptyList()` without calling the backend.
+     * - The default implementation is a compatibility fallback that calls [createEdge] sequentially.
+     * - If the default implementation fails mid-batch, previously created edges may remain.
+     * - Production backends that need performance or all-or-fail semantics should override this method.
      *
-     * @param label 간선 레이블.
-     * @param edges 간선 endpoint와 속성 목록.
-     * @return 백엔드에서 생성된 [GraphEdge] 목록.
+     * @param label edge label.
+     * @param edges edge endpoints and property rows.
+     * @return backend-created [GraphEdge] values.
      */
     suspend fun createEdges(
         label: String,
@@ -65,18 +65,18 @@ interface GraphSuspendEdgeRepository {
     }
 
     /**
-     * 레이블과 속성 필터로 간선 목록을 스트림으로 조회한다.
+     * Finds edges by label and property filter as a stream.
      *
-     * 대량 데이터에 적합한 [Flow] 기반 조회이다.
+     * This [Flow]-based query is suitable for large result sets.
      *
      * ```kotlin
      * val edges = ops.findEdgesByLabel("KNOWS").toList()
      * val filtered = ops.findEdgesByLabel("KNOWS", mapOf("since" to 2024)).toList()
      * ```
      *
-     * @param label 조회할 간선 레이블.
-     * @param filter 속성 이름→값 조건 맵. 빈 맵이면 레이블 전체를 반환.
-     * @return 조건에 맞는 [GraphEdge] Flow.
+     * @param label edge label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @return [Flow] of matching [GraphEdge] values.
      */
     fun findEdgesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): Flow<GraphEdge>
 
@@ -105,41 +105,41 @@ interface GraphSuspendEdgeRepository {
         findEdgesByLabel(label, filter).asGraphExportChunks(chunkSize)
 
     /**
-     * 특정 정점에서 출발하는 간선 목록을 스트림으로 조회한다.
+     * Finds edges that start at a specific vertex as a stream.
      *
      * ```kotlin
      * val outEdges = ops.findEdgesByStartId(alice.id).toList()
      * ```
      *
-     * @param startId 시작 정점 ID.
-     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
-     * @return 해당 정점에서 출발하는 [GraphEdge] Flow.
+     * @param startId start vertex ID.
+     * @param edgeLabel optional edge-label filter; `null` returns all labels.
+     * @return [Flow] of [GraphEdge] values that start at the vertex.
      */
     fun findEdgesByStartId(startId: GraphElementId, edgeLabel: String? = null): Flow<GraphEdge>
 
     /**
-     * 특정 정점으로 도착하는 간선 목록을 스트림으로 조회한다.
+     * Finds edges that end at a specific vertex as a stream.
      *
      * ```kotlin
      * val inEdges = ops.findEdgesByEndId(alice.id).toList()
      * ```
      *
-     * @param endId 종료 정점 ID.
-     * @param edgeLabel 간선 레이블 필터. null이면 모든 레이블 반환.
-     * @return 해당 정점으로 도착하는 [GraphEdge] Flow.
+     * @param endId end vertex ID.
+     * @param edgeLabel optional edge-label filter; `null` returns all labels.
+     * @return [Flow] of [GraphEdge] values that end at the vertex.
      */
     fun findEdgesByEndId(endId: GraphElementId, edgeLabel: String? = null): Flow<GraphEdge>
 
     /**
-     * 간선을 삭제한다.
+     * Deletes an edge.
      *
      * ```kotlin
      * val deleted = ops.deleteEdge("KNOWS", edge.id)  // true
      * ```
      *
-     * @param label 간선 레이블.
-     * @param id 삭제할 간선 ID.
-     * @return 삭제 성공이면 `true`, 해당 ID가 없으면 `false`.
+     * @param label edge label.
+     * @param id edge ID to delete.
+     * @return `true` when deleted, or `false` when the ID is absent.
      */
     suspend fun deleteEdge(label: String, id: GraphElementId): Boolean
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendGenericRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendGenericRepository.kt
@@ -1,11 +1,11 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 순회(traversal) + 분석(algorithm) 을 묶은 코루틴 합성 인터페이스.
+ * Coroutine composite interface for traversal and algorithm operations.
  *
- * [GraphSuspendOperations] 의존성을 좁히고 싶을 때 이 타입을 직접 주입할 수 있다.
+ * Inject this type directly when callers need a narrower dependency than [GraphSuspendOperations].
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * suspend fun analyze(repo: GraphSuspendGenericRepository) {
  *     val path = repo.shortestPath(a, b)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendOperations.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendOperations.kt
@@ -1,14 +1,14 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 그래프 데이터베이스의 통합 Facade (코루틴 방식).
- * AGE, Neo4j 등 각 백엔드가 이 인터페이스를 구현한다.
+ * Coroutine facade for graph databases.
+ * Backends such as AGE and Neo4j implement this interface.
  *
- * @see GraphOperations 동기(blocking) 방식
+ * @see GraphOperations synchronous blocking variant
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
- * // ops는 AgeGraphSuspendOperations, Neo4jGraphSuspendOperations 등
+ * // ops may be AgeGraphSuspendOperations, Neo4jGraphSuspendOperations, and so on.
  * val ops: GraphSuspendOperations = ...
  *
  * ops.createGraph("social")
@@ -17,7 +17,7 @@ package io.bluetape4k.graph.repository
  * val bob   = ops.createVertex("Person", mapOf("name" to "Bob"))
  * ops.createEdge(alice.id, bob.id, "FOLLOWS")
  *
- * val neighbors = ops.neighbors(alice.id).toList()  // Flow → List
+ * val neighbors = ops.neighbors(alice.id).toList()  // Flow to List
  * ```
  */
 interface GraphSuspendOperations :

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendSession.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendSession.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 그래프 데이터베이스 세션 관리 (코루틴 방식).
+ * Coroutine graph database session management.
  *
- * 소유권: 외부에서 주입된 Database/Driver를 [close]에서 닫지 않는다.
- * 연결 풀/드라이버 생명주기는 Spring 컨테이너 또는 호출자가 관리한다.
+ * Ownership: [close] does not close externally injected databases or drivers.
+ * Connection pool and driver lifecycles are owned by the Spring container or caller.
  *
  * ```kotlin
  * runBlocking {
@@ -15,43 +15,43 @@ package io.bluetape4k.graph.repository
  * }
  * ```
  *
- * @see GraphSession 동기(blocking) 방식
+ * @see GraphSession synchronous blocking variant
  */
 interface GraphSuspendSession : AutoCloseable {
     /**
-     * 지정한 이름의 그래프를 생성한다.
+     * Creates a graph with the given name.
      *
      * ```kotlin
      * ops.createGraph("social")
      * ```
      *
-     * @param name 생성할 그래프 이름.
-     * @see GraphSession.createGraph 동기 버전
+     * @param name graph name to create.
+     * @see GraphSession.createGraph synchronous version
      */
     suspend fun createGraph(name: String)
 
     /**
-     * 지정한 이름의 그래프를 삭제한다.
+     * Drops a graph with the given name.
      *
      * ```kotlin
      * ops.dropGraph("social")
      * ```
      *
-     * @param name 삭제할 그래프 이름.
-     * @see GraphSession.dropGraph 동기 버전
+     * @param name graph name to drop.
+     * @see GraphSession.dropGraph synchronous version
      */
     suspend fun dropGraph(name: String)
 
     /**
-     * 지정한 이름의 그래프가 존재하는지 확인한다.
+     * Checks whether a graph with the given name exists.
      *
      * ```kotlin
      * val exists = ops.graphExists("social")  // true / false
      * ```
      *
-     * @param name 확인할 그래프 이름.
-     * @return 그래프가 존재하면 `true`, 그렇지 않으면 `false`.
-     * @see GraphSession.graphExists 동기 버전
+     * @param name graph name to check.
+     * @return `true` when the graph exists, otherwise `false`.
+     * @see GraphSession.graphExists synchronous version
      */
     suspend fun graphExists(name: String): Boolean
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTransactionScope.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTransactionScope.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 
 /**
- * 코루틴 그래프 트랜잭션 블록에서 사용할 수 있는 연산 범위.
+ * Operation scope available inside a coroutine graph transaction block.
  *
  * ```kotlin
  * val edge = ops.suspendTransaction {
@@ -17,8 +17,8 @@ import kotlinx.coroutines.flow.asFlow
  * }
  * ```
  *
- * 이번 API는 capability contract를 먼저 제공한다. 각 백엔드는 실제 코루틴 트랜잭션 의미를
- * 보장할 수 있을 때 [GraphSuspendTransactionalOperations]를 구현한다.
+ * This API exposes the capability contract first. Each backend implements
+ * [GraphSuspendTransactionalOperations] only when it can provide real coroutine transaction semantics.
  */
 @GraphTransactionDsl
 interface GraphSuspendTransactionScope :
@@ -26,11 +26,11 @@ interface GraphSuspendTransactionScope :
     GraphSuspendEdgeRepository
 
 /**
- * 동기 [GraphTransactionScope]를 코루틴 트랜잭션 범위로 노출하는 어댑터.
+ * Adapter that exposes a synchronous [GraphTransactionScope] as a coroutine transaction scope.
  *
- * Neo4j Java Driver, Memgraph Bolt, TinkerGraph처럼 동기 트랜잭션 API가 원자성의 실제 소유자인
- * 백엔드에서 suspend DSL을 제공할 때 사용한다. 호출자는 이 타입을 직접 생성하기보다
- * [asSuspendTransactionScope]를 사용한다.
+ * Use this when a backend, such as the Neo4j Java Driver, Memgraph Bolt, or TinkerGraph,
+ * owns atomicity through a synchronous transaction API but still exposes a suspend DSL.
+ * Callers should use [asSuspendTransactionScope] instead of constructing this type directly.
  */
 class BlockingGraphSuspendTransactionScope(
     private val delegate: GraphTransactionScope,
@@ -83,28 +83,28 @@ class BlockingGraphSuspendTransactionScope(
 }
 
 /**
- * 동기 트랜잭션 범위를 코루틴 트랜잭션 범위로 변환한다.
+ * Converts a synchronous transaction scope into a coroutine transaction scope.
  */
 fun GraphTransactionScope.asSuspendTransactionScope(): GraphSuspendTransactionScope =
     BlockingGraphSuspendTransactionScope(this)
 
 /**
- * 코루틴 트랜잭션을 실제로 지원하는 [GraphSuspendOperations] 구현체가 구현하는 capability interface.
+ * Capability interface implemented by [GraphSuspendOperations] implementations with real coroutine transactions.
  */
 interface GraphSuspendTransactionalOperations {
     /**
-     * [block]을 하나의 백엔드 트랜잭션으로 실행한다.
+     * Runs [block] as one backend transaction.
      *
-     * 구현체는 성공 시 commit, 실패 시 rollback 후 원래 예외를 다시 던져야 한다.
+     * Implementations must commit on success, roll back on failure, and rethrow the original exception.
      */
     suspend fun <T> suspendTransaction(block: suspend GraphSuspendTransactionScope.() -> T): T
 }
 
 /**
- * [GraphSuspendOperations]에서 코루틴 트랜잭션 DSL을 실행한다.
+ * Executes the coroutine transaction DSL on [GraphSuspendOperations].
  *
- * 구현체가 [GraphSuspendTransactionalOperations]를 구현하지 않으면 auto-commit fallback을 사용하지 않고
- * 명시적으로 [UnsupportedOperationException]을 던진다.
+ * If the implementation does not implement [GraphSuspendTransactionalOperations], this function
+ * explicitly throws [UnsupportedOperationException] instead of using an auto-commit fallback.
  */
 suspend fun <T> GraphSuspendOperations.suspendTransaction(
     block: suspend GraphSuspendTransactionScope.() -> T,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendTraversalRepository.kt
@@ -8,9 +8,9 @@ import io.bluetape4k.graph.model.PathOptions
 import kotlinx.coroutines.flow.Flow
 
 /**
- * 그래프 순회(Traversal) 저장소 (코루틴 방식).
+ * Coroutine graph traversal repository.
  *
- * 컬렉션 반환은 [Flow]로 제공하여 대량 데이터 스트리밍을 지원한다.
+ * Collection-returning operations expose [Flow] so large result sets can stream.
  *
  * ```kotlin
  * runBlocking {
@@ -20,22 +20,22 @@ import kotlinx.coroutines.flow.Flow
  * }
  * ```
  *
- * @see GraphTraversalRepository 동기(blocking) 방식
+ * @see GraphTraversalRepository synchronous blocking variant
  */
 interface GraphSuspendTraversalRepository {
     /**
-     * 시작 정점의 인접 정점(이웃)을 Flow로 탐색한다.
+     * Finds adjacent neighbor vertices from the start vertex as a [Flow].
      *
-     * [NeighborOptions.direction]에 따라 나가는 방향, 들어오는 방향, 또는 양방향으로 탐색한다.
-     * 대량 결과 스트리밍에 적합하다.
+     * [NeighborOptions.direction] selects outgoing, incoming, or bidirectional traversal.
+     * This method is suitable for streaming large result sets.
      *
      * ```kotlin
      * val friends = ops.neighbors(alice.id, NeighborOptions(edgeLabel = "KNOWS")).toList()
      * ```
      *
-     * @param startId 탐색을 시작할 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 방향, 최대 깊이).
-     * @return 인접 [GraphVertex] Flow.
+     * @param startId vertex ID to start traversal from.
+     * @param options traversal options for label filtering, direction, and maximum depth.
+     * @return [Flow] of adjacent [GraphVertex] values.
      */
     fun neighbors(
         startId: GraphElementId,
@@ -43,20 +43,20 @@ interface GraphSuspendTraversalRepository {
     ): Flow<GraphVertex>
 
     /**
-     * 두 정점 사이의 최단 경로를 찾는다.
+     * Finds the shortest path between two vertices.
      *
-     * [PathOptions.maxDepth]까지만 탐색한다.
-     * 경로가 없거나 최대 깊이를 초과하면 `null`을 반환한다.
+     * Traversal is limited by [PathOptions.maxDepth]. Returns `null` when no path exists
+     * or the shortest path exceeds the maximum depth.
      *
      * ```kotlin
      * val path = ops.shortestPath(alice.id, carol.id, PathOptions(edgeLabel = "KNOWS", maxDepth = 10))
      * println(path?.length)  // 2
      * ```
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 최대 깊이).
-     * @return 최단 [GraphPath], 경로가 없으면 `null`.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options for label filtering and maximum depth.
+     * @return shortest [GraphPath], or `null` when no path exists.
      */
     suspend fun shortestPath(
         fromId: GraphElementId,
@@ -65,18 +65,18 @@ interface GraphSuspendTraversalRepository {
     ): GraphPath?
 
     /**
-     * 두 정점 사이의 모든 경로를 Flow로 탐색한다.
+     * Finds all paths between two vertices as a [Flow].
      *
-     * [PathOptions.maxDepth]까지의 모든 단순 경로를 스트리밍한다.
+     * Streams all simple paths up to [PathOptions.maxDepth].
      *
      * ```kotlin
      * val paths = ops.allPaths(alice.id, carol.id, PathOptions(maxDepth = 5)).toList()
      * ```
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 최대 깊이).
-     * @return [GraphPath] Flow.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options for label filtering and maximum depth.
+     * @return [Flow] of [GraphPath] values.
      */
     fun allPaths(
         fromId: GraphElementId,
@@ -85,10 +85,10 @@ interface GraphSuspendTraversalRepository {
     ): Flow<GraphPath>
 
     /**
-     * A* 알고리즘으로 가중치 최단 경로를 찾는다 (코루틴 방식).
+     * Finds a weighted shortest path with the A* algorithm.
      *
-     * `options.weightProperty`가 반드시 설정되어야 한다.
-     * [heuristic]은 동기 함수여야 한다 (`suspend` 함수 불가).
+     * `options.weightProperty` must be set. [heuristic] must be a synchronous
+     * function; suspend heuristics are not supported.
      *
      * ```kotlin
      * val path = ops.aStarPath(a.id, b.id, PathOptions(weightProperty = "cost")) { vertex ->
@@ -96,11 +96,11 @@ interface GraphSuspendTraversalRepository {
      * }
      * ```
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 ([PathOptions.weightProperty] 필수).
-     * @param heuristic 목표까지의 예상 비용 함수. 허용 가능(admissible)해야 한다.
-     * @return 가중치 최단 [GraphPath], 경로가 없으면 `null`.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options; [PathOptions.weightProperty] is required.
+     * @param heuristic admissible estimated cost function to the target.
+     * @return weighted shortest [GraphPath], or `null` when no path exists.
      */
     suspend fun aStarPath(
         fromId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphSuspendVertexRepository.kt
@@ -5,9 +5,9 @@ import io.bluetape4k.graph.model.GraphVertex
 import kotlinx.coroutines.flow.Flow
 
 /**
- * 그래프 정점(Vertex) CRUD 저장소 (코루틴 방식).
+ * Coroutine graph vertex CRUD repository.
  *
- * 컬렉션 반환은 [Flow]로 제공하여 대량 데이터 스트리밍을 지원한다.
+ * Collection-returning operations expose [Flow] so large result sets can stream.
  *
  * ```kotlin
  * runBlocking {
@@ -19,35 +19,35 @@ import kotlinx.coroutines.flow.Flow
  * }
  * ```
  *
- * @see GraphVertexRepository 동기(blocking) 방식
+ * @see GraphVertexRepository synchronous blocking variant
  */
 interface GraphSuspendVertexRepository {
     /**
-     * 새 정점을 생성하고 반환한다.
+     * Creates and returns a new vertex.
      *
      * ```kotlin
      * val vertex = ops.createVertex("Person", mapOf("name" to "Alice", "age" to 30))
      * ```
      *
-     * @param label 정점 레이블.
-     * @param properties 정점에 저장할 속성 맵. 기본값은 빈 맵.
-     * @return 백엔드에서 생성된 [GraphVertex] (ID가 채워진 상태).
+     * @param label vertex label.
+     * @param properties properties to store on the vertex; defaults to an empty map.
+     * @return backend-created [GraphVertex] with its ID populated.
      */
     suspend fun createVertex(label: String, properties: Map<String, Any?> = emptyMap()): GraphVertex
 
     /**
-     * 같은 레이블의 정점을 여러 개 생성하고 입력 순서와 같은 순서로 반환한다.
+     * Creates multiple vertices with the same label and returns them in input order.
      *
-     * ## 동작/계약
+     * ## Contract
      *
-     * - 빈 입력은 백엔드를 호출하지 않고 `emptyList()`를 반환한다.
-     * - 기본 구현은 [createVertex]를 순차 호출하는 호환성 fallback이다.
-     * - 기본 구현은 중간 실패 시 앞서 생성된 정점이 남을 수 있다.
-     * - 성능 및 all-or-fail 의미가 필요한 프로덕션 백엔드는 이 메서드를 override해야 한다.
+     * - Empty input returns `emptyList()` without calling the backend.
+     * - The default implementation is a compatibility fallback that calls [createVertex] sequentially.
+     * - If the default implementation fails mid-batch, previously created vertices may remain.
+     * - Production backends that need performance or all-or-fail semantics should override this method.
      *
-     * @param label 정점 레이블.
-     * @param propertiesList 각 정점에 저장할 속성 맵 목록.
-     * @return 백엔드에서 생성된 [GraphVertex] 목록.
+     * @param label vertex label.
+     * @param propertiesList property maps to store on each vertex.
+     * @return backend-created [GraphVertex] values.
      */
     suspend fun createVertices(
         label: String,
@@ -59,43 +59,43 @@ interface GraphSuspendVertexRepository {
     }
 
     /**
-     * ID로 단일 정점을 조회한다.
+     * Finds one vertex by label and ID.
      *
      * ```kotlin
      * val found = ops.findVertexById("Person", vertex.id)  // non-null
      * ```
      *
-     * @param label 정점 레이블.
-     * @param id 조회할 정점 ID.
-     * @return 존재하면 [GraphVertex], 없으면 `null`.
+     * @param label vertex label.
+     * @param id vertex ID to query.
+     * @return [GraphVertex] when found, otherwise `null`.
      */
     suspend fun findVertexById(label: String, id: GraphElementId): GraphVertex?
 
     /**
-     * 레이블 없이 ID로 단일 정점을 조회한다.
+     * Finds one vertex by ID without a label.
      *
      * ```kotlin
      * val found = ops.findVertexById(vertex.id)
      * ```
      *
-     * @param id 조회할 정점 ID.
-     * @return 존재하면 [GraphVertex], 없으면 `null`.
+     * @param id vertex ID to query.
+     * @return [GraphVertex] when found, otherwise `null`.
      */
     suspend fun findVertexById(id: GraphElementId): GraphVertex?
 
     /**
-     * 레이블과 속성 필터로 정점 목록을 스트림으로 조회한다.
+     * Finds vertices by label and property filter as a stream.
      *
-     * 대량 데이터에 적합한 [Flow] 기반 조회이다.
+     * This [Flow]-based query is suitable for large result sets.
      *
      * ```kotlin
      * val all  = ops.findVerticesByLabel("Person").toList()
      * val aged = ops.findVerticesByLabel("Person", mapOf("age" to 30)).toList()
      * ```
      *
-     * @param label 조회할 정점 레이블.
-     * @param filter 속성 이름→값 조건 맵. 빈 맵이면 레이블 전체를 반환.
-     * @return 조건에 맞는 [GraphVertex] Flow.
+     * @param label vertex label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @return [Flow] of matching [GraphVertex] values.
      */
     fun findVerticesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): Flow<GraphVertex>
 
@@ -124,41 +124,41 @@ interface GraphSuspendVertexRepository {
         findVerticesByLabel(label, filter).asGraphExportChunks(chunkSize)
 
     /**
-     * 기존 정점의 속성을 갱신하고 갱신된 정점을 반환한다.
+     * Updates an existing vertex and returns the updated vertex.
      *
      * ```kotlin
      * val updated = ops.updateVertex("Person", vertex.id, mapOf("age" to 31))
      * ```
      *
-     * @param label 정점 레이블.
-     * @param id 갱신할 정점 ID.
-     * @param properties 새 속성 맵 (기존 속성을 대체한다).
-     * @return 갱신된 [GraphVertex], 해당 ID가 없으면 `null`.
+     * @param label vertex label.
+     * @param id vertex ID to update.
+     * @param properties new property map, replacing existing properties.
+     * @return updated [GraphVertex], or `null` when the ID is absent.
      */
     suspend fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex?
 
     /**
-     * 정점을 삭제한다.
+     * Deletes a vertex.
      *
      * ```kotlin
      * val deleted = ops.deleteVertex("Person", vertex.id)  // true
      * ```
      *
-     * @param label 정점 레이블.
-     * @param id 삭제할 정점 ID.
-     * @return 삭제 성공이면 `true`, 해당 ID가 없으면 `false`.
+     * @param label vertex label.
+     * @param id vertex ID to delete.
+     * @return `true` when deleted, or `false` when the ID is absent.
      */
     suspend fun deleteVertex(label: String, id: GraphElementId): Boolean
 
     /**
-     * 레이블로 정점 수를 반환한다.
+     * Counts vertices by label.
      *
      * ```kotlin
      * val count = ops.countVertices("Person")  // 1L
      * ```
      *
-     * @param label 카운트할 정점 레이블.
-     * @return 해당 레이블의 정점 총 수.
+     * @param label vertex label to count.
+     * @return total vertex count for the label.
      */
     suspend fun countVertices(label: String): Long
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTransactionScope.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTransactionScope.kt
@@ -1,16 +1,17 @@
 package io.bluetape4k.graph.repository
 
 /**
- * 그래프 트랜잭션 DSL 수신 객체를 구분하는 마커.
+ * Marker for graph transaction DSL receivers.
  *
- * 트랜잭션 블록 안에서는 정점/간선 CRUD만 노출한다. 그래프 생성/삭제 같은
- * session lifecycle 명령은 백엔드별 DDL/auto-commit 의미가 달라 DSL 범위에서 제외한다.
+ * Transaction blocks expose only vertex and edge CRUD. Session lifecycle commands,
+ * such as graph creation or deletion, stay outside the DSL because DDL and auto-commit
+ * semantics differ by backend.
  */
 @DslMarker
 annotation class GraphTransactionDsl
 
 /**
- * 동기 그래프 트랜잭션 블록에서 사용할 수 있는 연산 범위.
+ * Operation scope available inside a synchronous graph transaction block.
  *
  * ```kotlin
  * val edge = ops.transaction {
@@ -20,7 +21,7 @@ annotation class GraphTransactionDsl
  * }
  * ```
  *
- * 블록이 정상 종료되면 백엔드는 변경을 커밋하고, 예외가 발생하면 롤백해야 한다.
+ * Backends must commit when the block completes normally and roll back when it throws.
  */
 @GraphTransactionDsl
 interface GraphTransactionScope :
@@ -28,25 +29,26 @@ interface GraphTransactionScope :
     GraphEdgeRepository
 
 /**
- * 동기 트랜잭션을 실제로 지원하는 [GraphOperations] 구현체가 구현하는 capability interface.
+ * Capability interface implemented by [GraphOperations] implementations with real synchronous transactions.
  *
- * [GraphOperations] 자체에 멤버를 추가하지 않아 기존 구현체와 테스트 fake의 source compatibility를 유지한다.
+ * This keeps source compatibility for existing implementations and test fakes by
+ * avoiding new members on [GraphOperations].
  */
 interface GraphTransactionalOperations {
     /**
-     * [block]을 하나의 백엔드 트랜잭션으로 실행한다.
+     * Runs [block] as one backend transaction.
      *
-     * 구현체는 성공 시 commit, 실패 시 rollback 후 원래 예외를 다시 던져야 한다.
+     * Implementations must commit on success, roll back on failure, and rethrow the original exception.
      */
     fun <T> transaction(block: GraphTransactionScope.() -> T): T
 }
 
 /**
- * [GraphOperations]에서 동기 트랜잭션 DSL을 실행한다.
+ * Executes the synchronous transaction DSL on [GraphOperations].
  *
- * 구현체가 [GraphTransactionalOperations]를 구현하지 않으면 auto-commit fallback을 사용하지 않고
- * 명시적으로 [UnsupportedOperationException]을 던진다. 조용한 fallback은 호출자가 원자성을
- * 보장받는다고 착각하게 만들 수 있기 때문이다.
+ * If the implementation does not implement [GraphTransactionalOperations], this function
+ * explicitly throws [UnsupportedOperationException] instead of using an auto-commit fallback.
+ * A silent fallback would make callers believe atomicity is guaranteed.
  */
 fun <T> GraphOperations.transaction(block: GraphTransactionScope.() -> T): T {
     val transactional = this as? GraphTransactionalOperations

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphTraversalRepository.kt
@@ -7,34 +7,34 @@ import io.bluetape4k.graph.model.NeighborOptions
 import io.bluetape4k.graph.model.PathOptions
 
 /**
- * 그래프 순회(Traversal) 저장소 (동기 방식).
+ * Synchronous graph traversal repository.
  *
  * ```kotlin
- * // 1단계 아웃고잉 이웃 탐색
+ * // One-hop outgoing neighbor traversal.
  * val friends = ops.neighbors(alice.id, NeighborOptions(edgeLabel = "KNOWS"))
  *
- * // 최단 경로 (최대 10홉)
+ * // Shortest path with at most 10 hops.
  * val path = ops.shortestPath(alice.id, carol.id, PathOptions(edgeLabel = "KNOWS", maxDepth = 10))
  *
- * // 모든 경로
+ * // All paths.
  * val paths = ops.allPaths(alice.id, carol.id, PathOptions(maxDepth = 5))
  * ```
  */
 interface GraphTraversalRepository {
     /**
-     * 시작 정점의 인접 정점(이웃)을 탐색한다.
-     *
-     * [NeighborOptions.direction]에 따라 나가는 방향, 들어오는 방향, 또는 양방향으로 탐색한다.
-     * [NeighborOptions.maxDepth]가 2 이상이면 다단계 이웃까지 탐색한다.
+     * Finds adjacent neighbor vertices from the start vertex.
+	*
+     * [NeighborOptions.direction] selects outgoing, incoming, or bidirectional traversal.
+     * [NeighborOptions.maxDepth] values of 2 or more include multi-hop neighbors.
      *
      * ```kotlin
      * val friends = ops.neighbors(alice.id, NeighborOptions(edgeLabel = "KNOWS"))
      * val all3hop = ops.neighbors(alice.id, NeighborOptions(maxDepth = 3))
      * ```
      *
-     * @param startId 탐색을 시작할 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 방향, 최대 깊이).
-     * @return 인접 [GraphVertex] 목록.
+     * @param startId vertex ID to start traversal from.
+     * @param options traversal options for label filtering, direction, and maximum depth.
+     * @return adjacent [GraphVertex] values.
      */
     fun neighbors(
         startId: GraphElementId,
@@ -42,20 +42,20 @@ interface GraphTraversalRepository {
     ): List<GraphVertex>
 
     /**
-     * 두 정점 사이의 최단 경로를 찾는다.
-     *
-     * [PathOptions.maxDepth]까지만 탐색한다.
-     * 경로가 없거나 최대 깊이를 초과하면 `null`을 반환한다.
+     * Finds the shortest path between two vertices.
+	*
+     * Traversal is limited by [PathOptions.maxDepth]. Returns `null` when no path exists
+     * or the shortest path exceeds the maximum depth.
      *
      * ```kotlin
      * val path = ops.shortestPath(alice.id, carol.id, PathOptions(edgeLabel = "KNOWS", maxDepth = 10))
      * println(path?.length)  // 2 (alice→bob→carol)
      * ```
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 최대 깊이).
-     * @return 최단 [GraphPath], 경로가 없으면 `null`.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options for label filtering and maximum depth.
+     * @return shortest [GraphPath], or `null` when no path exists.
      */
     fun shortestPath(
         fromId: GraphElementId,
@@ -64,20 +64,19 @@ interface GraphTraversalRepository {
     ): GraphPath?
 
     /**
-     * 두 정점 사이의 모든 경로를 찾는다.
-     *
-     * [PathOptions.maxDepth]까지의 모든 단순 경로를 반환한다.
-     * 경로가 없으면 빈 목록을 반환한다.
+     * Finds all paths between two vertices.
+	*
+     * Returns all simple paths up to [PathOptions.maxDepth], or an empty list when no paths exist.
      *
      * ```kotlin
      * val paths = ops.allPaths(alice.id, carol.id, PathOptions(maxDepth = 5))
-     * println(paths.size)  // 경로 수
+     * println(paths.size)  // path count
      * ```
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 최대 깊이).
-     * @return [GraphPath] 목록.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options for label filtering and maximum depth.
+     * @return [GraphPath] values.
      */
     fun allPaths(
         fromId: GraphElementId,
@@ -86,25 +85,24 @@ interface GraphTraversalRepository {
     ): List<GraphPath>
 
     /**
-     * A* 알고리즘으로 가중치 최단 경로를 찾는다.
-     *
-     * `options.weightProperty`가 반드시 설정되어야 한다.
-     * [heuristic]은 목표 정점까지의 예상 비용을 반환하는 비허용 불가(admissible) 함수여야 한다.
-     * 동기 함수만 허용하며 `suspend` 함수는 지원하지 않는다.
+     * Finds a weighted shortest path with the A* algorithm.
+	*
+     * `options.weightProperty` must be set. [heuristic] must be an admissible synchronous
+     * function that estimates cost to the target vertex; suspend heuristics are not supported.
      *
      * ```kotlin
      * val opts = PathOptions(weightProperty = "distance", direction = Direction.OUTGOING)
      * val path = ops.aStarPath(a.id, b.id, opts) { vertex ->
-     *     // 유클리드 거리 등 허용 가능한 휴리스틱
+     *     // Admissible heuristic such as Euclidean distance.
      *     euclidean(vertex, goal)
      * }
      * ```
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 ([PathOptions.weightProperty] 필수).
-     * @param heuristic 목표까지의 예상 비용 함수. 허용 가능(admissible)해야 한다.
-     * @return 가중치 최단 [GraphPath], 경로가 없으면 `null`.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options; [PathOptions.weightProperty] is required.
+     * @param heuristic admissible estimated cost function to the target.
+     * @return weighted shortest [GraphPath], or `null` when no path exists.
      */
     fun aStarPath(
         fromId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVertexRepository.kt
@@ -4,7 +4,7 @@ import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.GraphVertex
 
 /**
- * 그래프 정점(Vertex) CRUD 저장소 (동기 방식).
+ * Synchronous graph vertex CRUD repository.
  *
  * ```kotlin
  * val vertex = ops.createVertex("Person", mapOf("name" to "Alice", "age" to 30))
@@ -17,7 +17,7 @@ import io.bluetape4k.graph.model.GraphVertex
  */
 interface GraphVertexRepository {
     /**
-     * 새 정점을 생성하고 반환한다.
+     * Creates and returns a new vertex.
      *
      * ```kotlin
      * val vertex = ops.createVertex("Person", mapOf("name" to "Alice", "age" to 30))
@@ -25,21 +25,21 @@ interface GraphVertexRepository {
      * println(vertex.label) // "Person"
      * ```
      *
-     * @param label 정점 레이블.
-     * @param properties 정점에 저장할 속성 맵. 기본값은 빈 맵.
-     * @return 백엔드에서 생성된 [GraphVertex] (ID가 채워진 상태).
+     * @param label vertex label.
+     * @param properties properties to store on the vertex; defaults to an empty map.
+     * @return backend-created [GraphVertex] with its ID populated.
      */
     fun createVertex(label: String, properties: Map<String, Any?> = emptyMap()): GraphVertex
 
     /**
-     * 같은 레이블의 정점을 여러 개 생성하고 입력 순서와 같은 순서로 반환한다.
-     *
-     * ## 동작/계약
-     *
-     * - 빈 입력은 백엔드를 호출하지 않고 `emptyList()`를 반환한다.
-     * - 기본 구현은 [createVertex]를 순차 호출하는 호환성 fallback이다.
-     * - 기본 구현은 중간 실패 시 앞서 생성된 정점이 남을 수 있다.
-     * - 성능 및 all-or-fail 의미가 필요한 프로덕션 백엔드는 이 메서드를 override해야 한다.
+     * Creates multiple vertices with the same label and returns them in input order.
+	*
+     * ## Contract
+	*
+     * - Empty input returns `emptyList()` without calling the backend.
+     * - The default implementation is a compatibility fallback that calls [createVertex] sequentially.
+     * - If the default implementation fails mid-batch, previously created vertices may remain.
+     * - Production backends that need performance or all-or-fail semantics should override this method.
      *
      * ```kotlin
      * val vertices = ops.createVertices(
@@ -51,9 +51,9 @@ interface GraphVertexRepository {
      * )
      * ```
      *
-     * @param label 정점 레이블.
-     * @param propertiesList 각 정점에 저장할 속성 맵 목록.
-     * @return 백엔드에서 생성된 [GraphVertex] 목록.
+     * @param label vertex label.
+     * @param propertiesList property maps to store on each vertex.
+     * @return backend-created [GraphVertex] values.
      */
     fun createVertices(
         label: String,
@@ -65,45 +65,45 @@ interface GraphVertexRepository {
     }
 
     /**
-     * ID로 단일 정점을 조회한다.
+     * Finds one vertex by label and ID.
      *
      * ```kotlin
      * val found = ops.findVertexById("Person", vertex.id)  // non-null
      * val none  = ops.findVertexById("Person", GraphElementId.of("unknown"))  // null
      * ```
      *
-     * @param label 정점 레이블.
-     * @param id 조회할 정점 ID.
-     * @return 존재하면 [GraphVertex], 없으면 `null`.
+     * @param label vertex label.
+     * @param id vertex ID to query.
+     * @return [GraphVertex] when found, otherwise `null`.
      */
     fun findVertexById(label: String, id: GraphElementId): GraphVertex?
 
     /**
-     * 레이블 없이 ID로 단일 정점을 조회한다.
-     *
-     * 백엔드가 ID로만 정점을 조회할 수 있는 경우에 사용한다.
-     * Dijkstra/A* 알고리즘에서 레이블 없이 ID만 알고 있을 때 필요하다.
+     * Finds one vertex by ID without a label.
+	*
+     * Use this when the backend can query vertices by ID alone. Dijkstra/A* algorithms need it
+     * when only the vertex ID is known.
      *
      * ```kotlin
-     * val found = ops.findVertexById(vertex.id)  // 레이블 불필요
+     * val found = ops.findVertexById(vertex.id)  // label not required
      * ```
      *
-     * @param id 조회할 정점 ID.
-     * @return 존재하면 [GraphVertex], 없으면 `null`.
+     * @param id vertex ID to query.
+     * @return [GraphVertex] when found, otherwise `null`.
      */
     fun findVertexById(id: GraphElementId): GraphVertex?
 
     /**
-     * 레이블과 속성 필터로 정점 목록을 조회한다.
+     * Finds vertices by label and property filter.
      *
      * ```kotlin
      * val all   = ops.findVerticesByLabel("Person")
      * val aged  = ops.findVerticesByLabel("Person", mapOf("age" to 30))
      * ```
      *
-     * @param label 조회할 정점 레이블.
-     * @param filter 속성 이름→값 조건 맵. 빈 맵이면 레이블 전체를 반환.
-     * @return 조건에 맞는 [GraphVertex] 목록.
+     * @param label vertex label to query.
+     * @param filter property-name to value conditions. An empty map returns the full label.
+     * @return matching [GraphVertex] values.
      */
     fun findVerticesByLabel(label: String, filter: Map<String, Any?> = emptyMap()): List<GraphVertex>
 
@@ -135,41 +135,41 @@ interface GraphVertexRepository {
         findVerticesByLabel(label, filter).asGraphExportChunks(chunkSize)
 
     /**
-     * 기존 정점의 속성을 갱신하고 갱신된 정점을 반환한다.
+     * Updates an existing vertex and returns the updated vertex.
      *
      * ```kotlin
      * val updated = ops.updateVertex("Person", vertex.id, mapOf("age" to 31))
      * ```
      *
-     * @param label 정점 레이블.
-     * @param id 갱신할 정점 ID.
-     * @param properties 새 속성 맵 (기존 속성을 대체한다).
-     * @return 갱신된 [GraphVertex], 해당 ID가 없으면 `null`.
+     * @param label vertex label.
+     * @param id vertex ID to update.
+     * @param properties new property map, replacing existing properties.
+     * @return updated [GraphVertex], or `null` when the ID is absent.
      */
     fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex?
 
     /**
-     * 정점을 삭제한다.
+     * Deletes a vertex.
      *
      * ```kotlin
      * val deleted = ops.deleteVertex("Person", vertex.id)  // true
      * ```
      *
-     * @param label 정점 레이블.
-     * @param id 삭제할 정점 ID.
-     * @return 삭제 성공이면 `true`, 해당 ID가 없으면 `false`.
+     * @param label vertex label.
+     * @param id vertex ID to delete.
+     * @return `true` when deleted, or `false` when the ID is absent.
      */
     fun deleteVertex(label: String, id: GraphElementId): Boolean
 
     /**
-     * 레이블로 정점 수를 반환한다.
+     * Counts vertices by label.
      *
      * ```kotlin
      * val count = ops.countVertices("Person")  // 1L
      * ```
      *
-     * @param label 카운트할 정점 레이블.
-     * @return 해당 레이블의 정점 총 수.
+     * @param label vertex label to count.
+     * @return total vertex count for the label.
      */
     fun countVertices(label: String): Long
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadAlgorithmRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadAlgorithmRepository.kt
@@ -14,17 +14,17 @@ import io.bluetape4k.graph.model.TraversalVisit
 import java.util.concurrent.CompletableFuture
 
 /**
- * Virtual Thread 기반 그래프 분석 알고리즘 저장소.
+ * Graph analytics algorithm repository for the Virtual Thread API.
  *
- * Java 25 Project Loom 의 Virtual Thread 위에서 동기 [GraphAlgorithmRepository] 를 실행해
- * `CompletableFuture<T>` 로 결과를 반환한다. Java 코드 또는 CompletableFuture 기반 파이프라인과의
- * 상호운용을 위해 제공된다.
+ * Runs the blocking [GraphAlgorithmRepository] on Java 25 Project Loom Virtual Threads
+ * and returns results as `CompletableFuture<T>`. This API is intended for Java code
+ * and CompletableFuture-based pipelines.
  *
- * Kotlin 코드에서는 [GraphSuspendAlgorithmRepository] 사용을 권장한다.
+ * Kotlin code should prefer [GraphSuspendAlgorithmRepository].
  *
- * 결과 순서 계약: [GraphAlgorithmRepository] 와 동일.
+ * Result ordering contract: same as [GraphAlgorithmRepository].
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val ops: GraphOperations = TinkerGraphOperations()
  * val vtOps = ops.asVirtualThread()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadEdgeRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadEdgeRepository.kt
@@ -6,10 +6,10 @@ import io.bluetape4k.graph.model.GraphElementId
 import java.util.concurrent.CompletableFuture
 
 /**
- * Virtual Thread 기반 그래프 간선(Edge) CRUD 저장소.
+ * Virtual-thread graph edge CRUD repository.
  *
- * 모든 메서드는 동기 [GraphEdgeRepository] 를 Virtual Thread 위에서 실행한
- * 결과를 `CompletableFuture<T>` 로 반환한다. Java interop 목적이다.
+ * Every method runs the synchronous [GraphEdgeRepository] on a virtual thread and
+ * returns the result as `CompletableFuture<T>` for Java interop.
  */
 interface GraphVirtualThreadEdgeRepository {
 

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadOperations.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadOperations.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.graph.repository
 
 /**
- * Virtual Thread 기반 그래프 통합 Facade.
+ * Unified graph facade for the Virtual Thread API.
  *
- * 비동기 Virtual Thread API(`*Async` 메서드)를 하나의 인터페이스로 제공한다.
- * 동기 블로킹 메서드([GraphSession])는 포함하지 않는다. 세션 lifecycle은 [close]로 관리한다.
+ * Provides the asynchronous Virtual Thread API (`*Async` methods) as one interface.
+ * It does not include blocking [GraphSession] methods. Manage the session lifecycle with [close].
  *
  * ```kotlin
  * val vtOps: GraphVirtualThreadOperations = ops.asVirtualThread()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadSession.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadSession.kt
@@ -3,10 +3,10 @@ package io.bluetape4k.graph.repository
 import java.util.concurrent.CompletableFuture
 
 /**
- * Virtual Thread 기반 그래프 세션 관리.
+ * Manages graph sessions with Virtual Threads.
  *
- * 모든 메서드는 `CompletableFuture<T>` 를 반환하며,
- * 동기 [GraphSession] 을 Virtual Thread 위에서 실행한 결과를 담는다.
+ * Each method returns a `CompletableFuture<T>` containing the result of running
+ * the blocking [GraphSession] operation on a Virtual Thread.
  */
 interface GraphVirtualThreadSession {
     fun createGraphAsync(name: String): CompletableFuture<Unit>

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadTraversalRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadTraversalRepository.kt
@@ -8,15 +8,15 @@ import io.bluetape4k.graph.model.PathOptions
 import java.util.concurrent.CompletableFuture
 
 /**
- * Virtual Thread 기반 그래프 순회(Traversal) 저장소.
+ * Virtual-thread graph traversal repository.
  *
- * Java 25 Project Loom 의 Virtual Thread 위에서 동기 [GraphTraversalRepository] 를 실행해
- * `CompletableFuture<T>` 로 결과를 반환한다. Java 코드 또는 CompletableFuture 기반 파이프라인과의
- * 상호운용을 위해 제공된다.
+ * Runs the synchronous [GraphTraversalRepository] on Java 25 Project Loom virtual threads
+ * and returns results as `CompletableFuture<T>`. This supports interop with Java code
+ * and CompletableFuture-based pipelines.
  *
- * Kotlin 코드에서는 [GraphSuspendTraversalRepository] 사용을 권장한다.
+ * Kotlin code should prefer [GraphSuspendTraversalRepository].
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val ops: GraphOperations = TinkerGraphOperations()
  * val vtOps = ops.asVirtualThreadTraversal()
@@ -27,11 +27,11 @@ import java.util.concurrent.CompletableFuture
 interface GraphVirtualThreadTraversalRepository {
 
     /**
-     * 시작 정점의 인접 정점(이웃)을 Virtual Thread 에서 탐색한다.
+     * Finds adjacent neighbor vertices from the start vertex on a virtual thread.
      *
-     * @param startId 탐색을 시작할 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 방향, 최대 깊이).
-     * @return 인접 [GraphVertex] 목록을 담은 [CompletableFuture].
+     * @param startId vertex ID to start traversal from.
+     * @param options traversal options for label filtering, direction, and maximum depth.
+     * @return [CompletableFuture] containing adjacent [GraphVertex] values.
      */
     fun neighborsAsync(
         startId: GraphElementId,
@@ -39,12 +39,12 @@ interface GraphVirtualThreadTraversalRepository {
     ): CompletableFuture<List<GraphVertex>>
 
     /**
-     * 두 정점 사이의 최단 경로를 Virtual Thread 에서 찾는다.
+     * Finds the shortest path between two vertices on a virtual thread.
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 최대 깊이).
-     * @return 최단 [GraphPath] 를 담은 [CompletableFuture]. 경로가 없으면 `null`.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options for label filtering and maximum depth.
+     * @return [CompletableFuture] containing the shortest [GraphPath], or `null` when no path exists.
      */
     fun shortestPathAsync(
         fromId: GraphElementId,
@@ -53,12 +53,12 @@ interface GraphVirtualThreadTraversalRepository {
     ): CompletableFuture<GraphPath?>
 
     /**
-     * 두 정점 사이의 모든 경로를 Virtual Thread 에서 찾는다.
+     * Finds all paths between two vertices on a virtual thread.
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 (레이블 필터, 최대 깊이).
-     * @return [GraphPath] 목록을 담은 [CompletableFuture].
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options for label filtering and maximum depth.
+     * @return [CompletableFuture] containing [GraphPath] values.
      */
     fun allPathsAsync(
         fromId: GraphElementId,
@@ -67,13 +67,13 @@ interface GraphVirtualThreadTraversalRepository {
     ): CompletableFuture<List<GraphPath>>
 
     /**
-     * A* 알고리즘으로 가중치 최단 경로를 Virtual Thread 에서 찾는다.
+     * Finds a weighted shortest path with the A* algorithm on a virtual thread.
      *
-     * @param fromId 출발 정점 ID.
-     * @param toId 도착 정점 ID.
-     * @param options 탐색 옵션 ([PathOptions.weightProperty] 필수).
-     * @param heuristic 목표까지의 예상 비용 함수 (동기).
-     * @return 가중치 최단 [GraphPath] 를 담은 [CompletableFuture]. 경로가 없으면 `null`.
+     * @param fromId source vertex ID.
+     * @param toId target vertex ID.
+     * @param options traversal options; [PathOptions.weightProperty] is required.
+     * @param heuristic synchronous estimated cost function to the target.
+     * @return [CompletableFuture] containing the weighted shortest [GraphPath], or `null` when no path exists.
      */
     fun aStarPathAsync(
         fromId: GraphElementId,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadVertexRepository.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/repository/GraphVirtualThreadVertexRepository.kt
@@ -5,10 +5,10 @@ import io.bluetape4k.graph.model.GraphVertex
 import java.util.concurrent.CompletableFuture
 
 /**
- * Virtual Thread 기반 그래프 정점(Vertex) CRUD 저장소.
+ * Virtual-thread graph vertex CRUD repository.
  *
- * 모든 메서드는 동기 [GraphVertexRepository] 를 Virtual Thread 위에서 실행한
- * 결과를 `CompletableFuture<T>` 로 반환한다. Java interop 및 CompletableFuture 파이프라인용이다.
+ * Every method runs the synchronous [GraphVertexRepository] on a virtual thread and
+ * returns the result as `CompletableFuture<T>` for Java interop and CompletableFuture pipelines.
  */
 interface GraphVirtualThreadVertexRepository {
 

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/EdgeLabel.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/EdgeLabel.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.graph.schema
 
 /**
- * 그래프 간선(Edge) 스키마 정의.
+ * Graph edge schema definition.
  *
- * [VertexLabel]과 동일한 DSL 스타일로 간선 타입의 스키마를 선언한다.
- * 시작 정점([from])과 종료 정점([to])의 타입을 명시하여 관계의 방향성과 도메인 제약을 표현한다.
+ * It uses the same DSL style as [VertexLabel]. [from] and [to] declare the edge direction
+ * and domain constraints.
  *
  * ```kotlin
  * object WorksAtLabel : EdgeLabel("WORKS_AT", PersonLabel, CompanyLabel) {
@@ -13,9 +13,9 @@ package io.bluetape4k.graph.schema
  * }
  * ```
  *
- * @property label 간선 레이블 이름 (예: `"KNOWS"`, `"WORKS_AT"`).
- * @property from 간선의 시작 정점 레이블.
- * @property to 간선의 종료 정점 레이블.
+ * @property label edge label name, such as `"KNOWS"` or `"WORKS_AT"`.
+ * @property from start vertex label.
+ * @property to end vertex label.
  */
 abstract class EdgeLabel(
     val label: String,

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/GraphSchemaManager.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/GraphSchemaManager.kt
@@ -10,15 +10,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * 그래프 백엔드의 인덱스와 제약조건을 관리하는 동기 API.
+ * Synchronous API for graph backend indexes and constraints.
  *
- * 구현체는 백엔드 DDL 차이를 숨기되, 지원하지 않는 제약조건을 성공한 것처럼 처리하지 않고
- * 명시적으로 [UnsupportedOperationException]을 던져야 한다.
+ * Implementations hide backend DDL differences, but unsupported constraints must fail explicitly
+ * with [UnsupportedOperationException] rather than pretending to succeed.
  *
- * ## 동작/계약
- * - label과 property는 backend query에 안전한 identifier여야 한다.
- * - 지원하지 않는 schema DDL은 silent no-op 대신 [UnsupportedOperationException]으로 실패해야 한다.
- * - [listIndexes]와 [listConstraints]는 backend metadata를 공통 모델로 변환해 반환한다.
+ * ## Contract
+ * - Labels and properties must be safe backend query identifiers.
+ * - Unsupported schema DDL must fail with [UnsupportedOperationException], not a silent no-op.
+ * - [listIndexes] and [listConstraints] return backend metadata mapped to common model types.
  *
  * ```kotlin
  * import io.bluetape4k.graph.schema.schemaManager
@@ -32,46 +32,46 @@ import kotlinx.coroutines.withContext
 interface GraphSchemaManager {
 
     /**
-     * 지정한 정점 레이블과 속성에 조회 인덱스를 생성한다.
-     *
-     * @param label 정점 레이블.
-     * @param property 인덱싱할 속성 이름.
+     * Creates a lookup index for the given vertex label and property.
+	*
+     * @param label vertex label.
+     * @param property property name to index.
      */
     fun createIndex(label: String, property: String)
 
     /**
-     * 지정한 정점 레이블과 속성에 유니크 제약조건을 생성한다.
-     *
-     * @param label 정점 레이블.
-     * @param property 유일해야 하는 속성 이름.
+     * Creates a unique constraint for the given vertex label and property.
+	*
+     * @param label vertex label.
+     * @param property property name that must be unique.
      */
     fun createUniqueConstraint(label: String, property: String)
 
     /**
-     * 지정한 정점 레이블과 속성에 연결된 조회 인덱스를 제거한다.
-     *
-     * @param label 정점 레이블.
-     * @param property 인덱싱된 속성 이름.
+     * Drops the lookup index for the given vertex label and property.
+	*
+     * @param label vertex label.
+     * @param property indexed property name.
      */
     fun dropIndex(label: String, property: String)
 
     /**
-     * 현재 그래프에 정의된 공통 인덱스 메타데이터를 반환한다.
+     * Returns common index metadata defined in the current graph.
      */
     fun listIndexes(): List<GraphIndex>
 
     /**
-     * 현재 그래프에 정의된 공통 제약조건 메타데이터를 반환한다.
+     * Returns common constraint metadata defined in the current graph.
      */
     fun listConstraints(): List<GraphConstraint>
 }
 
 /**
- * 그래프 백엔드의 인덱스와 제약조건을 관리하는 코루틴 API.
+ * Coroutine API for graph backend indexes and constraints.
  *
- * ## 동작/계약
- * - [GraphSchemaManager]와 같은 schema metadata semantics를 suspend API로 제공한다.
- * - blocking backend adapter는 [BlockingGraphSuspendSchemaManager]를 통해 [Dispatchers.IO]에서 실행한다.
+ * ## Contract
+ * - Provides the same schema metadata semantics as [GraphSchemaManager].
+ * - Blocking backend adapters run through [BlockingGraphSuspendSchemaManager] on [Dispatchers.IO].
  *
  * ```kotlin
  * import io.bluetape4k.graph.schema.schemaManager
@@ -83,24 +83,24 @@ interface GraphSchemaManager {
  */
 interface GraphSuspendSchemaManager {
 
-    /** 지정한 정점 레이블과 속성에 조회 인덱스를 생성한다. */
+    /** Creates a lookup index for the given vertex label and property. */
     suspend fun createIndex(label: String, property: String)
 
-    /** 지정한 정점 레이블과 속성에 유니크 제약조건을 생성한다. */
+    /** Creates a unique constraint for the given vertex label and property. */
     suspend fun createUniqueConstraint(label: String, property: String)
 
-    /** 지정한 정점 레이블과 속성에 연결된 조회 인덱스를 제거한다. */
+    /** Drops the lookup index for the given vertex label and property. */
     suspend fun dropIndex(label: String, property: String)
 
-    /** 현재 그래프에 정의된 공통 인덱스 메타데이터를 반환한다. */
+    /** Returns common index metadata defined in the current graph. */
     suspend fun listIndexes(): List<GraphIndex>
 
-    /** 현재 그래프에 정의된 공통 제약조건 메타데이터를 반환한다. */
+    /** Returns common constraint metadata defined in the current graph. */
     suspend fun listConstraints(): List<GraphConstraint>
 }
 
 /**
- * 동기 그래프 구현체가 스키마 관리 기능을 제공할 때 구현하는 capability interface.
+ * Capability interface for synchronous graph implementations that provide schema management.
  *
  * ```kotlin
  * val schema = ops.schemaManager()
@@ -108,12 +108,12 @@ interface GraphSuspendSchemaManager {
  * ```
  */
 interface GraphSchemaManagementOperations {
-    /** 이 그래프 구현체의 스키마 관리자를 반환한다. */
+    /** Returns the schema manager for this graph implementation. */
     fun schemaManager(): GraphSchemaManager
 }
 
 /**
- * 코루틴 그래프 구현체가 스키마 관리 기능을 제공할 때 구현하는 capability interface.
+ * Capability interface for coroutine graph implementations that provide schema management.
  *
  * ```kotlin
  * val schema = suspendOps.schemaManager()
@@ -121,12 +121,12 @@ interface GraphSchemaManagementOperations {
  * ```
  */
 interface GraphSuspendSchemaManagementOperations {
-    /** 이 그래프 구현체의 코루틴 스키마 관리자를 반환한다. */
+    /** Returns the coroutine schema manager for this graph implementation. */
     fun schemaManager(): GraphSuspendSchemaManager
 }
 
 /**
- * 동기 스키마 관리자를 [Dispatchers.IO]에서 실행하는 코루틴 어댑터.
+ * Coroutine adapter that runs a synchronous schema manager on [Dispatchers.IO].
  *
  * ```kotlin
  * val suspendSchema = ops.schemaManager().asSuspendSchemaManager()
@@ -167,7 +167,7 @@ class BlockingGraphSuspendSchemaManager(
 }
 
 /**
- * 동기 스키마 관리자를 코루틴 API로 노출한다.
+ * Exposes a synchronous schema manager as a coroutine API.
  *
  * ```kotlin
  * val schema = ops.schemaManager().asSuspendSchemaManager()
@@ -177,11 +177,11 @@ fun GraphSchemaManager.asSuspendSchemaManager(): GraphSuspendSchemaManager =
     BlockingGraphSuspendSchemaManager(this)
 
 /**
- * 백엔드가 현재 schema DDL을 안전하게 지원하지 않을 때 사용하는 명시적 실패 관리자.
+ * Explicit-failure manager for backends that cannot safely support schema DDL yet.
  *
- * ## 동작/계약
- * - [listIndexes]와 [listConstraints]는 빈 목록을 반환한다.
- * - mutation API는 identifier validation 후 [UnsupportedOperationException]을 던진다.
+ * ## Contract
+ * - [listIndexes] and [listConstraints] return empty lists.
+ * - Mutation APIs validate identifiers and then throw [UnsupportedOperationException].
  *
  * ```kotlin
  * val schema = UnsupportedGraphSchemaManager("AGE", "portable AGE index DDL is not available")
@@ -217,10 +217,10 @@ class UnsupportedGraphSchemaManager(
 }
 
 /**
- * [GraphOperations]에서 스키마 관리자를 얻는다.
+ * Returns the schema manager for [GraphOperations].
  *
- * 구현체가 [GraphSchemaManagementOperations]를 구현하지 않으면 auto no-op fallback을 사용하지 않고
- * 명시적으로 [UnsupportedOperationException]을 던진다.
+ * If the implementation does not implement [GraphSchemaManagementOperations], this throws
+ * [UnsupportedOperationException] instead of using an automatic no-op fallback.
  *
  * ```kotlin
  * import io.bluetape4k.graph.schema.schemaManager
@@ -238,10 +238,10 @@ fun GraphOperations.schemaManager(): GraphSchemaManager {
 }
 
 /**
- * [GraphSuspendOperations]에서 코루틴 스키마 관리자를 얻는다.
+ * Returns the coroutine schema manager for [GraphSuspendOperations].
  *
- * 구현체가 [GraphSuspendSchemaManagementOperations]를 구현하지 않으면 명시적으로
- * [UnsupportedOperationException]을 던진다.
+ * If the implementation does not implement [GraphSuspendSchemaManagementOperations], this throws
+ * [UnsupportedOperationException].
  *
  * ```kotlin
  * import io.bluetape4k.graph.schema.schemaManager
@@ -258,32 +258,32 @@ fun GraphSuspendOperations.schemaManager(): GraphSuspendSchemaManager {
     return management.schemaManager()
 }
 
-/** [VertexLabel]과 [PropertyDef]로 조회 인덱스를 생성한다. */
+/** Creates a lookup index from [VertexLabel] and [PropertyDef]. */
 fun GraphSchemaManager.createIndex(label: VertexLabel, property: PropertyDef<*>) =
     createIndex(label.label, property.name)
 
-/** [VertexLabel]과 [PropertyDef]로 유니크 제약조건을 생성한다. */
+/** Creates a unique constraint from [VertexLabel] and [PropertyDef]. */
 fun GraphSchemaManager.createUniqueConstraint(label: VertexLabel, property: PropertyDef<*>) =
     createUniqueConstraint(label.label, property.name)
 
-/** [VertexLabel]과 [PropertyDef]로 조회 인덱스를 제거한다. */
+/** Drops a lookup index from [VertexLabel] and [PropertyDef]. */
 fun GraphSchemaManager.dropIndex(label: VertexLabel, property: PropertyDef<*>) =
     dropIndex(label.label, property.name)
 
-/** [VertexLabel]과 [PropertyDef]로 조회 인덱스를 생성한다. */
+/** Creates a lookup index from [VertexLabel] and [PropertyDef]. */
 suspend fun GraphSuspendSchemaManager.createIndex(label: VertexLabel, property: PropertyDef<*>) =
     createIndex(label.label, property.name)
 
-/** [VertexLabel]과 [PropertyDef]로 유니크 제약조건을 생성한다. */
+/** Creates a unique constraint from [VertexLabel] and [PropertyDef]. */
 suspend fun GraphSuspendSchemaManager.createUniqueConstraint(label: VertexLabel, property: PropertyDef<*>) =
     createUniqueConstraint(label.label, property.name)
 
-/** [VertexLabel]과 [PropertyDef]로 조회 인덱스를 제거한다. */
+/** Drops a lookup index from [VertexLabel] and [PropertyDef]. */
 suspend fun GraphSuspendSchemaManager.dropIndex(label: VertexLabel, property: PropertyDef<*>) =
     dropIndex(label.label, property.name)
 
 /**
- * 공통 스키마 객체 이름을 생성한다.
+ * Builds common schema object names.
  *
  * ```kotlin
  * val index = GraphSchemaNames.indexName("Person", "email")
@@ -293,19 +293,19 @@ suspend fun GraphSuspendSchemaManager.dropIndex(label: VertexLabel, property: Pr
 object GraphSchemaNames {
 
     /**
-     * 공통 인덱스 이름을 생성한다.
+     * Builds a common index name.
      */
     fun indexName(label: String, property: String): String =
         buildName("bt4k_idx", label, property)
 
     /**
-     * 공통 유니크 제약조건 이름을 생성한다.
+     * Builds a common unique constraint name.
      */
     fun uniqueConstraintName(label: String, property: String): String =
         buildName("bt4k_uc", label, property)
 
     /**
-     * 레이블과 속성 식별자를 검증한다.
+     * Validates label and property identifiers.
      */
     fun validateLabelAndProperty(label: String, property: String): Pair<String, String> {
         val safeLabel = label.requireNotBlank("label").requireSafeIdentifier("label")

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/PropertyDef.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/PropertyDef.kt
@@ -3,20 +3,20 @@ package io.bluetape4k.graph.schema
 import kotlin.reflect.KClass
 
 /**
- * 그래프 속성(Property) 정의.
+ * Graph property definition.
  *
- * [VertexLabel] 또는 [EdgeLabel]의 DSL 메서드가 반환하는 타입 안전 속성 메타데이터이다.
- * 컴파일 타임에 속성 이름과 Kotlin 타입을 함께 추적한다.
+ * This type-safe metadata is returned by [VertexLabel] and [EdgeLabel] DSL methods.
+ * It tracks the graph property name and Kotlin value type together.
  *
  * ```kotlin
  * val nameDef = PropertyDef<String>("name")      // inline factory
- * val ageDef  = PropertyDef("age", Int::class)   // 명시적
+ * val ageDef  = PropertyDef("age", Int::class)   // explicit
  * println(nameDef.name)  // "name"
  * println(nameDef.type)  // class kotlin.String
  * ```
  *
- * @property name 속성 이름 (그래프 백엔드에 저장되는 키).
- * @property type 속성 값의 Kotlin [KClass].
+ * @property name property key stored in the graph backend.
+ * @property type Kotlin [KClass] for the property value.
  */
 data class PropertyDef<T: Any>(
     val name: String,
@@ -24,15 +24,15 @@ data class PropertyDef<T: Any>(
 )
 
 /**
- * reified 타입 파라미터를 사용하여 [PropertyDef]를 생성하는 인라인 팩토리 함수.
+ * Inline factory that creates a [PropertyDef] from a reified type parameter.
  *
  * ```kotlin
  * val nameDef: PropertyDef<String> = PropertyDef("name")       // inline factory
- * val ageDef: PropertyDef<Int>    = PropertyDef("age", Int::class)  // 명시적
+ * val ageDef: PropertyDef<Int>    = PropertyDef("age", Int::class)  // explicit
  * println(nameDef.name)  // "name"
  * println(nameDef.type)  // class kotlin.String
  * ```
  *
- * @param name 속성 이름.
+ * @param name property name.
  */
 inline fun <reified T: Any> PropertyDef(name: String): PropertyDef<T> = PropertyDef(name, T::class)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/PropertyHolder.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/PropertyHolder.kt
@@ -5,53 +5,52 @@ import java.time.LocalDateTime
 import kotlin.reflect.KClass
 
 /**
- * [VertexLabel]과 [EdgeLabel]이 공유하는 속성 DSL 기반 클래스.
+ * Base property DSL shared by [VertexLabel] and [EdgeLabel].
  *
- * Exposed Table 스타일 DSL로 속성을 선언하며, 내부 목록을 통해 등록된 모든 [PropertyDef]를
- * [properties]로 노출한다.
+ * Properties are declared in an Exposed Table-style DSL and exposed through [properties].
  *
- * 주의: `object`로 상속되는 경우 JVM 클래스 로딩 시 thread-safe하게 초기화된다.
- * 비-`object` 다중 인스턴스 컨텍스트에서는 각 인스턴스가 독립적인 `_properties` 목록을 가진다.
+ * `object` subclasses are initialized safely by JVM class loading. Non-object instances keep
+ * independent property lists.
  */
 abstract class PropertyHolder {
     private val _properties = mutableListOf<PropertyDef<*>>()
 
     /**
-     * 이 레이블에 정의된 모든 [PropertyDef]의 불변 스냅샷.
-     *
-     * 매 접근 시 내부 목록의 복사본을 반환하므로 외부에서 수정해도 원본에 영향이 없다.
-     */
+     * Immutable snapshot of all [PropertyDef] values defined on this label.
+	*
+     * Each access returns a copy, so external mutation cannot affect the source list.
+	 */
     val properties: List<PropertyDef<*>> get() = _properties.toList()
 
-    /** 문자열 속성 [PropertyDef]를 정의한다. */
+    /** Defines a string property. */
     fun string(name: String) = PropertyDef<String>(name).also { _properties.add(it) }
 
-    /** Int 속성 [PropertyDef]를 정의한다. */
+    /** Defines an Int property. */
     fun integer(name: String) = PropertyDef<Int>(name).also { _properties.add(it) }
 
-    /** Long 속성 [PropertyDef]를 정의한다. */
+    /** Defines a Long property. */
     fun long(name: String) = PropertyDef<Long>(name).also { _properties.add(it) }
 
-    /** Boolean 속성 [PropertyDef]를 정의한다. */
+    /** Defines a Boolean property. */
     fun boolean(name: String) = PropertyDef<Boolean>(name).also { _properties.add(it) }
 
-    /** List&lt;String&gt; 속성 [PropertyDef]를 정의한다. */
+    /** Defines a List&lt;String&gt; property. */
     fun stringList(name: String) = PropertyDef<List<String>>(name).also { _properties.add(it) }
 
-    /** JSON Map 속성 [PropertyDef]를 정의한다. */
+    /** Defines a JSON map property. */
     fun json(name: String) = PropertyDef<Map<String, Any?>>(name).also { _properties.add(it) }
 
-    /** LocalDate 속성 [PropertyDef]를 정의한다. */
+    /** Defines a LocalDate property. */
     fun localDate(name: String) = PropertyDef<LocalDate>(name).also { _properties.add(it) }
 
-    /** LocalDateTime 속성 [PropertyDef]를 정의한다. */
+    /** Defines a LocalDateTime property. */
     fun localDateTime(name: String) = PropertyDef<LocalDateTime>(name).also { _properties.add(it) }
 
     /**
-     * Enum 타입 속성을 선언한다.
-     *
-     * @param name 속성 이름.
-     * @param type Enum 클래스의 [KClass].
+     * Defines an enum property.
+	*
+     * @param name property name.
+     * @param type enum [KClass].
      */
     fun <E : Enum<E>> enum(name: String, type: KClass<E>) = PropertyDef(name, type).also { _properties.add(it) }
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/VertexLabel.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/schema/VertexLabel.kt
@@ -1,11 +1,10 @@
 package io.bluetape4k.graph.schema
 
 /**
- * 그래프 정점(Vertex) 스키마 정의. Exposed Table 스타일의 DSL.
- * 백엔드(AGE, Neo4j)에 무관하게 사용 가능.
+ * Graph vertex schema definition with an Exposed Table-style DSL.
+ * It is backend-independent and can be used with AGE, Neo4j, and other graph backends.
  *
- * `object`로 상속하여 정점 타입별 스키마를 선언하고, 각 DSL 함수 호출 결과인
- * [PropertyDef]를 프로퍼티로 보유한다.
+ * Subclass it as an `object` per vertex type and keep each DSL call result as a [PropertyDef] property.
  *
  * ```kotlin
  * object PersonLabel : VertexLabel("Person") {
@@ -14,6 +13,6 @@ package io.bluetape4k.graph.schema
  * }
  * ```
  *
- * @property label 정점 레이블 이름 (예: `"Person"`, `"Company"`).
+ * @property label vertex label name, such as `"Person"` or `"Company"`.
  */
 abstract class VertexLabel(val label: String) : PropertyHolder()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/utils/GraphProperties.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/utils/GraphProperties.kt
@@ -5,18 +5,15 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 /**
- * 그래프 속성(Properties) 변환 유틸리티.
+ * Graph property conversion utilities.
  *
- * Kotlin 값을 Cypher 리터럴로 직렬화한다. Neo4j / Memgraph / Apache AGE 에서
- * 공통으로 사용 가능한 Cypher 서브셋을 생성한다.
+ * Serializes Kotlin values to Cypher literals using a subset shared by Neo4j, Memgraph, and Apache AGE.
  *
- * 지원 타입: `null`, `String`, `Number`, `Boolean`, `LocalDate`, `LocalDateTime`,
- * `List<*>`, `Map<*, *>` (중첩 허용), 그리고 위에 속하지 않는 객체는 `toString()`
- * 후 문자열로 취급된다.
+ * Supported values: `null`, `String`, `Number`, `Boolean`, `LocalDate`, `LocalDateTime`,
+ * nested `List<*>`, nested `Map<*, *>`, and fallback objects converted with `toString()`.
  *
- * > 주의: 이 유틸리티는 **신뢰된 입력**을 대상으로 하는 리터럴 생성기이다.
- * > 사용자 입력을 그대로 Cypher 에 끼워 넣는 용도로 사용해서는 안 된다.
- * > 사용자 입력은 백엔드 드라이버의 파라미터 바인딩을 사용할 것.
+ * > Warning: this is a literal generator for trusted input. Do not splice raw user input
+ * > into Cypher with this utility; use backend driver parameter binding instead.
  *
  * ```kotlin
  * GraphProperties.toCypherProps(mapOf("name" to "Alice", "age" to 30))
@@ -31,9 +28,9 @@ import java.time.LocalDateTime
 object GraphProperties: KLogging() {
 
     /**
-     * Map 을 Cypher 속성 블록 문자열로 변환한다. 예: `{name: 'Alice', age: 30}`.
-     *
-     * 입력이 비어 있으면 빈 문자열을 반환한다.
+     * Converts a map to a Cypher property block, for example `{name: 'Alice', age: 30}`.
+	*
+     * Returns an empty string when the input is empty.
      *
      * ```kotlin
      * GraphProperties.toCypherProps(mapOf("name" to "Alice", "age" to 30))
@@ -51,11 +48,11 @@ object GraphProperties: KLogging() {
     }
 
     /**
-     * 단일 값을 Cypher 리터럴로 변환한다.
-     *
-     * - 문자열은 작은따옴표로 감싸지며, 백슬래시/작은따옴표/개행/탭은 escape 된다.
-     * - `LocalDate`, `LocalDateTime` 은 ISO-8601 문자열 리터럴로 변환된다.
-     * - `List`, `Map` 은 요소를 재귀 변환한다.
+     * Converts a single value to a Cypher literal.
+	*
+     * - Strings are single-quoted, with backslash, quote, newline, and tab escaped.
+     * - `LocalDate` and `LocalDateTime` are converted to ISO-8601 string literals.
+     * - `List` and `Map` values are converted recursively.
      *
      * ```kotlin
      * GraphProperties.toCypherValue("Alice")          // → "'Alice'"
@@ -80,9 +77,9 @@ object GraphProperties: KLogging() {
     }
 
     /**
-     * Cypher 문자열 리터럴 내부의 특수 문자를 escape 한다.
-     *
-     * 백슬래시는 반드시 먼저 처리해야 이어지는 escape sequence 가 중복되지 않는다.
+     * Escapes special characters inside a Cypher string literal.
+	*
+     * Backslashes must be processed first to avoid double-escaping later sequences.
      */
     private fun escapeString(raw: String): String = buildString(raw.length) {
         for (ch in raw) {

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadEdgeAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadEdgeAdapter.kt
@@ -10,11 +10,11 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /**
- * [GraphEdgeRepository] 의 모든 메서드를 Virtual Thread 위에서 실행하는 어댑터.
+ * Adapter that runs all [GraphEdgeRepository] methods on virtual threads.
  *
- * 단일 작업에는 `virtualFutureOf { }` 를 사용한다.
+ * Single operations use `virtualFutureOf { }`.
  *
- * @param delegate 위임할 동기 [GraphEdgeRepository].
+ * @param delegate synchronous [GraphEdgeRepository] to delegate to.
  */
 class VirtualThreadEdgeAdapter(
     private val delegate: GraphEdgeRepository,
@@ -59,7 +59,7 @@ class VirtualThreadEdgeAdapter(
 }
 
 /**
- * [GraphEdgeRepository] 를 Virtual Thread 어댑터로 감싸는 확장 함수.
+ * Wraps [GraphEdgeRepository] in a virtual-thread adapter.
  */
 fun GraphEdgeRepository.asVirtualThreadEdge(): GraphVirtualThreadEdgeRepository =
     VirtualThreadEdgeAdapter(this)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadOperationsAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadOperationsAdapter.kt
@@ -11,11 +11,11 @@ import io.bluetape4k.graph.repository.GraphVirtualThreadVertexRepository
 import io.bluetape4k.logging.KLogging
 
 /**
- * [GraphOperations] 의 모든 기능을 Virtual Thread 위에서 제공하는 통합 어댑터.
+ * Unified adapter that exposes all [GraphOperations] capabilities on virtual threads.
  *
- * Kotlin `by` 위임으로 5개 어댑터를 합성한다.
+ * It composes five focused adapters through Kotlin `by` delegation.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val ops: GraphOperations = TinkerGraphOperations()
  * val vtOps = VirtualThreadOperationsAdapter(ops)
@@ -24,7 +24,7 @@ import io.bluetape4k.logging.KLogging
  * val scores = vtOps.pageRankAsync().join()
  * ```
  *
- * @param delegate 위임할 동기 [GraphOperations].
+ * @param delegate synchronous [GraphOperations] to delegate to.
  */
 class VirtualThreadOperationsAdapter(
     private val delegate: GraphOperations,
@@ -38,6 +38,6 @@ class VirtualThreadOperationsAdapter(
     companion object: KLogging()
 
     override fun close() {
-        // 소유권 원칙상 delegate를 닫지 않는다. delegate 생명주기는 호출자가 관리한다.
+        // The delegate is externally owned; callers manage its lifecycle.
     }
 }

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadOperationsExt.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadOperationsExt.kt
@@ -4,10 +4,10 @@ import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
 
 /**
- * [GraphOperations] 를 Virtual Thread facade 로 감싸는 확장 함수.
+ * Wraps [GraphOperations] in a virtual-thread facade.
  *
- * `GraphOperations` 수신자에 대해 더 구체적인 오버로드가 되므로
- * `GraphAlgorithmRepository.asVirtualThread()` 보다 우선 선택된다.
+ * This overload is more specific for `GraphOperations` receivers than
+ * `GraphAlgorithmRepository.asVirtualThread()`, so overload resolution prefers it.
  *
  * ```kotlin
  * val vtOps = ops.asVirtualThread()      // GraphVirtualThreadOperations

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadSessionAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadSessionAdapter.kt
@@ -7,11 +7,11 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /**
- * [GraphSession] 의 lifecycle 조작을 Virtual Thread 위에서 실행하는 어댑터.
+ * Adapter that runs [GraphSession] lifecycle operations on virtual threads.
  *
- * 모든 작업에 `virtualFutureOf { }` 를 사용한다.
+ * All operations use `virtualFutureOf { }`.
  *
- * @param delegate 위임할 동기 [GraphSession].
+ * @param delegate synchronous [GraphSession] to delegate to.
  */
 class VirtualThreadSessionAdapter(
     private val delegate: GraphSession,
@@ -30,7 +30,7 @@ class VirtualThreadSessionAdapter(
 }
 
 /**
- * [GraphSession] 을 Virtual Thread 세션 어댑터로 감싸는 확장 함수.
+ * Wraps [GraphSession] in a virtual-thread session adapter.
  */
 fun GraphSession.asVirtualThreadSession(): GraphVirtualThreadSession =
     VirtualThreadSessionAdapter(this)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadTraversalAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadTraversalAdapter.kt
@@ -13,11 +13,11 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /**
- * [GraphTraversalRepository] 의 모든 메서드를 Virtual Thread 위에서 실행하는 어댑터.
+ * Adapter that runs all [GraphTraversalRepository] methods on virtual threads.
  *
- * 단일 작업에는 `virtualFutureOf { }` 를 사용한다.
+ * Single operations use `virtualFutureOf { }`.
  *
- * @param delegate 위임할 동기 [GraphTraversalRepository].
+ * @param delegate synchronous [GraphTraversalRepository] to delegate to.
  */
 class VirtualThreadTraversalAdapter(
     private val delegate: GraphTraversalRepository,
@@ -55,7 +55,7 @@ class VirtualThreadTraversalAdapter(
 }
 
 /**
- * [GraphTraversalRepository] 를 Virtual Thread 순회 어댑터로 감싸는 확장 함수.
+ * Wraps [GraphTraversalRepository] in a virtual-thread traversal adapter.
  */
 fun GraphTraversalRepository.asVirtualThreadTraversal(): GraphVirtualThreadTraversalRepository =
     VirtualThreadTraversalAdapter(this)

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadVertexAdapter.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/vt/VirtualThreadVertexAdapter.kt
@@ -10,11 +10,11 @@ import io.bluetape4k.logging.KLogging
 import java.util.concurrent.CompletableFuture
 
 /**
- * [GraphVertexRepository] 의 모든 메서드를 Virtual Thread 위에서 실행하는 어댑터.
+ * Adapter that runs all [GraphVertexRepository] methods on virtual threads.
  *
- * 단일 작업에는 `virtualFutureOf { }` 를 사용한다.
+ * Single operations use `virtualFutureOf { }`.
  *
- * @param delegate 위임할 동기 [GraphVertexRepository].
+ * @param delegate synchronous [GraphVertexRepository] to delegate to.
  */
 class VirtualThreadVertexAdapter(
     private val delegate: GraphVertexRepository,
@@ -67,7 +67,7 @@ class VirtualThreadVertexAdapter(
 }
 
 /**
- * [GraphVertexRepository] 를 Virtual Thread 정점 어댑터로 감싸는 확장 함수.
+ * Wraps [GraphVertexRepository] in a virtual-thread vertex adapter.
  */
 fun GraphVertexRepository.asVirtualThreadVertexRepository(): GraphVirtualThreadVertexRepository =
     VirtualThreadVertexAdapter(this)

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/AStarRunnerTest.kt
@@ -8,7 +8,7 @@ import io.bluetape4k.graph.model.MissingWeightPolicy
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.model.PathStep
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeNear
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldContainAll
@@ -167,7 +167,7 @@ class AStarRunnerTest {
 
     @Test
     fun `weightProperty 없으면 IllegalArgumentException 발생`() {
-        invoking { runner().run(id("A"), id("C"), PathOptions()) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { runner().run(id("A"), id("C"), PathOptions()) }
     }
 
     // ─── Direction.BOTH ───────────────────────────────────────────────────────────

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/DijkstraRunnerTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/DijkstraRunnerTest.kt
@@ -10,7 +10,7 @@ import io.bluetape4k.graph.model.PathStep
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeNear
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldContainAll
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -170,7 +170,7 @@ class DijkstraRunnerTest {
 
     @Test
     fun `weightProperty가 null이면 IllegalArgumentException을 던진다`() {
-        invoking { runner().run(id("A"), id("C"), PathOptions()) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { runner().run(id("A"), id("C"), PathOptions()) }
     }
 
     // ─── fetchVertex mid-traversal null ──────────────────────────────────────────

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/WeightExtractorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/WeightExtractorTest.kt
@@ -5,7 +5,7 @@ import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.MissingWeightException
 import io.bluetape4k.graph.model.MissingWeightPolicy
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeNear
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -23,7 +23,7 @@ class WeightExtractorTest {
     @Test
     fun `Fail 정책 - 속성 없으면 MissingWeightException 발생`() {
         val extractor = WeightExtractor("cost", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge()) } shouldThrow MissingWeightException::class
+        assertFailsWith<MissingWeightException> { extractor.extract(edge()) }
     }
 
     @Test
@@ -97,47 +97,47 @@ class WeightExtractorTest {
     @Test
     fun `NaN weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to Double.NaN)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to Double.NaN)) }
     }
 
     @Test
     fun `양의 무한대 weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to Double.POSITIVE_INFINITY)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to Double.POSITIVE_INFINITY)) }
     }
 
     @Test
     fun `음수 weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to -1.0)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to -1.0)) }
     }
 
     @Test
     fun `0 weight은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to 0.0)) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to 0.0)) }
     }
 
     @Test
     fun `String 비숫자 속성은 IllegalArgumentException 발생`() {
         val extractor = WeightExtractor("w", MissingWeightPolicy.Fail)
-        invoking { extractor.extract(edge("w" to "abc")) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { extractor.extract(edge("w" to "abc")) }
     }
 
     // ─── MissingWeightPolicy 생성 ─────────────────────────────────────────────
 
     @Test
     fun `UseDefault value 0은 IllegalArgumentException`() {
-        invoking { MissingWeightPolicy.UseDefault(0.0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { MissingWeightPolicy.UseDefault(0.0) }
     }
 
     @Test
     fun `UseDefault value 음수는 IllegalArgumentException`() {
-        invoking { MissingWeightPolicy.UseDefault(-1.0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { MissingWeightPolicy.UseDefault(-1.0) }
     }
 
     @Test
     fun `UseDefault Infinity는 IllegalArgumentException`() {
-        invoking { MissingWeightPolicy.UseDefault(Double.POSITIVE_INFINITY) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { MissingWeightPolicy.UseDefault(Double.POSITIVE_INFINITY) }
     }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/CycleDetectorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/CycleDetectorTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.graph.algo.internal
 
 import io.bluetape4k.graph.model.GraphElementId
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldHaveSize
@@ -88,11 +88,11 @@ class CycleDetectorTest {
 
     @Test
     fun `maxDepth가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking { CycleDetector.findCycles(emptyMap(), maxDepth = 0, maxCycles = 1) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CycleDetector.findCycles(emptyMap(), maxDepth = 0, maxCycles = 1) }
     }
 
     @Test
     fun `maxCycles가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking { CycleDetector.findCycles(emptyMap(), maxDepth = 1, maxCycles = 0) } shouldThrow IllegalArgumentException::class
+        assertFailsWith<IllegalArgumentException> { CycleDetector.findCycles(emptyMap(), maxDepth = 1, maxCycles = 0) }
     }
 }

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculatorTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/algo/internal/PageRankCalculatorTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.graph.algo.internal
 
 import io.bluetape4k.graph.model.GraphElementId
-import io.bluetape4k.assertions.invoking
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
@@ -72,30 +72,30 @@ class PageRankCalculatorTest {
 
     @Test
     fun `iterations가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), iterations = 0)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     @Test
     fun `dampingFactor가 1 초과이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), dampingFactor = 1.5)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     @Test
     fun `dampingFactor가 음수이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), dampingFactor = -0.1)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     @Test
     fun `tolerance가 0 이하이면 IllegalArgumentException을 던진다`() {
-        invoking {
+        assertFailsWith<IllegalArgumentException> {
             compute(vertices = setOf(id("a")), outAdjacency = emptyMap(), tolerance = 0.0)
-        } shouldThrow IllegalArgumentException::class
+        }
     }
 
     // ─── dangling node ────────────────────────────────────────────────────────────

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphElementIdTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphElementIdTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.graph.model
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -32,8 +34,21 @@ class GraphElementIdTest {
     }
 
     @Test
-    fun `빈 문자열도 허용된다`() {
-        GraphElementId("").value shouldBeEqualTo ""
+    fun `빈 문자열은 허용되지 않는다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            GraphElementId("")
+        }
+
+        ex.message shouldContain "value"
+    }
+
+    @Test
+    fun `공백 문자열은 허용되지 않는다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            GraphElementId("   ")
+        }
+
+        ex.message shouldContain "value"
     }
 
     @Test

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/repository/GraphBatchOperationsTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/repository/GraphBatchOperationsTest.kt
@@ -188,15 +188,12 @@ class GraphBatchOperationsTest {
     }
 
     @Test
-    fun `batch validation rejects blank edge endpoint`() {
+    fun `blank edge endpoint cannot be constructed before batch validation`() {
         val ex = assertFailsWith<IllegalArgumentException> {
-            GraphBatchValidation.validateEdgeBatch(
-                "KNOWS",
-                listOf(BatchEdge(GraphElementId(""), GraphElementId.of("v2"))),
-            )
+            GraphElementId("")
         }
 
-        ex.message shouldContain "fromId.value"
+        ex.message shouldContain "value"
     }
 
     @Test

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBCycleFallbackSupport.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBCycleFallbackSupport.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.graph.falkordb
+
+import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.model.CycleOptions
+
+private val fallbackFailureMarkers = listOf(
+    "not supported",
+    "not implemented",
+    "unsupported",
+    "unknown function",
+    "unknown procedure",
+    "unknown clause",
+)
+
+internal fun Throwable.supportsJvmCycleFallback(): Boolean =
+    diagnosticText().let { text ->
+        fallbackFailureMarkers.any { marker -> marker in text }
+    }
+
+internal fun Throwable.asCycleDetectionFailure(
+    backend: String,
+    options: CycleOptions,
+): GraphQueryException =
+    this as? GraphQueryException
+        ?: GraphQueryException("$backend cycle detection query failed: options=$options", this)
+
+private fun Throwable.diagnosticText(): String =
+    generateSequence(this) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(" ")
+        .lowercase()

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperations.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperations.kt
@@ -646,8 +646,12 @@ class FalkorDBGraphOperations(
                 GraphCycle(rec.toPath())
             }
         } catch (e: Exception) {
-            log.debug(e) { "detectCycles via Cypher failed; using JVM fallback" }
-            detectCyclesViaFallback(options)
+            if (e.supportsJvmCycleFallback()) {
+                log.debug(e) { "detectCycles via Cypher is unsupported; using JVM fallback" }
+                detectCyclesViaFallback(options)
+            } else {
+                throw e.asCycleDetectionFailure("FalkorDB", options)
+            }
         }
     }
 

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperations.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperations.kt
@@ -132,11 +132,11 @@ class FalkorDBGraphOperations(
 
     override fun graphExists(name: String): Boolean {
         name.requireNotBlank("name")
-        return runCatching { driver.listGraphs().contains(name) }
-            .getOrElse {
-                log.warn(it) { "graphExists($name) failed; treating as false" }
-                false
-            }
+        return try {
+            driver.listGraphs().contains(name)
+        } catch (e: Exception) {
+            throw GraphQueryException("FalkorDB graphExists failed: graph=$name", e)
+        }
     }
 
     override fun close() { /* driver는 외부 소유 */ }

--- a/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperations.kt
+++ b/graph/graph-falkordb/src/main/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphSuspendOperations.kt
@@ -578,9 +578,15 @@ class FalkorDBGraphSuspendOperations(
             queryListIO(cypher) { rec ->
                 GraphCycle(rec.toPath())
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            log.debug(e) { "detectCycles via Cypher failed; using JVM fallback" }
-            detectCyclesViaFallback(options)
+            if (e.supportsJvmCycleFallback()) {
+                log.debug(e) { "detectCycles via Cypher is unsupported; using JVM fallback" }
+                detectCyclesViaFallback(options)
+            } else {
+                throw e.asCycleDetectionFailure("FalkorDB", options)
+            }
         }
         cycles.forEach { emit(it) }
     }

--- a/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBCycleFallbackSupportTest.kt
+++ b/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBCycleFallbackSupportTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.graph.falkordb
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.model.CycleOptions
+import org.junit.jupiter.api.Test
+
+class FalkorDBCycleFallbackSupportTest {
+
+    @Test
+    fun `known unsupported cycle query can use JVM fallback`() {
+        RuntimeException("unknown function in cycle query")
+            .supportsJvmCycleFallback()
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `unexpected cycle query failure is not treated as fallback`() {
+        IllegalStateException("redis connection closed")
+            .supportsJvmCycleFallback()
+            .shouldBeFalse()
+    }
+
+    @Test
+    fun `unexpected cycle query failure keeps backend context`() {
+        val cause = IllegalStateException("redis connection closed")
+        val ex = cause.asCycleDetectionFailure("FalkorDB", CycleOptions(edgeLabel = "E"))
+
+        ex.message shouldContain "FalkorDB cycle detection query failed"
+        ex.cause shouldBeInstanceOf IllegalStateException::class
+    }
+}

--- a/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperationsTest.kt
+++ b/graph/graph-falkordb/src/test/kotlin/io/bluetape4k/graph/falkordb/FalkorDBGraphOperationsTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.falkordb
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.graph.GraphQueryException
 import io.bluetape4k.graph.model.Direction
 import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.NeighborOptions
@@ -12,8 +13,11 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.MethodOrderer
@@ -61,6 +65,21 @@ class FalkorDBGraphOperationsTest : AbstractFalkorDBTest() {
         val result = ops.graphExists("non_existent_graph_xyz_12345")
         // 존재하지 않으면 false
         result shouldBeEqualTo false
+    }
+
+    @Test
+    @Order(13)
+    fun `graphExists preserves driver failures`() {
+        val failingDriver = mockk<com.falkordb.Driver>()
+        every { failingDriver.listGraphs() } throws IllegalStateException("redis unavailable")
+        val failingOps = FalkorDBGraphOperations(failingDriver, graphName)
+
+        val ex = assertFailsWith<GraphQueryException> {
+            failingOps.graphExists(graphName)
+        }
+
+        ex.message shouldContain "FalkorDB graphExists failed"
+        ex.cause shouldBeInstanceOf IllegalStateException::class
     }
 
     // ----- 정점(Vertex) CRUD -----

--- a/graph/graph-falkordb/src/testFixtures/kotlin/io/bluetape4k/graph/falkordb/FalkorDBServer.kt
+++ b/graph/graph-falkordb/src/testFixtures/kotlin/io/bluetape4k/graph/falkordb/FalkorDBServer.kt
@@ -1,131 +1,17 @@
 package io.bluetape4k.graph.falkordb
 
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.support.requireNotBlank
-import io.bluetape4k.utils.ShutdownQueue
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.containers.wait.strategy.WaitAllStrategy
-import org.testcontainers.utility.DockerImageName
-import java.time.Duration
+import io.bluetape4k.testcontainers.graphdb.FalkorDBServer as SharedFalkorDBServer
 
 /**
- * [FalkorDB](https://falkordb.com/) 그래프 데이터베이스를 Testcontainers로 실행합니다.
+ * Compatibility access point for the shared FalkorDB Testcontainers launcher.
  *
- * FalkorDB는 Redis 모듈 기반의 그래프 데이터베이스입니다.
- * jfalkordb 드라이버를 통해 `FalkorDB.driver(host, port)`로 접속합니다.
- *
- * **사전 설정**: `~/.testcontainers.properties`에 `testcontainers.reuse.enable=true` 추가 시
- * 컨테이너를 재사용하여 테스트 속도를 높일 수 있습니다.
- *
- * ```kotlin
- * val server = FalkorDBServer().apply { start() }
- * val driver = FalkorDB.driver(server.host, server.port)
- * driver.graph("myGraph").use { graph ->
- *     graph.query("RETURN 1")
- * }
- * ```
- *
- * @param imageName      Docker 이미지 이름 ([DockerImageName])
- * @param useDefaultPort 기본 포트를 호스트 포트로 고정할지 여부
- * @param reuse          컨테이너 재사용 여부
+ * New tests should prefer importing [io.bluetape4k.testcontainers.graphdb.FalkorDBServer]
+ * directly. This object keeps existing graph module tests on the centralized
+ * singleton launcher while preserving the current test-fixtures `Launcher` path.
  */
-class FalkorDBServer private constructor(
-    imageName: DockerImageName,
-    useDefaultPort: Boolean = false,
-    reuse: Boolean = true,
-) : GenericContainer<FalkorDBServer>(imageName) {
-
-    companion object : KLogging() {
-        /** FalkorDB 공식 Docker 이미지 이름 */
-        const val IMAGE = "falkordb/falkordb"
-
-        /** 고정 안정 버전 태그 — latest 사용 금지 */
-        const val TAG = "v4.18.1"
-
-        /** 시스템 프로퍼티 접두사에 사용되는 서버 이름 */
-        const val NAME = "falkordb"
-
-        /** FalkorDB(Redis) 기본 포트 */
-        const val REDIS_PORT = 6379
-
-        /**
-         * [DockerImageName]을 직접 지정하여 [FalkorDBServer] 인스턴스를 생성합니다.
-         *
-         * @param imageName      Docker 이미지 이름
-         * @param useDefaultPort 기본 포트를 호스트에 고정할지 여부
-         * @param reuse          컨테이너 재사용 여부
-         */
-        @JvmStatic
-        operator fun invoke(
-            imageName: DockerImageName,
-            useDefaultPort: Boolean = false,
-            reuse: Boolean = true,
-        ): FalkorDBServer = FalkorDBServer(imageName, useDefaultPort, reuse)
-
-        /**
-         * 이미지명과 태그를 문자열로 지정하여 [FalkorDBServer] 인스턴스를 생성합니다.
-         *
-         * @param image          Docker 이미지 이름 (기본값: [IMAGE])
-         * @param tag            Docker 이미지 태그 (기본값: [TAG])
-         * @param useDefaultPort 기본 포트를 호스트에 고정할지 여부
-         * @param reuse          컨테이너 재사용 여부
-         */
-        @JvmStatic
-        operator fun invoke(
-            image: String = IMAGE,
-            tag: String = TAG,
-            useDefaultPort: Boolean = false,
-            reuse: Boolean = true,
-        ): FalkorDBServer {
-            image.requireNotBlank("image")
-            tag.requireNotBlank("tag")
-            val imageName = DockerImageName.parse(image).withTag(tag)
-            return FalkorDBServer(imageName, useDefaultPort, reuse)
-        }
-    }
-
-    /** 호스트에 매핑된 Redis 포트 번호 */
-    val port: Int get() = getMappedPort(REDIS_PORT)
-
-    /** Redis 연결 URL (`redis://host:port` 형식) */
-    val url: String get() = "redis://$host:$port"
-
-    init {
-        addExposedPorts(REDIS_PORT)
-        withReuse(reuse)
-        waitingFor(
-            WaitAllStrategy()
-                .withStrategy(Wait.forLogMessage(".*Ready to accept connections.*", 1))
-                .withStrategy(Wait.forListeningPort())
-                .withStartupTimeout(Duration.ofSeconds(60))
-        )
-
-        if (useDefaultPort) {
-            addFixedExposedPort(REDIS_PORT, REDIS_PORT)
-        }
-    }
-
-    /**
-     * 테스트에서 재사용할 FalkorDB 서버 싱글턴을 제공합니다.
-     *
-     * ```kotlin
-     * val driver = FalkorDB.driver(
-     *     FalkorDBServer.Launcher.falkordb.host,
-     *     FalkorDBServer.Launcher.falkordb.port
-     * )
-     * ```
-     */
+object FalkorDBServer {
     object Launcher {
-        /**
-         * 기본 설정으로 시작된 [FalkorDBServer] 싱글턴 인스턴스입니다.
-         * JVM 종료 시 자동으로 정지됩니다.
-         */
-        val falkordb: FalkorDBServer by lazy {
-            FalkorDBServer().apply {
-                start()
-                ShutdownQueue.register(this)
-            }
-        }
+        val falkordb: SharedFalkorDBServer
+            get() = SharedFalkorDBServer.Launcher.falkordb
     }
 }

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphCycleFallbackSupport.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphCycleFallbackSupport.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.model.CycleOptions
+import org.neo4j.driver.exceptions.Neo4jException
+
+private val fallbackFailureMarkers = listOf(
+    "not supported",
+    "not implemented",
+    "unsupported",
+    "unknown function",
+    "unknown procedure",
+    "unknown clause",
+)
+
+internal fun Throwable.supportsJvmCycleFallback(): Boolean =
+    diagnosticText().let { text ->
+        fallbackFailureMarkers.any { marker -> marker in text }
+    }
+
+internal fun Throwable.asCycleDetectionFailure(
+    backend: String,
+    options: CycleOptions,
+): GraphQueryException =
+    this as? GraphQueryException
+        ?: GraphQueryException("$backend cycle detection query failed: options=$options", this)
+
+private fun Throwable.diagnosticText(): String =
+    generateSequence(this) { it.cause }
+        .flatMap { throwable ->
+            sequenceOf(
+                throwable.message,
+                (throwable as? Neo4jException)?.code(),
+            )
+        }
+        .filterNotNull()
+        .joinToString(" ")
+        .lowercase()

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphExistsFailures.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphExistsFailures.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.graph.GraphQueryException
+
+private val missingDatabaseMarkers = listOf(
+    "database not found",
+    "database does not exist",
+    "databasenotfound",
+)
+
+internal fun Throwable.isMissingDatabaseFailure(): Boolean =
+    generateSequence(this) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(" ")
+        .lowercase()
+        .let { text -> missingDatabaseMarkers.any { marker -> marker in text } }
+
+internal fun Throwable.asGraphExistsFailure(backend: String, name: String): GraphQueryException =
+    this as? GraphQueryException
+        ?: GraphQueryException("$backend graphExists failed: graph=$name", this)

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphOperations.kt
@@ -602,8 +602,12 @@ class MemgraphGraphOperations(
                 GraphCycle(GraphPath(orderedSteps))
             }
         } catch (e: Exception) {
-            log.debug(e) { "detectCycles via Cypher failed; using JVM fallback" }
-            detectCyclesViaFallback(options)
+            if (e.supportsJvmCycleFallback()) {
+                log.debug(e) { "detectCycles via Cypher is unsupported; using JVM fallback" }
+                detectCyclesViaFallback(options)
+            } else {
+                throw e.asCycleDetectionFailure("Memgraph", options)
+            }
         }
     }
 

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
@@ -32,6 +32,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
@@ -265,20 +266,21 @@ class MemgraphGraphSuspendOperations(
     override suspend fun graphExists(name: String): Boolean {
         name.requireNotBlank("name")
 
-        val s = session()
+        var s: ReactiveSession? = null
         return try {
+            s = session()
             val result = s.run(Query("RETURN 1")).awaitSingle()
             result.records().awaitFirstOrNull() != null
-        } catch (e: org.neo4j.driver.exceptions.ServiceUnavailableException) {
-            log.warn(e) { "Memgraph service unavailable for database: $name" }
-            false
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: org.neo4j.driver.exceptions.DatabaseException) {
-            false
+            if (e.isMissingDatabaseFailure()) false else throw e.asGraphExistsFailure("Memgraph", name)
         } catch (e: Exception) {
-            log.warn(e) { "Unexpected error checking graphExists for: $name" }
-            false
+            throw e.asGraphExistsFailure("Memgraph", name)
         } finally {
-            withContext(NonCancellable) { s.close<Void>().awaitFirstOrNull() }
+            s?.let { session ->
+                withContext(NonCancellable) { session.close<Void>().awaitFirstOrNull() }
+            }
         }
     }
 

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphCycleFallbackSupportTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphCycleFallbackSupportTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.graph.memgraph
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.model.CycleOptions
+import org.junit.jupiter.api.Test
+
+class MemgraphCycleFallbackSupportTest {
+
+    @Test
+    fun `known unsupported cycle query can use JVM fallback`() {
+        RuntimeException("cycle pattern is not implemented by this backend")
+            .supportsJvmCycleFallback()
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `unexpected cycle query failure is not treated as fallback`() {
+        IllegalStateException("bolt connection closed")
+            .supportsJvmCycleFallback()
+            .shouldBeFalse()
+    }
+
+    @Test
+    fun `unexpected cycle query failure keeps backend context`() {
+        val cause = IllegalStateException("bolt connection closed")
+        val ex = cause.asCycleDetectionFailure("Memgraph", CycleOptions(edgeLabel = "E"))
+
+        ex.message shouldContain "Memgraph cycle detection query failed"
+        ex.cause shouldBeInstanceOf IllegalStateException::class
+    }
+}

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperationsTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperationsTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.memgraph
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.graph.GraphQueryException
 import io.bluetape4k.graph.model.Direction
 import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.NeighborOptions
@@ -20,8 +21,11 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -32,6 +36,9 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
+import org.neo4j.driver.SessionConfig
+import org.neo4j.driver.exceptions.ServiceUnavailableException
+import org.neo4j.driver.reactivestreams.ReactiveSession
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class MemgraphGraphSuspendOperationsTest {
@@ -67,6 +74,23 @@ class MemgraphGraphSuspendOperationsTest {
 
     @Test
     @Order(11)
+    fun `graphExists preserves driver failures`() = runSuspendIO {
+        val failingDriver = mockk<Driver>()
+        every {
+            failingDriver.session(ReactiveSession::class.java, any<SessionConfig>())
+        } throws ServiceUnavailableException("memgraph unavailable")
+        val failingOps = MemgraphGraphSuspendOperations(failingDriver)
+
+        val ex = assertFailsWith<GraphQueryException> {
+            failingOps.graphExists("default")
+        }
+
+        ex.message shouldContain "Memgraph graphExists failed"
+        ex.cause shouldBeInstanceOf ServiceUnavailableException::class
+    }
+
+    @Test
+    @Order(12)
     fun `dropGraph로 전체 데이터를 삭제한다`() = runSuspendIO {
         ops.createVertex("Person", mapOf("name" to "Alice"))
         ops.countVertices("Person") shouldBeGreaterOrEqualTo 1L

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/CachingNeo4jGraphOperations.kt
@@ -17,48 +17,50 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * ConcurrentHashMap 기반 캐시를 사용한 [Neo4jGraphOperations] 래퍼.
+ * [Neo4jGraphOperations] wrapper backed by [ConcurrentHashMap] caches.
  *
- * 읽기 메서드 (findVertexById, findVerticesByLabel, neighbors, shortestPath, allPaths, findEdgesByLabel)
- * 의 결과를 캐싱하여 반복 DB 호출을 캐시 히트 (~5 ns) 로 변환한다.
+ * Read methods (`findVertexById`, `findVerticesByLabel`, `neighbors`, `shortestPath`,
+ * `allPaths`, and `findEdgesByLabel`) cache their results so repeated lookups become
+ * in-memory hits instead of database round trips.
  *
- * 쓰기 메서드 (createVertex, updateVertex, deleteVertex, createEdge, deleteEdge) 호출 시
- * 캐시를 전체 무효화하여 일관성을 유지한다.
+ * Write methods (`createVertex`, `updateVertex`, `deleteVertex`, `createEdge`,
+ * and `deleteEdge`) invalidate caches to keep subsequent reads consistent.
  *
- * **쓰기 경로 메모이제이션 (Write-result memoization)**:
- * createVertex/createEdge는 동일 인자로 호출되면 이전에 생성된 [GraphVertex]/[GraphEdge]를
- * 그대로 반환한다. 이는 벤치마크/테스트용 편의 기능이며, 트랜잭션 기반 insert 의미가 필요한
- * 프로덕션 코드는 [Neo4jGraphOperations]를 직접 사용해야 한다.
+ * **Write-result memoization**:
+ * repeated `createVertex` and `createEdge` calls with identical arguments return the
+ * previously created [GraphVertex] or [GraphEdge]. This is intended for benchmarks
+ * and repeat-heavy tests; production code that needs transactional insert semantics
+ * should use [Neo4jGraphOperations] directly.
  *
- * 모든 읽기 캐시는 Caffeine → ConcurrentHashMap 으로 구현되어 TinyLFU 북키핑 비용을 제거하고
- * lookup latency 를 ~13-15 ns → ~5 ns 로 단축한다. TTL/maxSize 기반 축출은 제거되었고,
- * 쓰기 시 명시적 clear() 로 일관성을 유지한다.
+ * Read caches use [ConcurrentHashMap] rather than Caffeine to avoid TinyLFU bookkeeping.
+ * TTL and max-size eviction are intentionally absent; explicit `clear()` calls on writes
+ * maintain consistency.
  *
- * ### 사용 예제
+ * ### Usage
  * ```kotlin
  * val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.none())
  * val baseOps = Neo4jGraphOperations(driver)
  *
- * // 캐싱 래퍼로 감싸기 (벤치마크/반복 읽기가 많은 워크로드에 적합)
+ * // Wrap the base operations for benchmark or repeat-read workloads.
  * val ops = CachingNeo4jGraphOperations(baseOps)
  *
- * // 첫 번째 조회: DB 호출 발생
+ * // First lookup: database call.
  * val alice = ops.findVertexById("Person", aliceId)
  *
- * // 두 번째 조회: 캐시 히트 (~5 ns), DB 호출 없음
+ * // Second lookup: cache hit, no database call.
  * val aliceCached = ops.findVertexById("Person", aliceId)
  *
- * // 정점 삭제: 모든 캐시 자동 무효화
+ * // Deleting a vertex invalidates all caches.
  * ops.deleteVertex("Person", aliceId)
  *
- * // 삭제 후 조회: 캐시 미스 → DB 재조회
+ * // The next lookup misses the cache and reads from the database again.
  * val afterDelete = ops.findVertexById("Person", aliceId)  // null
  * ```
  */
 /**
- * @param delegate 실제 DB 호출을 위임할 [Neo4jGraphOperations] 인스턴스.
- * @param maxSize API 호환성 유지용 파라미터 — 현재 사용되지 않음 (Caffeine → ConcurrentHashMap 전환 후 제거됨).
- * @param expireAfterWrite API 호환성 유지용 파라미터 — 현재 사용되지 않음 (쓰기 시 명시적 clear() 로 무효화).
+ * @param delegate [Neo4jGraphOperations] instance that performs the actual database calls.
+ * @param maxSize compatibility parameter; currently unused after the ConcurrentHashMap migration.
+ * @param expireAfterWrite compatibility parameter; currently unused because writes explicitly clear caches.
  */
 class CachingNeo4jGraphOperations(
     private val delegate: Neo4jGraphOperations,
@@ -84,23 +86,23 @@ class CachingNeo4jGraphOperations(
         val properties: Map<String, Any?>,
     )
 
-    // ConcurrentHashMap: ~5 ns lookup vs Caffeine's ~13-15 ns (TinyLFU 북키핑 비용 제거).
-    // null 값을 허용하지 않으므로 nullable 결과는 Optional 로 래핑한다.
+    // ConcurrentHashMap avoids TinyLFU bookkeeping and keeps lookup overhead low.
+    // It does not allow null values, so nullable results are wrapped in Optional.
     private val vertexByIdCache: ConcurrentHashMap<VertexKey, Optional<GraphVertex>> = ConcurrentHashMap(128)
 
     private val verticesByLabelCache: ConcurrentHashMap<LabelKey, List<GraphVertex>> = ConcurrentHashMap(128)
 
     private val neighborsCache: ConcurrentHashMap<NeighborKey, List<GraphVertex>> = ConcurrentHashMap(128)
 
-    // shortestPath: null 가능 → Optional 래핑
+    // shortestPath can return null, so the cache stores Optional values.
     private val shortestPathCache: ConcurrentHashMap<PathKey, Optional<GraphPath>> = ConcurrentHashMap(128)
 
     private val allPathsCache: ConcurrentHashMap<PathKey, List<GraphPath>> = ConcurrentHashMap(128)
 
     private val edgesByLabelCache: ConcurrentHashMap<EdgeLabelKey, List<GraphEdge>> = ConcurrentHashMap(128)
 
-    // 쓰기 경로 메모이제이션: 동일 인자 create 호출이 반복될 때 DB 라운드트립을 피하기 위한 캐시.
-    // invalidateAll() 이 파괴적 쓰기(updateVertex/deleteVertex/deleteEdge) 시 명시적으로 clear() 한다.
+    // Write-result memoization avoids database round trips for repeated identical create calls.
+    // invalidateAll() clears these maps on destructive writes.
     private val createVertexMap: ConcurrentHashMap<WriteVertexKey, GraphVertex> = ConcurrentHashMap(128)
 
     private val createEdgeMap: ConcurrentHashMap<WriteEdgeKey, GraphEdge> = ConcurrentHashMap(128)
@@ -116,8 +118,7 @@ class CachingNeo4jGraphOperations(
         createEdgeMap.clear()
     }
 
-    // 읽기 캐시만 무효화 (쓰기 메모이제이션 캐시는 보존)
-    // createVertex/createEdge 내부에서 사용하여 write-cache self-destruct 방지
+    // Invalidate only read caches so createVertex/createEdge do not clear their own write caches.
     private fun invalidateReads() {
         vertexByIdCache.clear()
         verticesByLabelCache.clear()
@@ -128,15 +129,15 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * ID로 단일 정점을 조회한다. `null` 결과도 [Optional.empty] 로 캐시하여 다음 동일 호출에서 DB 를 재조회하지 않는다.
-     *
-     * ```kotlin
-     * val first  = ops.findVertexById("Person", id)  // DB 조회
-     * val second = ops.findVertexById("Person", id)  // 캐시 히트 (~5 ns), DB 호출 없음
-     * val absent = ops.findVertexById("Person", unknownId)  // DB 조회 → null 캐시
-     * val again  = ops.findVertexById("Person", unknownId)  // 캐시 히트 → null (DB 재조회 없음)
-     * ```
-     */
+     * Finds one vertex by ID and caches both hits and misses.
+	*
+	 * ```kotlin
+     * val first  = ops.findVertexById("Person", id)         // database lookup
+     * val second = ops.findVertexById("Person", id)         // cache hit
+     * val absent = ops.findVertexById("Person", unknownId)  // database lookup, null cached
+     * val again  = ops.findVertexById("Person", unknownId)  // cache hit, still null
+	 * ```
+	 */
     override fun findVertexById(label: String, id: GraphElementId): GraphVertex? {
         val key = VertexKey(label, id)
         val cached = vertexByIdCache[key]
@@ -147,15 +148,16 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * 레이블과 속성 필터로 정점 목록을 조회한다. `(label, filter)` 쌍을 캐시 키로 사용하므로
-     * 빈 필터와 특정 필터 조합은 각각 독립적으로 캐시된다.
+     * Finds vertices by label and property filter.
      *
-     * ```kotlin
-     * val all   = ops.findVerticesByLabel("Person")                      // DB 조회 후 캐시
-     * val all2  = ops.findVerticesByLabel("Person")                      // 캐시 히트
-     * val alice = ops.findVerticesByLabel("Person", mapOf("name" to "Alice"))  // 별도 캐시 엔트리
-     * ```
-     */
+     * The `(label, filter)` pair is the cache key, so empty and non-empty filters are cached independently.
+	 *
+	 * ```kotlin
+     * val all   = ops.findVerticesByLabel("Person")                             // database lookup
+     * val all2  = ops.findVerticesByLabel("Person")                             // cache hit
+     * val alice = ops.findVerticesByLabel("Person", mapOf("name" to "Alice"))   // separate cache entry
+	 * ```
+	 */
     override fun findVerticesByLabel(label: String, filter: Map<String, Any?>): List<GraphVertex> {
         val key = LabelKey(label, filter)
         val cached = verticesByLabelCache[key]
@@ -166,13 +168,13 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * 이웃 정점 목록을 조회한다. `(startId, options)` 쌍을 캐시 키로 사용한다.
-     *
-     * ```kotlin
-     * val first  = ops.neighbors(aliceId, NeighborOptions.Default)  // DB 조회
-     * val second = ops.neighbors(aliceId, NeighborOptions.Default)  // 캐시 히트
-     * ```
-     */
+     * Finds neighbor vertices and caches by `(startId, options)`.
+	 *
+	 * ```kotlin
+     * val first  = ops.neighbors(aliceId, NeighborOptions.Default)  // database lookup
+     * val second = ops.neighbors(aliceId, NeighborOptions.Default)  // cache hit
+	 * ```
+	 */
     override fun neighbors(startId: GraphElementId, options: NeighborOptions): List<GraphVertex> {
         val key = NeighborKey(startId, options)
         val cached = neighborsCache[key]
@@ -183,13 +185,13 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * 두 정점 사이의 최단 경로를 조회한다. `null` 결과도 캐시하여 경로가 없는 쌍에 대한 반복 쿼리를 방지한다.
-     *
-     * ```kotlin
-     * val path  = ops.shortestPath(aId, bId, PathOptions.Default)  // DB 조회
-     * val path2 = ops.shortestPath(aId, bId, PathOptions.Default)  // 캐시 히트 (null 포함)
-     * ```
-     */
+     * Finds the shortest path between two vertices and caches both hits and misses.
+	 *
+	 * ```kotlin
+     * val path  = ops.shortestPath(aId, bId, PathOptions.Default)  // database lookup
+     * val path2 = ops.shortestPath(aId, bId, PathOptions.Default)  // cache hit, including null
+	 * ```
+	 */
     override fun shortestPath(
         fromId: GraphElementId,
         toId: GraphElementId,
@@ -204,13 +206,13 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * 두 정점 사이의 모든 경로를 조회한다. `(fromId, toId, options)` 쌍을 캐시 키로 사용한다.
-     *
-     * ```kotlin
-     * val paths  = ops.allPaths(aId, bId, PathOptions.Default)  // DB 조회
-     * val paths2 = ops.allPaths(aId, bId, PathOptions.Default)  // 캐시 히트
-     * ```
-     */
+     * Finds all paths between two vertices and caches by `(fromId, toId, options)`.
+	 *
+	 * ```kotlin
+     * val paths  = ops.allPaths(aId, bId, PathOptions.Default)  // database lookup
+     * val paths2 = ops.allPaths(aId, bId, PathOptions.Default)  // cache hit
+	 * ```
+	 */
     override fun allPaths(
         fromId: GraphElementId,
         toId: GraphElementId,
@@ -225,14 +227,16 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * 레이블과 속성 필터로 간선 목록을 조회한다. `(label, filter)` 쌍을 캐시 키로 사용한다.
+     * Finds edges by label and property filter.
      *
-     * ```kotlin
-     * val all      = ops.findEdgesByLabel("KNOWS")                             // DB 조회 후 캐시
-     * val filtered = ops.findEdgesByLabel("KNOWS", mapOf("since" to 2020))     // 별도 캐시 엔트리
-     * val cached   = ops.findEdgesByLabel("KNOWS")                             // 캐시 히트
-     * ```
-     */
+     * The `(label, filter)` pair is the cache key.
+	 *
+	 * ```kotlin
+     * val all      = ops.findEdgesByLabel("KNOWS")                         // database lookup
+     * val filtered = ops.findEdgesByLabel("KNOWS", mapOf("since" to 2020)) // separate cache entry
+     * val cached   = ops.findEdgesByLabel("KNOWS")                         // cache hit
+	 * ```
+	 */
     override fun findEdgesByLabel(label: String, filter: Map<String, Any?>): List<GraphEdge> {
         val key = EdgeLabelKey(label, filter)
         val cached = edgesByLabelCache[key]
@@ -243,17 +247,18 @@ class CachingNeo4jGraphOperations(
     }
 
     /**
-     * 새 정점을 생성하고 결과를 **쓰기 메모이제이션** 캐시에 저장한다.
-     * 동일 `(label, properties)` 인자로 재호출 시 DB 를 거치지 않고 캐시된 [GraphVertex] 를 반환한다.
-     * 읽기 캐시([findVertexById] 등)는 무효화하지만 쓰기 메모이제이션 캐시는 유지된다.
+     * Creates a vertex and stores the result in the write-result memoization cache.
      *
-     * ```kotlin
-     * val a = ops.createVertex("Person", props)  // DB write, 읽기 캐시 무효화
-     * val b = ops.createVertex("Person", props)  // 메모이제이션 히트 — a 와 동일한 객체 반환
-     * ```
-     *
-     * > **주의**: 트랜잭션 기반 insert 의미가 필요하다면 [Neo4jGraphOperations] 를 직접 사용한다.
-     */
+     * Repeating the same `(label, properties)` call returns the cached [GraphVertex] without
+     * another database call. Read caches are invalidated, but write-result caches are retained.
+	 *
+	 * ```kotlin
+     * val a = ops.createVertex("Person", props)  // database write, read caches invalidated
+     * val b = ops.createVertex("Person", props)  // memoized hit, same object as a
+	 * ```
+	 *
+     * > **Note**: use [Neo4jGraphOperations] directly when transactional insert semantics matter.
+	 */
     override fun createVertex(label: String, properties: Map<String, Any?>): GraphVertex {
         val key = WriteVertexKey(label, properties)
         val cached = createVertexMap[key]
@@ -268,40 +273,43 @@ class CachingNeo4jGraphOperations(
         delegate.createVertices(label, propertiesList).also { invalidateAll() }
 
     /**
-     * 기존 정점의 속성을 갱신한다. 갱신 후 **읽기·쓰기 캐시 전체**를 무효화하여 이후 조회가 DB 에서 최신 데이터를 가져온다.
-     *
-     * ```kotlin
-     * ops.updateVertex("Person", id, mapOf("age" to 31))
-     * // 이후 findVertexById, findVerticesByLabel 등 모두 캐시 미스 → DB 재조회
-     * ```
-     */
+     * Updates vertex properties and invalidates all read and write caches.
+	 *
+	 * ```kotlin
+	 * ops.updateVertex("Person", id, mapOf("age" to 31))
+     * // Later findVertexById/findVerticesByLabel calls miss the cache and read fresh data.
+	 * ```
+	 */
     override fun updateVertex(label: String, id: GraphElementId, properties: Map<String, Any?>): GraphVertex? =
         delegate.updateVertex(label, id, properties).also { invalidateAll() }
 
     /**
-     * 정점을 삭제하고 **읽기·쓰기 캐시 전체**를 무효화한다.
-     * `createVertex` 의 쓰기 메모이제이션 캐시도 함께 지워지므로 삭제 후 동일 인자로 재생성하면 DB 에 새 레코드가 생긴다.
+     * Deletes a vertex and invalidates all read and write caches.
      *
-     * ```kotlin
-     * ops.deleteVertex("Person", id)
-     * // createVertex("Person", sameProps) → 쓰기 캐시 미스 → 새 DB 레코드 생성
-     * ```
-     */
+     * The `createVertex` memoization cache is also cleared, so recreating with the same
+     * arguments after deletion creates a new database record.
+	 *
+	 * ```kotlin
+	 * ops.deleteVertex("Person", id)
+     * // createVertex("Person", sameProps) misses the write cache and creates a new record.
+	 * ```
+	 */
     override fun deleteVertex(label: String, id: GraphElementId): Boolean =
         delegate.deleteVertex(label, id).also { invalidateAll() }
 
     /**
-     * 새 간선을 생성하고 결과를 **쓰기 메모이제이션** 캐시에 저장한다.
-     * 동일 `(fromId, toId, label, properties)` 인자로 재호출 시 DB 를 거치지 않고 캐시된 [GraphEdge] 를 반환한다.
-     * 읽기 캐시([findEdgesByLabel] 등)는 무효화하지만 쓰기 메모이제이션 캐시는 유지된다.
+     * Creates an edge and stores the result in the write-result memoization cache.
      *
-     * ```kotlin
-     * val e1 = ops.createEdge(aId, bId, "KNOWS")  // DB write, 읽기 캐시 무효화
-     * val e2 = ops.createEdge(aId, bId, "KNOWS")  // 메모이제이션 히트 — e1 과 동일한 객체 반환
-     * ```
-     *
-     * > **주의**: 트랜잭션 기반 insert 의미가 필요하다면 [Neo4jGraphOperations] 를 직접 사용한다.
-     */
+     * Repeating the same `(fromId, toId, label, properties)` call returns the cached [GraphEdge]
+     * without another database call. Read caches are invalidated, but write-result caches are retained.
+	 *
+	 * ```kotlin
+     * val e1 = ops.createEdge(aId, bId, "KNOWS")  // database write, read caches invalidated
+     * val e2 = ops.createEdge(aId, bId, "KNOWS")  // memoized hit, same object as e1
+	 * ```
+	 *
+     * > **Note**: use [Neo4jGraphOperations] directly when transactional insert semantics matter.
+	 */
     override fun createEdge(
         fromId: GraphElementId,
         toId: GraphElementId,
@@ -321,14 +329,16 @@ class CachingNeo4jGraphOperations(
         delegate.createEdges(label, edges).also { invalidateAll() }
 
     /**
-     * 간선을 삭제하고 **읽기·쓰기 캐시 전체**를 무효화한다.
-     * `createEdge` 의 쓰기 메모이제이션 캐시도 함께 지워지므로 삭제 후 동일 인자로 재생성하면 DB 에 새 레코드가 생긴다.
+     * Deletes an edge and invalidates all read and write caches.
      *
-     * ```kotlin
-     * ops.deleteEdge("KNOWS", edgeId)
-     * // createEdge(aId, bId, "KNOWS") → 쓰기 캐시 미스 → 새 DB 레코드 생성
-     * ```
-     */
+     * The `createEdge` memoization cache is also cleared, so recreating with the same
+     * arguments after deletion creates a new database record.
+	 *
+	 * ```kotlin
+	 * ops.deleteEdge("KNOWS", edgeId)
+     * // createEdge(aId, bId, "KNOWS") misses the write cache and creates a new record.
+	 * ```
+	 */
     override fun deleteEdge(label: String, id: GraphElementId): Boolean =
         delegate.deleteEdge(label, id).also { invalidateAll() }
 

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jCoroutineSession.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jCoroutineSession.kt
@@ -14,29 +14,29 @@ import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.reactivestreams.ReactiveSession
 
 /**
- * Neo4j Java Driver의 Reactive API를 Kotlin Coroutine으로 브릿지.
+ * Bridges the Neo4j Java Driver reactive API to Kotlin coroutines.
  *
- * `org.neo4j.driver.reactivestreams.ReactiveSession`이 반환하는
- * `org.reactivestreams.Publisher<T>`를 `kotlinx-coroutines-reactive`로 변환합니다.
+ * It converts `org.reactivestreams.Publisher<T>` values returned by
+ * `org.neo4j.driver.reactivestreams.ReactiveSession` through `kotlinx-coroutines-reactive`.
  *
- * 소유권: 외부에서 주입된 [Driver]를 [close]에서 닫지 않습니다.
+ * Ownership: [close] does not close the externally provided [Driver].
  *
  * ```kotlin
  * val session = Neo4jCoroutineSession(driver)
  *
- * // 쓰기 쿼리
+ * // Write query
  * val records = session.runWriteQuery(
  *     "CREATE (n:Person {name: $name}) RETURN n",
  *     mapOf("name" to "Alice")
  * )
  *
- * // 읽기 쿼리
+ * // Read query
  * val results = session.runReadQuery("MATCH (n:Person) RETURN n")
  * val vertices = results.map { Neo4jRecordMapper.recordToVertex(it) }
  * ```
  *
- * @param driver Neo4j Java Driver (외부 소유)
- * @param database Neo4j 데이터베이스 이름 (기본: "neo4j")
+ * @param driver externally owned Neo4j Java Driver.
+ * @param database Neo4j database name, defaulting to `"neo4j"`.
  */
 class Neo4jCoroutineSession(
     private val driver: Driver,
@@ -46,7 +46,7 @@ class Neo4jCoroutineSession(
     companion object: KLoggingChannel()
 
     /**
-     * 읽기 전용 트랜잭션 실행.
+     * Runs a read-only reactive session block.
      *
      * ```kotlin
      * val vertices = session.read { s ->
@@ -66,7 +66,7 @@ class Neo4jCoroutineSession(
     }
 
     /**
-     * 쓰기 트랜잭션 실행.
+     * Runs a write reactive session block.
      *
      * ```kotlin
      * session.write { s ->
@@ -86,7 +86,7 @@ class Neo4jCoroutineSession(
     }
 
     /**
-     * 읽기 쿼리를 Flow로 실행하여 Record 목록을 반환합니다.
+     * Runs a read query and returns the materialized records.
      *
      * ```kotlin
      * val records = session.runReadQuery(
@@ -110,7 +110,7 @@ class Neo4jCoroutineSession(
     }
 
     /**
-     * 쓰기 쿼리를 실행하고 Record 목록을 반환합니다.
+     * Runs a write query and returns the materialized records.
      *
      * ```kotlin
      * val records = session.runWriteQuery(
@@ -126,7 +126,7 @@ class Neo4jCoroutineSession(
     }
 
     override fun close() {
-        // driver는 외부 소유이므로 닫지 않음
+        // The driver is externally owned.
     }
 
     private fun sessionConfig(): SessionConfig =

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jCycleFallbackSupport.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jCycleFallbackSupport.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.model.CycleOptions
+import org.neo4j.driver.exceptions.Neo4jException
+
+private val fallbackFailureMarkers = listOf(
+    "not supported",
+    "not implemented",
+    "unsupported",
+    "unknown function",
+    "unknown procedure",
+    "unknown clause",
+)
+
+internal fun Throwable.supportsJvmCycleFallback(): Boolean =
+    diagnosticText().let { text ->
+        fallbackFailureMarkers.any { marker -> marker in text }
+    }
+
+internal fun Throwable.asCycleDetectionFailure(
+    backend: String,
+    options: CycleOptions,
+): GraphQueryException =
+    this as? GraphQueryException
+        ?: GraphQueryException("$backend cycle detection query failed: options=$options", this)
+
+private fun Throwable.diagnosticText(): String =
+    generateSequence(this) { it.cause }
+        .flatMap { throwable ->
+            sequenceOf(
+                throwable.message,
+                (throwable as? Neo4jException)?.code(),
+            )
+        }
+        .filterNotNull()
+        .joinToString(" ")
+        .lowercase()

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphExistsFailures.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphExistsFailures.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.graph.GraphQueryException
+
+private val missingDatabaseMarkers = listOf(
+    "database not found",
+    "database does not exist",
+    "databasenotfound",
+)
+
+internal fun Throwable.isMissingDatabaseFailure(): Boolean =
+    generateSequence(this) { it.cause }
+        .mapNotNull { it.message }
+        .joinToString(" ")
+        .lowercase()
+        .let { text -> missingDatabaseMarkers.any { marker -> marker in text } }
+
+internal fun Throwable.asGraphExistsFailure(backend: String, name: String): GraphQueryException =
+    this as? GraphQueryException
+        ?: GraphQueryException("$backend graphExists failed: graph=$name", this)

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
@@ -596,8 +596,12 @@ class Neo4jGraphOperations(
                 GraphCycle(GraphPath(orderedSteps))
             }
         } catch (e: Exception) {
-            log.debug(e) { "detectCycles via Cypher failed; using JVM fallback" }
-            detectCyclesViaFallback(options)
+            if (e.supportsJvmCycleFallback()) {
+                log.debug(e) { "detectCycles via Cypher is unsupported; using JVM fallback" }
+                detectCyclesViaFallback(options)
+            } else {
+                throw e.asCycleDetectionFailure("Neo4j", options)
+            }
         }
     }
 

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
@@ -106,15 +106,10 @@ class Neo4jGraphOperations(
                 s.run("RETURN 1")
                 true
             }
-        } catch (e: org.neo4j.driver.exceptions.ServiceUnavailableException) {
-            log.warn(e) { "Neo4j service unavailable for database: $name" }
-            false
         } catch (e: org.neo4j.driver.exceptions.DatabaseException) {
-            log.warn(e) { "Neo4j database error checking graphExists for: $name" }
-            false
+            if (e.isMissingDatabaseFailure()) false else throw e.asGraphExistsFailure("Neo4j", name)
         } catch (e: Exception) {
-            log.warn(e) { "Unexpected error checking graphExists for: $name" }
-            false
+            throw e.asGraphExistsFailure("Neo4j", name)
         }
     }
 

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperations.kt
@@ -48,9 +48,9 @@ import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.Transaction
 
 /**
- * Neo4j Java Driver 기반 [GraphOperations] 구현체 (동기 방식).
+ * Blocking [GraphOperations] implementation backed by the Neo4j Java Driver.
  *
- * blocking [Session]을 사용한다.
+ * It uses blocking [Session] instances and does not own the supplied [Driver].
  *
  *
  * ```kotlin
@@ -66,8 +66,8 @@ import org.neo4j.driver.Transaction
  * driver.close()
  * ```
  *
- * @param driver Neo4j Java Driver (외부 소유)
- * @param database 데이터베이스 이름 (기본: "neo4j")
+ * @param driver externally owned Neo4j Java Driver.
+ * @param database Neo4j database name, defaulting to `"neo4j"`.
  */
 class Neo4jGraphOperations(
     private val driver: Driver,
@@ -113,7 +113,7 @@ class Neo4jGraphOperations(
         }
     }
 
-    override fun close() { /* driver는 외부 소유 */
+    override fun close() { /* driver is externally owned */
     }
 
     override fun schemaManager(): GraphSchemaManager =

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSchemaManager.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSchemaManager.kt
@@ -13,9 +13,9 @@ import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.Value
 
 /**
- * Neo4j Cypher DDL 기반 스키마 관리자.
+ * Schema manager backed by Neo4j Cypher DDL.
  *
- * 정점 레이블의 단일 속성 인덱스와 유니크 제약조건을 관리한다.
+ * It manages single-property indexes and unique constraints for vertex labels.
  */
 class Neo4jGraphSchemaManager(
     private val driver: Driver,

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSuspendOperations.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSuspendOperations.kt
@@ -73,8 +73,8 @@ import org.neo4j.driver.reactivestreams.ReactiveTransaction
  * }
  * ```
  *
- * @param driver Neo4j Java Driver (외부 소유)
- * @param database 데이터베이스 이름 (기본: "neo4j")
+ * @param driver externally owned Neo4j Java Driver.
+ * @param database Neo4j database name, defaulting to `"neo4j"`.
  */
 class Neo4jGraphSuspendOperations(
     private val driver: Driver,
@@ -202,7 +202,7 @@ class Neo4jGraphSuspendOperations(
         }
 
     /**
-     * 단일값/삭제 등 suspend 메서드용 쿼리 헬퍼.
+     * Query helper for suspend methods that materialize records immediately.
      */
     private suspend fun <T> runQuery(
         cypher: String,
@@ -221,9 +221,9 @@ class Neo4jGraphSuspendOperations(
     }
 
     /**
-     * 컬렉션 [Flow] 반환용 쿼리 헬퍼.
-     *
-     * 취소 시에도 세션이 안전하게 닫히도록 [NonCancellable]을 사용한다.
+     * Query helper for methods that return [Flow] collections.
+	*
+     * Uses [NonCancellable] so the session closes safely even when the caller is cancelled.
      */
     private fun <T> flowQuery(
         cypher: String,
@@ -269,7 +269,7 @@ class Neo4jGraphSuspendOperations(
         }
     }
 
-    override fun close() { /* driver는 외부 소유 */
+    override fun close() { /* driver is externally owned */
     }
 
     // -- GraphSuspendVertexRepository --

--- a/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jRecordMapper.kt
+++ b/graph/graph-neo4j/src/main/kotlin/io/bluetape4k/graph/neo4j/Neo4jRecordMapper.kt
@@ -13,15 +13,15 @@ import org.neo4j.driver.types.Path
 import org.neo4j.driver.types.Relationship
 
 /**
- * Neo4j Driver [Record]를 Graph 모델로 변환합니다.
+ * Converts Neo4j Driver [Record] values to graph model objects.
  *
  * ```kotlin
- * // 단독 사용 예
+ * // Record-level helpers
  * val vertex: GraphVertex = Neo4jRecordMapper.recordToVertex(record)          // key="n"
  * val edge: GraphEdge     = Neo4jRecordMapper.recordToEdge(record, key="r")
  * val path: GraphPath     = Neo4jRecordMapper.recordToPath(record, key="p")
  *
- * // nodeToVertex / relationshipToEdge 직접 사용
+ * // Direct Node/Relationship helpers
  * val node: Node = record["n"].asNode()
  * val vertex = Neo4jRecordMapper.nodeToVertex(node)
  * ```
@@ -29,18 +29,18 @@ import org.neo4j.driver.types.Relationship
 object Neo4jRecordMapper: KLogging() {
 
     /**
-     * Neo4j [Node]를 [GraphVertex]로 변환합니다.
-     *
-     * 노드의 첫 번째 레이블을 [GraphVertex.label]로 사용하며, 레이블이 없으면 "Unknown"을 사용합니다.
+     * Converts a Neo4j [Node] to a [GraphVertex].
+	*
+     * The first node label becomes [GraphVertex.label]; nodes without labels use `"Unknown"`.
      *
      * ```kotlin
      * val node = record["n"].asNode()
      * val vertex = Neo4jRecordMapper.nodeToVertex(node)
-     * println(vertex.label)  // 노드의 첫 번째 레이블
+     * println(vertex.label)  // first node label
      * ```
      *
-     * @param node Neo4j Driver Node 객체.
-     * @return 변환된 [GraphVertex].
+     * @param node Neo4j Driver node.
+     * @return converted [GraphVertex].
      */
     fun nodeToVertex(node: Node): GraphVertex {
         val id = GraphElementId(node.elementId())
@@ -50,16 +50,16 @@ object Neo4jRecordMapper: KLogging() {
     }
 
     /**
-     * Neo4j [Relationship]을 [GraphEdge]로 변환합니다.
+     * Converts a Neo4j [Relationship] to a [GraphEdge].
      *
      * ```kotlin
      * val rel = record["r"].asRelationship()
      * val edge = Neo4jRecordMapper.relationshipToEdge(rel)
-     * println(edge.label)  // 관계 타입
+     * println(edge.label)  // relationship type
      * ```
      *
-     * @param rel Neo4j Driver Relationship 객체.
-     * @return 변환된 [GraphEdge].
+     * @param rel Neo4j Driver relationship.
+     * @return converted [GraphEdge].
      */
     fun relationshipToEdge(rel: Relationship): GraphEdge {
         val id = GraphElementId(rel.elementId())
@@ -69,17 +69,17 @@ object Neo4jRecordMapper: KLogging() {
     }
 
     /**
-     * Neo4j [Path]를 [GraphPath]로 변환합니다.
-     *
-     * 노드와 관계를 교대로 [PathStep.VertexStep] / [PathStep.EdgeStep]으로 변환합니다.
+     * Converts a Neo4j [Path] to a [GraphPath].
+	*
+     * Nodes and relationships are converted to alternating [PathStep.VertexStep] and [PathStep.EdgeStep] values.
      *
      * ```kotlin
      * val path = Neo4jRecordMapper.pathToGraphPath(record["p"].asPath())
-     * println(path.length)  // 경로 단계 수
+     * println(path.length)  // number of path steps
      * ```
      *
-     * @param path Neo4j Driver Path 객체.
-     * @return 변환된 [GraphPath].
+     * @param path Neo4j Driver path.
+     * @return converted [GraphPath].
      */
     fun pathToGraphPath(path: Path): GraphPath {
         val steps = mutableListOf<PathStep>()
@@ -96,16 +96,16 @@ object Neo4jRecordMapper: KLogging() {
     }
 
     /**
-     * [Record]에서 [GraphVertex]를 추출합니다.
+     * Extracts a [GraphVertex] from a [Record].
      *
      * ```kotlin
      * val vertex = Neo4jRecordMapper.recordToVertex(record)        // key="n"
      * val vertex2 = Neo4jRecordMapper.recordToVertex(record, "node")
      * ```
      *
-     * @param record Cypher 쿼리 결과 레코드.
-     * @param key 레코드에서 노드를 추출할 키 (기본: "n").
-     * @return 변환된 [GraphVertex].
+     * @param record Cypher query result record.
+     * @param key key used to extract the node, defaulting to `"n"`.
+     * @return converted [GraphVertex].
      */
     fun recordToVertex(record: Record, key: String = "n"): GraphVertex {
         key.requireNotBlank("key")
@@ -114,16 +114,16 @@ object Neo4jRecordMapper: KLogging() {
 
 
     /**
-     * [Record]에서 [GraphEdge]를 추출합니다.
+     * Extracts a [GraphEdge] from a [Record].
      *
      * ```kotlin
      * val edge = Neo4jRecordMapper.recordToEdge(record)        // key="r"
      * val edge2 = Neo4jRecordMapper.recordToEdge(record, "rel")
      * ```
      *
-     * @param record Cypher 쿼리 결과 레코드.
-     * @param key 레코드에서 관계를 추출할 키 (기본: "r").
-     * @return 변환된 [GraphEdge].
+     * @param record Cypher query result record.
+     * @param key key used to extract the relationship, defaulting to `"r"`.
+     * @return converted [GraphEdge].
      */
     fun recordToEdge(record: Record, key: String = "r"): GraphEdge {
         key.requireNotBlank("key")
@@ -131,15 +131,15 @@ object Neo4jRecordMapper: KLogging() {
     }
 
     /**
-     * [Record]에서 [GraphPath]를 추출합니다.
+     * Extracts a [GraphPath] from a [Record].
      *
      * ```kotlin
      * val path = Neo4jRecordMapper.recordToPath(record)        // key="p"
      * ```
      *
-     * @param record Cypher 쿼리 결과 레코드.
-     * @param key 레코드에서 경로를 추출할 키 (기본: "p").
-     * @return 변환된 [GraphPath].
+     * @param record Cypher query result record.
+     * @param key key used to extract the path, defaulting to `"p"`.
+     * @return converted [GraphPath].
      */
     fun recordToPath(record: Record, key: String = "p"): GraphPath {
         key.requireNotBlank("key")

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jCycleFallbackSupportTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jCycleFallbackSupportTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.model.CycleOptions
+import org.junit.jupiter.api.Test
+
+class Neo4jCycleFallbackSupportTest {
+
+    @Test
+    fun `known unsupported cycle query can use JVM fallback`() {
+        RuntimeException("cycle pattern is not supported by this backend")
+            .supportsJvmCycleFallback()
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `unexpected cycle query failure is not treated as fallback`() {
+        IllegalStateException("connection reset while reading records")
+            .supportsJvmCycleFallback()
+            .shouldBeFalse()
+    }
+
+    @Test
+    fun `unexpected cycle query failure keeps backend context`() {
+        val cause = IllegalStateException("connection reset while reading records")
+        val ex = cause.asCycleDetectionFailure("Neo4j", CycleOptions(edgeLabel = "E"))
+
+        ex.message shouldContain "Neo4j cycle detection query failed"
+        ex.cause shouldBeInstanceOf IllegalStateException::class
+    }
+}

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperationsTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphOperationsTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.graph.neo4j
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.graph.GraphQueryException
 import io.bluetape4k.graph.model.Direction
 import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.NeighborOptions
@@ -17,8 +18,11 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeEmpty
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -29,6 +33,8 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
+import org.neo4j.driver.SessionConfig
+import org.neo4j.driver.exceptions.ServiceUnavailableException
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class Neo4jGraphOperationsTest {
@@ -65,6 +71,21 @@ class Neo4jGraphOperationsTest {
 
     @Test
     @Order(11)
+    fun `graphExists preserves driver failures`() {
+        val failingDriver = mockk<Driver>()
+        every { failingDriver.session(any<SessionConfig>()) } throws ServiceUnavailableException("neo4j unavailable")
+        val failingOps = Neo4jGraphOperations(failingDriver)
+
+        val ex = assertFailsWith<GraphQueryException> {
+            failingOps.graphExists("default")
+        }
+
+        ex.message shouldContain "Neo4j graphExists failed"
+        ex.cause shouldBeInstanceOf ServiceUnavailableException::class
+    }
+
+    @Test
+    @Order(12)
     fun `dropGraph로 전체 데이터를 삭제한다`() = runSuspendIO {
         ops.createVertex("Person", mapOf("name" to "Alice"))
         ops.countVertices("Person") shouldBeGreaterOrEqualTo 1L

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -113,7 +113,7 @@ class TinkerGraphOperations :
 
     override fun <T> transaction(block: GraphTransactionScope.() -> T): T =
         withTransactionGate {
-            synchronized(graph) {
+            writeLock.withLock {
                 val snapshot = snapshot()
                 try {
                     block(TinkerGraphTransactionScope(this))
@@ -136,12 +136,12 @@ class TinkerGraphOperations :
     }
 
     internal fun createTransactionSnapshot(): Any =
-        synchronized(graph) {
+        writeLock.withLock {
             snapshot()
         }
 
     internal fun restoreTransactionSnapshot(snapshot: Any) {
-        synchronized(graph) {
+        writeLock.withLock {
             restore(snapshot as TinkerGraphSnapshot)
         }
     }
@@ -277,7 +277,7 @@ class TinkerGraphOperations :
         setProperties: Map<String, Any?>,
     ): GraphVertex =
         withTransactionGate {
-            synchronized(graph) {
+            writeLock.withLock {
                 val properties = GraphMergeValidation.validateVertex(label, matchProperties, setProperties)
                 val traversal = g.V().hasLabel(label)
                 properties.matchProperties.forEach { (key, value) ->
@@ -426,7 +426,7 @@ class TinkerGraphOperations :
         setProperties: Map<String, Any?>,
     ): GraphEdge =
         withTransactionGate {
-            synchronized(graph) {
+            writeLock.withLock {
                 val properties = GraphMergeValidation.validateEdge(fromId, toId, label, matchProperties, setProperties)
                 val fromIdValue = fromId.value.toLongOrNull()
                     ?: throw GraphQueryException("Invalid fromId: ${fromId.value}")

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphOperations.kt
@@ -521,8 +521,7 @@ class TinkerGraphOperations :
                 .limit(1)
                 .toList()
         } catch (e: Exception) {
-            log.warn(e) { "shortestPath traversal failed: from=$fromId to=$toId options=$options" }
-            emptyList()
+            throw tinkerGraphTraversalFailure("shortestPath", fromId, toId, options, e)
         }
 
         // Post-process: vertex-only paths from both() need edges inserted between consecutive vertices.
@@ -561,8 +560,7 @@ class TinkerGraphOperations :
                 .path()
                 .toList()
         } catch (e: Exception) {
-            log.warn(e) { "allPaths traversal failed: from=$fromId to=$toId options=$options" }
-            emptyList()
+            throw tinkerGraphTraversalFailure("allPaths", fromId, toId, options, e)
         }
 
         // Post-process: vertex-only paths from both() need edges inserted between consecutive vertices.

--- a/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphTraversalFailures.kt
+++ b/graph/graph-tinkerpop/src/main/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphTraversalFailures.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.graph.tinkerpop
+
+import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.PathOptions
+
+internal fun tinkerGraphTraversalFailure(
+    operation: String,
+    fromId: GraphElementId,
+    toId: GraphElementId,
+    options: PathOptions,
+    cause: Exception,
+): GraphQueryException =
+    cause as? GraphQueryException
+        ?: GraphQueryException(
+            "TinkerGraph $operation traversal failed: from=${fromId.value}, to=${toId.value}, options=$options",
+            cause,
+        )

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphTraversalFailuresTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphTraversalFailuresTest.kt
@@ -1,0 +1,44 @@
+package io.bluetape4k.graph.tinkerpop
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.model.GraphElementId
+import io.bluetape4k.graph.model.PathOptions
+import org.junit.jupiter.api.Test
+
+class TinkerGraphTraversalFailuresTest {
+
+    @Test
+    fun `unexpected traversal failure is wrapped with backend context`() {
+        val cause = IllegalStateException("traversal engine failed")
+
+        val ex = tinkerGraphTraversalFailure(
+            operation = "shortestPath",
+            fromId = GraphElementId.of("1"),
+            toId = GraphElementId.of("2"),
+            options = PathOptions(edgeLabel = "KNOWS"),
+            cause = cause,
+        )
+
+        ex.message shouldContain "TinkerGraph shortestPath traversal failed"
+        ex.message shouldContain "from=1"
+        ex.message shouldContain "to=2"
+        ex.cause shouldBeInstanceOf IllegalStateException::class
+    }
+
+    @Test
+    fun `existing GraphQueryException is preserved`() {
+        val original = GraphQueryException("already contextual")
+
+        val ex = tinkerGraphTraversalFailure(
+            operation = "allPaths",
+            fromId = GraphElementId.of("1"),
+            toId = GraphElementId.of("2"),
+            options = PathOptions(),
+            cause = original,
+        )
+
+        ex.message shouldContain "already contextual"
+    }
+}

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/AgeGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/AgeGraphPluginConfig.kt
@@ -33,13 +33,5 @@ fun GraphPluginConfig.age(
         backendName = "age",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("AgeGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("AgeGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/FalkorDBGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/FalkorDBGraphPluginConfig.kt
@@ -33,13 +33,5 @@ fun GraphPluginConfig.falkorDB(
         backendName = "falkorDB",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("FalkorDBGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("FalkorDBGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/MemgraphGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/MemgraphGraphPluginConfig.kt
@@ -34,13 +34,5 @@ fun GraphPluginConfig.memgraph(
         backendName = "memgraph",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("MemgraphGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("MemgraphGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/Neo4jGraphPluginConfig.kt
+++ b/ktor/graph-ktor/src/main/kotlin/io/bluetape4k/graph/ktor/Neo4jGraphPluginConfig.kt
@@ -33,13 +33,5 @@ fun GraphPluginConfig.neo4j(
         backendName = "neo4j",
         graphOperationsFactory = { graphOperations },
         graphSuspendOperationsFactory = { graphSuspendOperations },
-        closeActions = listOf(
-            GraphPluginCloseAction("Neo4jGraphOperations") {
-                graphOperations.close()
-            },
-            GraphPluginCloseAction("Neo4jGraphSuspendOperations") {
-                graphSuspendOperations.close()
-            },
-        ),
     )
 }

--- a/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
+++ b/ktor/graph-ktor/src/test/kotlin/io/bluetape4k/graph/ktor/GraphPluginTest.kt
@@ -136,6 +136,40 @@ class GraphPluginTest {
     }
 
     @Test
+    fun `caller owned backend helper 는 close action 을 등록하지 않는다`() {
+        GraphPluginConfig()
+            .neo4j(mockk(), database = "neo4j")
+            .closeActions.size shouldBeEqualTo 0
+
+        GraphPluginConfig()
+            .memgraph(mockk(), database = "memgraph")
+            .closeActions.size shouldBeEqualTo 0
+
+        GraphPluginConfig()
+            .falkorDB(mockk(), graphName = "graph")
+            .closeActions.size shouldBeEqualTo 0
+
+        GraphPluginConfig()
+            .age("graph")
+            .closeActions.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `managed backend DSL 은 plugin owned close action 을 등록한다`() {
+        val neo4jConfig = GraphPluginConfig().neo4j {
+            uri = "bolt://localhost:7687"
+        }
+        neo4jConfig.closeActions.size shouldBeEqualTo 3
+        neo4jConfig.resolveState().close()
+
+        val memgraphConfig = GraphPluginConfig().memgraph {
+            uri = "bolt://localhost:7687"
+        }
+        memgraphConfig.closeActions.size shouldBeEqualTo 3
+        memgraphConfig.resolveState().close()
+    }
+
+    @Test
     fun `managed backend DSL 은 잘못된 property 를 fail fast 한다`() {
         assertFailsWith<IllegalArgumentException> {
             GraphPluginConfig().neo4j {

--- a/spring-boot/graph-spring-boot/README.ko.md
+++ b/spring-boot/graph-spring-boot/README.ko.md
@@ -1,5 +1,7 @@
 # graph-spring-boot
 
+[English](README.md) | 한국어
+
 [bluetape4k-graph](../../README.ko.md)용 Spring Boot 4 Auto-configuration 통합 모듈.
 
 단일 설정 프로퍼티로 원하는 그래프 백엔드를 선택하면, `GraphOperations`, `GraphSuspendOperations`,

--- a/spring-boot/graph-spring-boot/README.md
+++ b/spring-boot/graph-spring-boot/README.md
@@ -1,5 +1,7 @@
 # graph-spring-boot
 
+English | [한국어](README.ko.md)
+
 Spring Boot 4 auto-configuration integration for [bluetape4k-graph](../../README.md).
 
 Registers `GraphOperations`, `GraphSuspendOperations`, and `GraphVirtualThreadOperations` beans

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
@@ -63,16 +63,18 @@ class GraphAgeAutoConfiguration {
     companion object : KLogging()
 
     /**
-     * Exposed Database 빈 — AGE DataSource에 연결.
+     * Connects an Exposed [Database] to the AGE-backed [DataSource].
      *
-     * **필수**: `application.yml`에 아래 설정을 추가해야 AGE extension이 올바르게 로드된다.
+     * Applications must configure the Hikari connection initialization SQL so
+     * the AGE extension is loaded before graph operations run:
      * ```yaml
      * spring:
      *   datasource:
      *     hikari:
      *       connection-init-sql: "LOAD 'age'; SET search_path = ag_catalog, \"$user\", public;"
      * ```
-     * HikariCP 풀은 시작 후 설정이 봉인(seal)되므로 AutoConfiguration에서 직접 설정할 수 없다.
+     * HikariCP seals pool configuration after startup, so this auto-configuration
+     * documents the required setting instead of mutating the pool at runtime.
      */
     @Bean(name = ["ageExposedDatabase"])
     @DependsOn("dataSource")
@@ -83,9 +85,8 @@ class GraphAgeAutoConfiguration {
     }
 
     /**
-     * AGE 기반 `GraphOperations` 빈. 구체 타입 `AgeGraphOperations`를 반환한다.
-     *
-     * 사용자가 `GraphOperations` 빈을 직접 등록하면 이 빈은 생성되지 않는다.
+     * Registers AGE-backed [GraphOperations] when the application has not
+     * provided its own graph operations bean.
      */
     @Bean
     @ConditionalOnMissingBean(GraphOperations::class)
@@ -96,7 +97,7 @@ class GraphAgeAutoConfiguration {
     }
 
     /**
-     * AGE 그래프 초기화 빈 — `createGraph()` API로 그래프를 생성한다.
+     * Initializes the configured AGE graph with `createGraph()` when auto-create is enabled.
      */
     @Bean(name = ["ageGraphInitializer"])
     @DependsOn("graphOperations")
@@ -121,7 +122,7 @@ class GraphAgeAutoConfiguration {
         }
 
     /**
-     * AGE 기반 `GraphSuspendOperations` 빈 (코루틴).
+     * Registers coroutine-friendly AGE graph operations when suspend support is enabled.
      */
     @Bean
     @ConditionalOnMissingBean(GraphSuspendOperations::class)
@@ -138,7 +139,7 @@ class GraphAgeAutoConfiguration {
     }
 
     /**
-     * Virtual Thread 기반 `GraphVirtualThreadOperations` 빈.
+     * Registers virtual-thread graph operations backed by the synchronous AGE operations.
      */
     @Bean
     @ConditionalOnMissingBean(GraphVirtualThreadOperations::class)
@@ -153,8 +154,8 @@ class GraphAgeAutoConfiguration {
         ops.asVirtualThread()
 
     /**
-     * Actuator HealthIndicator — nested class로 격리.
-     * Actuator 미사용 앱에서 `NoClassDefFoundError` 방지.
+     * Isolates the Actuator health indicator so non-Actuator applications avoid
+     * `NoClassDefFoundError`.
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfiguration.kt
@@ -18,7 +18,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
-import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -49,8 +48,13 @@ import javax.sql.DataSource
  * val operations = context.getBean(GraphOperations::class.java)
  * ```
  */
-@AutoConfiguration(after = [DataSourceAutoConfiguration::class])
-@ConditionalOnClass(AgeGraphOperations::class, DataSource::class)
+@AutoConfiguration(afterName = ["org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"])
+@ConditionalOnClass(
+    name = [
+        "io.bluetape4k.graph.age.AgeGraphOperations",
+        "javax.sql.DataSource",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "age")
 @ConditionalOnSingleCandidate(DataSource::class)
 @EnableConfigurationProperties(AgeGraphProperties::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfiguration.kt
@@ -29,12 +29,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * ```
  */
 @AutoConfiguration(
-    before = [
-        GraphTinkerGraphAutoConfiguration::class,
-        GraphNeo4jAutoConfiguration::class,
-        GraphMemgraphAutoConfiguration::class,
-        GraphAgeAutoConfiguration::class,
-        GraphFalkorDBAutoConfiguration::class,
+    beforeName = [
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphTinkerGraphAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphNeo4jAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphMemgraphAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphAgeAutoConfiguration",
+        "io.bluetape4k.graph.spring.boot.autoconfigure.GraphFalkorDBAutoConfiguration",
     ],
 )
 @EnableConfigurationProperties(GraphProperties::class)

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphFalkorDBAutoConfiguration.kt
@@ -43,7 +43,12 @@ import org.springframework.context.annotation.Configuration
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(com.falkordb.Driver::class, FalkorDBGraphOperations::class)
+@ConditionalOnClass(
+    name = [
+        "com.falkordb.Driver",
+        "io.bluetape4k.graph.falkordb.FalkorDBGraphOperations",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "falkordb")
 @EnableConfigurationProperties(FalkorDBGraphProperties::class)
 class GraphFalkorDBAutoConfiguration {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -80,7 +80,7 @@ class GraphMemgraphAutoConfiguration {
     }
 
     /**
-     * Memgraph 기반 `GraphOperations` 빈.
+     * Registers Memgraph-backed [GraphOperations] for the configured database.
      */
     @Bean
     @ConditionalOnMissingBean(GraphOperations::class)
@@ -91,7 +91,7 @@ class GraphMemgraphAutoConfiguration {
         MemgraphGraphOperations(driver, props.database)
 
     /**
-     * Memgraph 기반 `GraphSuspendOperations` 빈 (코루틴).
+     * Registers coroutine-friendly Memgraph graph operations when suspend support is enabled.
      */
     @Bean
     @ConditionalOnMissingBean(GraphSuspendOperations::class)
@@ -108,7 +108,7 @@ class GraphMemgraphAutoConfiguration {
         MemgraphGraphSuspendOperations(driver, props.database)
 
     /**
-     * Virtual Thread 기반 `GraphVirtualThreadOperations` 빈.
+     * Registers virtual-thread graph operations backed by the synchronous Memgraph operations.
      */
     @Bean
     @ConditionalOnMissingBean(GraphVirtualThreadOperations::class)
@@ -122,8 +122,8 @@ class GraphMemgraphAutoConfiguration {
         ops.asVirtualThread()
 
     /**
-     * Actuator HealthIndicator — nested class로 격리.
-     * Actuator 미사용 앱에서 `NoClassDefFoundError` 방지.
+     * Isolates the Actuator health indicator so non-Actuator applications avoid
+     * `NoClassDefFoundError`.
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -47,7 +47,12 @@ import java.util.concurrent.TimeUnit
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(Driver::class, MemgraphGraphOperations::class)
+@ConditionalOnClass(
+    name = [
+        "org.neo4j.driver.Driver",
+        "io.bluetape4k.graph.memgraph.MemgraphGraphOperations",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "memgraph")
 @EnableConfigurationProperties(MemgraphGraphProperties::class)
 class GraphMemgraphAutoConfiguration {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfiguration.kt
@@ -13,6 +13,7 @@ import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Config
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -54,11 +55,13 @@ class GraphMemgraphAutoConfiguration {
     companion object : KLogging()
 
     /**
-     * Memgraph Driver 빈. 이미 등록된 Driver 빈이 있으면 재사용한다.
-     * Memgraph는 Neo4j Bolt 프로토콜 호환이므로 Neo4j `GraphDatabase.driver()`를 사용한다.
+     * Memgraph driver bean.
+     *
+     * Memgraph uses the Neo4j Bolt-compatible Java driver. Only a bean explicitly named
+     * `memgraphDriver` is reused, because a generic [Driver] bean may belong to a Neo4j backend.
      */
     @Bean(name = ["memgraphDriver"], destroyMethod = "close")
-    @ConditionalOnMissingBean(Driver::class)
+    @ConditionalOnMissingBean(name = ["memgraphDriver"])
     fun memgraphDriver(props: MemgraphGraphProperties): Driver {
         val auth = if (props.username.isBlank() || props.password.isBlank()) AuthTokens.none()
                    else AuthTokens.basic(props.username, props.password)
@@ -76,7 +79,10 @@ class GraphMemgraphAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(GraphOperations::class)
-    fun graphOperations(driver: Driver, props: MemgraphGraphProperties): GraphOperations =
+    fun graphOperations(
+        @Qualifier("memgraphDriver") driver: Driver,
+        props: MemgraphGraphProperties,
+    ): GraphOperations =
         MemgraphGraphOperations(driver, props.database)
 
     /**
@@ -90,7 +96,10 @@ class GraphMemgraphAutoConfiguration {
         havingValue = "true",
         matchIfMissing = true,
     )
-    fun graphSuspendOperations(driver: Driver, props: MemgraphGraphProperties): GraphSuspendOperations =
+    fun graphSuspendOperations(
+        @Qualifier("memgraphDriver") driver: Driver,
+        props: MemgraphGraphProperties,
+    ): GraphSuspendOperations =
         MemgraphGraphSuspendOperations(driver, props.database)
 
     /**
@@ -119,7 +128,9 @@ class GraphMemgraphAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        fun memgraphHealthIndicator(driver: Driver): org.springframework.boot.health.contributor.HealthIndicator =
+        fun memgraphHealthIndicator(
+            @Qualifier("memgraphDriver") driver: Driver,
+        ): org.springframework.boot.health.contributor.HealthIndicator =
             org.springframework.boot.health.contributor.HealthIndicator {
                 try {
                     driver.verifyConnectivity()

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
@@ -59,7 +59,7 @@ class GraphNeo4jAutoConfiguration {
     companion object : KLogging()
 
     /**
-     * Neo4j Driver 빈. 이미 등록된 Driver 빈이 있으면 재사용한다.
+     * Creates the Neo4j [Driver] when the application has not provided one.
      */
     @Bean(name = ["neo4jDriver"], destroyMethod = "close")
     @ConditionalOnMissingBean(Driver::class)
@@ -76,7 +76,7 @@ class GraphNeo4jAutoConfiguration {
     }
 
     /**
-     * Neo4j 기반 `GraphOperations` 빈.
+     * Registers Neo4j-backed [GraphOperations] for the configured database.
      */
     @Bean
     @ConditionalOnMissingBean(GraphOperations::class)
@@ -84,7 +84,7 @@ class GraphNeo4jAutoConfiguration {
         Neo4jGraphOperations(driver, props.database)
 
     /**
-     * Neo4j 기반 `GraphSuspendOperations` 빈 (코루틴).
+     * Registers coroutine-friendly Neo4j graph operations when suspend support is enabled.
      */
     @Bean
     @ConditionalOnMissingBean(GraphSuspendOperations::class)
@@ -98,7 +98,7 @@ class GraphNeo4jAutoConfiguration {
         Neo4jGraphSuspendOperations(driver, props.database)
 
     /**
-     * Virtual Thread 기반 `GraphVirtualThreadOperations` 빈.
+     * Registers virtual-thread graph operations backed by the synchronous Neo4j operations.
      */
     @Bean
     @ConditionalOnMissingBean(GraphVirtualThreadOperations::class)
@@ -112,8 +112,8 @@ class GraphNeo4jAutoConfiguration {
         ops.asVirtualThread()
 
     /**
-     * Actuator HealthIndicator — nested class로 격리.
-     * Actuator 미사용 앱에서 `NoClassDefFoundError` 방지.
+     * Isolates the Actuator health indicator so non-Actuator applications avoid
+     * `NoClassDefFoundError`.
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfiguration.kt
@@ -46,7 +46,12 @@ import java.util.concurrent.TimeUnit
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(Driver::class, Neo4jGraphOperations::class)
+@ConditionalOnClass(
+    name = [
+        "org.neo4j.driver.Driver",
+        "io.bluetape4k.graph.neo4j.Neo4jGraphOperations",
+    ]
+)
 @ConditionalOnProperty(prefix = "bluetape4k.graph", name = ["backend"], havingValue = "neo4j")
 @EnableConfigurationProperties(Neo4jGraphProperties::class)
 class GraphNeo4jAutoConfiguration {

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -54,9 +54,8 @@ class GraphTinkerGraphAutoConfiguration {
     companion object : KLogging()
 
     /**
-     * TinkerGraph 기반 `GraphOperations` 빈.
-     *
-     * 사용자가 `GraphOperations` 빈을 직접 등록하면 이 빈은 생성되지 않는다.
+     * Registers in-memory TinkerGraph operations when the application has not
+     * provided its own graph operations bean.
      */
     @Bean(destroyMethod = "close")
     @ConditionalOnMissingBean(GraphOperations::class)
@@ -66,7 +65,7 @@ class GraphTinkerGraphAutoConfiguration {
     }
 
     /**
-     * TinkerGraph 기반 `GraphSuspendOperations` 빈.
+     * Registers coroutine-friendly TinkerGraph operations when suspend support is enabled.
      */
     @Bean
     @ConditionalOnMissingBean(GraphSuspendOperations::class)
@@ -80,7 +79,7 @@ class GraphTinkerGraphAutoConfiguration {
         TinkerGraphSuspendOperations(ops)
 
     /**
-     * Virtual Thread 기반 `GraphVirtualThreadOperations` 빈.
+     * Registers virtual-thread graph operations backed by the synchronous TinkerGraph operations.
      */
     @Bean
     @ConditionalOnMissingBean(GraphVirtualThreadOperations::class)
@@ -94,8 +93,8 @@ class GraphTinkerGraphAutoConfiguration {
         ops.asVirtualThread()
 
     /**
-     * Actuator HealthIndicator — nested class로 격리.
-     * Actuator 미사용 앱에서 `NoClassDefFoundError` 방지.
+     * Isolates the Actuator health indicator so non-Actuator applications avoid
+     * `NoClassDefFoundError`.
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(name = ["org.springframework.boot.health.contributor.HealthIndicator"])

--- a/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
+++ b/spring-boot/graph-spring-boot/src/main/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfiguration.kt
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Configuration
  * ```
  */
 @AutoConfiguration
-@ConditionalOnClass(TinkerGraphOperations::class)
+@ConditionalOnClass(name = ["io.bluetape4k.graph.tinkerpop.TinkerGraphOperations"])
 @ConditionalOnProperty(
     prefix = "bluetape4k.graph",
     name = ["backend"],

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfigurationClasspathTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAutoConfigurationClasspathTest.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.graph.spring.boot.autoconfigure
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GraphAutoConfigurationClasspathTest {
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                GraphAutoConfiguration::class.java,
+                GraphAgeAutoConfiguration::class.java,
+                GraphFalkorDBAutoConfiguration::class.java,
+                GraphMemgraphAutoConfiguration::class.java,
+                GraphNeo4jAutoConfiguration::class.java,
+                GraphTinkerGraphAutoConfiguration::class.java,
+            )
+        )
+
+    @Test
+    fun `missing optional AGE backend classes back off without startup failure`() {
+        runner
+            .withClassLoader(FilteredClassLoader("io.bluetape4k.graph.age"))
+            .withPropertyValues("bluetape4k.graph.backend=age")
+            .run { ctx ->
+                ctx.startupFailure.shouldBeNull()
+                ctx.containsBean("graphOperations").shouldBeFalse()
+            }
+    }
+
+    @Test
+    fun `missing optional Memgraph backend classes back off without startup failure`() {
+        runner
+            .withClassLoader(FilteredClassLoader("io.bluetape4k.graph.memgraph"))
+            .withPropertyValues("bluetape4k.graph.backend=memgraph")
+            .run { ctx ->
+                ctx.startupFailure.shouldBeNull()
+                ctx.containsBean("graphOperations").shouldBeFalse()
+            }
+    }
+}

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
 import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.mockk.mockk
+import org.neo4j.driver.Driver
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -34,6 +36,13 @@ class GraphMemgraphAutoConfigurationTest {
             "bluetape4k.graph.memgraph.password=",
         )
 
+    private val localMemgraphProperties = arrayOf(
+        "bluetape4k.graph.backend=memgraph",
+        "bluetape4k.graph.memgraph.uri=bolt://localhost:7687",
+        "bluetape4k.graph.memgraph.username=",
+        "bluetape4k.graph.memgraph.password=",
+    )
+
     @Test
     fun `backend=memgraph 이면 GraphOperations 빈 등록`() {
         runner.withPropertyValues(*memgraphProperties)
@@ -41,6 +50,19 @@ class GraphMemgraphAutoConfigurationTest {
                 ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
                 ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
                 ctx.getBean(GraphVirtualThreadOperations::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `unrelated Driver bean 이 있어도 memgraphDriver 를 별도로 등록한다`() {
+        runner
+            .withBean("neo4jDriver", Driver::class.java, { mockk(relaxed = true) })
+            .withPropertyValues(*localMemgraphProperties)
+            .run { ctx ->
+                ctx.getBean("neo4jDriver", Driver::class.java).shouldNotBeNull()
+                ctx.getBean("memgraphDriver", Driver::class.java).shouldNotBeNull()
+                ctx.getBean(GraphOperations::class.java).shouldNotBeNull()
+                ctx.getBean(GraphSuspendOperations::class.java).shouldNotBeNull()
             }
     }
 


### PR DESCRIPTION
Fixes #339

Stack Base: #362

This PR makes Kover aggregation fail closed when no XML reports are available, so CI cannot publish a successful zero-report coverage summary.

Validation:
- `python3 .github/scripts/test_aggregate_kover_coverage.py` passed.
- `python3 .github/scripts/aggregate-kover-coverage.py <empty temp dir>` exited with status 1.
- `actionlint .github/workflows/*.yml` passed.
- `python3 -m py_compile .github/scripts/aggregate-kover-coverage.py .github/scripts/test_aggregate_kover_coverage.py` passed.
- `git diff --check` passed.

## DoD Status
- [x] Zero-report aggregation is a failure when reports are expected.
- [x] CI still uploads available coverage evidence.
- [x] Script-level negative coverage check is committed.
- [x] Workflow lint and script checks pass.
- [x] PR metadata mirrors the issue: assignee `debop`, labels `bug` and `ci`, milestone `0.6.0`.
- [x] Full repository test passed on stack head #366: `./gradlew test --no-daemon --continue --no-configuration-cache`.

