### PR TITLE
fix: restore develop CI detekt

### DIFF
--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/model/GraphIoRecordTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/model/GraphIoRecordTest.kt
@@ -13,9 +13,15 @@ class GraphIoRecordTest {
 
     @Test
     fun `edge record requires non-blank label and endpoints`() {
-        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2") }
-        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2") }
-        assertFailsWith<IllegalArgumentException> { GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ") }
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoEdgeRecord(label = " ", fromExternalId = "v1", toExternalId = "v2")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoEdgeRecord(label = "KNOWS", fromExternalId = " ", toExternalId = "v2")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphIoEdgeRecord(label = "KNOWS", fromExternalId = "v1", toExternalId = " ")
+        }
     }
 
     @Test

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/report/GraphIoReportTest.kt
@@ -52,20 +52,72 @@ class GraphIoReportTest {
 
     @Test
     fun `GraphImportReport rejects negative counts`() {
-        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> {
+            GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, 0L, 0L, elapsed = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, 0L, 0L, elapsed = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, -1L, 0L, elapsed = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphImportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, 0L, -1L, elapsed = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphImportReport(
+                GraphIoStatus.COMPLETED,
+                GraphIoFormat.CSV,
+                0L,
+                0L,
+                0L,
+                0L,
+                skippedVertices = -1L,
+                elapsed = Duration.ZERO,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphImportReport(
+                GraphIoStatus.COMPLETED,
+                GraphIoFormat.CSV,
+                0L,
+                0L,
+                0L,
+                0L,
+                skippedEdges = -1L,
+                elapsed = Duration.ZERO,
+            )
+        }
     }
 
     @Test
     fun `GraphExportReport rejects negative counts`() {
-        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedVertices = -1L, elapsed = Duration.ZERO) }
-        assertFailsWith<IllegalArgumentException> { GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, 0L, skippedEdges = -1L, elapsed = Duration.ZERO) }
+        assertFailsWith<IllegalArgumentException> {
+            GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, -1L, 0L, elapsed = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphExportReport(GraphIoStatus.COMPLETED, GraphIoFormat.CSV, 0L, -1L, elapsed = Duration.ZERO)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphExportReport(
+                GraphIoStatus.COMPLETED,
+                GraphIoFormat.CSV,
+                0L,
+                0L,
+                skippedVertices = -1L,
+                elapsed = Duration.ZERO,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            GraphExportReport(
+                GraphIoStatus.COMPLETED,
+                GraphIoFormat.CSV,
+                0L,
+                0L,
+                skippedEdges = -1L,
+                elapsed = Duration.ZERO,
+            )
+        }
     }
 
     @Test

--- a/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
+++ b/graph-io/jackson2/src/main/kotlin/io/bluetape4k/graph/io/jackson2/SuspendJackson2NdJsonBulkImporter.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.graph.io.jackson2
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import io.bluetape4k.graph.io.contract.GraphSuspendBulkImporter
 import io.bluetape4k.graph.io.jackson2.internal.Jackson2EnvelopeCodec
 import io.bluetape4k.graph.io.jackson2.internal.NdJsonEnvelope
@@ -28,7 +29,6 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
-import java.util.concurrent.CancellationException
 
 /**
  * Coroutine NDJSON bulk importer backed by Jackson 2.
@@ -71,90 +71,29 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         val reader = withContext(Dispatchers.IO) { GraphIoPaths.openReader(source) }
         try {
             var lineNo = 0
-            while (status != GraphIoStatus.FAILED) {
+            var keepReading = true
+            while (keepReading && status != GraphIoStatus.FAILED) {
                 coroutineContext.ensureActive()
-                val raw = withContext(Dispatchers.IO) { reader.readLine() } ?: break
-                lineNo++
-                val line = raw.trim().ifBlank { continue }
-                val env = try {
-                    codec.parseLine(line)
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
-                    log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
-                    failures += GraphIoFailure(
-                        phase = GraphIoPhase.READ_VERTEX,
-                        fileRole = GraphIoFileRole.UNIFIED,
-                        location = "line:$lineNo",
-                        message = "Malformed JSON: ${e.message}",
+                val raw = withContext(Dispatchers.IO) { reader.readLine() }
+                if (raw == null) {
+                    keepReading = false
+                } else {
+                    lineNo++
+                    status = importLine(
+                        raw = raw,
+                        lineNo = lineNo,
+                        currentStatus = status,
+                        options = options,
+                        idMap = idMap,
+                        batchWriter = batchWriter,
+                        failures = failures,
+                        bufferedEdges = bufferedEdges,
+                        verticesCreated = { vc },
+                        onVertexRead = { vr++ },
+                        onVertexCreated = { created -> vc += created },
+                        onVertexSkipped = { sv++ },
+                        onEdgeRead = { er++ },
                     )
-                    status = GraphIoStatus.FAILED
-                    break
-                }
-                when (env.type) {
-                    NdJsonEnvelope.TYPE_VERTEX -> {
-                        val rec = try {
-                            codec.toVertex(env, options.defaultVertexLabel)
-                        } catch (e: Exception) {
-                            if (e is CancellationException) throw e
-                            failures += GraphIoFailure(
-                                phase = GraphIoPhase.READ_VERTEX,
-                                fileRole = GraphIoFileRole.UNIFIED,
-                                location = "line:$lineNo",
-                                message = "Invalid vertex envelope: ${e.message}",
-                            )
-                            status = GraphIoStatus.FAILED
-                            break
-                        }
-                        vr++
-                        val props = options.preserveExternalIdProperty
-                            ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
-                        when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
-                            GraphIoExternalIdMap.PutResult.CREATED -> {
-                                vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
-                            }
-                            GraphIoExternalIdMap.PutResult.SKIPPED -> {
-                                sv++
-                                status = GraphIoStatus.PARTIAL
-                            }
-                        }
-                    }
-                    NdJsonEnvelope.TYPE_EDGE -> {
-                        val rec = try {
-                            codec.toEdge(env, options.defaultEdgeLabel)
-                        } catch (e: Exception) {
-                            if (e is CancellationException) throw e
-                            failures += GraphIoFailure(
-                                phase = GraphIoPhase.READ_EDGE,
-                                fileRole = GraphIoFileRole.UNIFIED,
-                                location = "line:$lineNo",
-                                message = "Invalid edge envelope: ${e.message}",
-                            )
-                            status = GraphIoStatus.FAILED
-                            break
-                        }
-                        er++
-                        bufferedEdges += rec
-                        if (bufferedEdges.size > options.maxEdgeBufferSize) {
-                            failures += GraphIoFailure(
-                                phase = GraphIoPhase.READ_EDGE,
-                                fileRole = GraphIoFileRole.UNIFIED,
-                                location = "line:$lineNo",
-                                message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}; " +
-                                    "verticesCreated=$vc remain in graph as partial state",
-                            )
-                            status = GraphIoStatus.FAILED
-                        }
-                    }
-                    else -> {
-                        failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_VERTEX,
-                            severity = GraphIoFailureSeverity.WARN,
-                            fileRole = GraphIoFileRole.UNIFIED,
-                            location = "line:$lineNo",
-                            message = "Unknown envelope type=${env.type}",
-                        )
-                        status = GraphIoStatus.PARTIAL
-                    }
                 }
             }
         } finally {
@@ -170,41 +109,16 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
             )
         }
 
-        for (e in bufferedEdges) {
-            val from = idMap.resolve(e.fromExternalId)
-            val to = idMap.resolve(e.toExternalId)
-            if (from == null || to == null) {
-                when (options.onMissingEdgeEndpoint) {
-                    MissingEndpointPolicy.FAIL -> {
-                        ec += batchWriter.flushEdges()
-                        failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
-                            fileRole = GraphIoFileRole.UNIFIED,
-                            recordId = e.externalId,
-                            message = "Unresolved endpoint from=${e.fromExternalId} to=${e.toExternalId}",
-                        )
-                        status = GraphIoStatus.FAILED
-                        break
-                    }
-                    MissingEndpointPolicy.SKIP_EDGE -> {
-                        se++
-                        status = GraphIoStatus.PARTIAL
-                        failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
-                            severity = GraphIoFailureSeverity.WARN,
-                            fileRole = GraphIoFileRole.UNIFIED,
-                            recordId = e.externalId,
-                            message = "Missing endpoint skipped from=${e.fromExternalId} to=${e.toExternalId}",
-                        )
-                        continue
-                    }
-                }
-            }
-            val props = e.externalId?.let { eid ->
-                options.preserveExternalIdProperty?.let { key -> e.properties + (key to eid) } ?: e.properties
-            } ?: e.properties
-            ec += batchWriter.addEdge(e.label, from, to, props)
-        }
+        status = drainBufferedEdges(
+            bufferedEdges = bufferedEdges,
+            idMap = idMap,
+            options = options,
+            batchWriter = batchWriter,
+            failures = failures,
+            currentStatus = status,
+            onEdgesCreated = { created -> ec += created },
+            onEdgeSkipped = { se++ },
+        )
 
         if (status != GraphIoStatus.FAILED) {
             ec += batchWriter.flushEdges()
@@ -213,6 +127,287 @@ class SuspendJackson2NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         return GraphImportReport(status, GraphIoFormat.NDJSON_JACKSON2, vr, vc, er, ec, sv, se, watch.elapsed(), failures).also {
             log.debug { "NDJSON_JACKSON2 import (suspend) completed: vertices=$vc/$vr, edges=$ec/$er, skipped=$sv/$se, status=$status, elapsed=${watch.elapsed()}" }
         }
+    }
+
+    private suspend fun importLine(
+        raw: String,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        idMap: GraphIoExternalIdMap,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        verticesCreated: () -> Long,
+        onVertexRead: () -> Unit,
+        onVertexCreated: (Int) -> Unit,
+        onVertexSkipped: () -> Unit,
+        onEdgeRead: () -> Unit,
+    ): GraphIoStatus {
+        var nextStatus = currentStatus
+        val line = raw.trim()
+        if (line.isNotBlank()) {
+            val env = parseEnvelope(line, lineNo, failures)
+            nextStatus = env?.let {
+                importEnvelope(
+                    env = it,
+                    lineNo = lineNo,
+                    currentStatus = currentStatus,
+                    options = options,
+                    idMap = idMap,
+                    batchWriter = batchWriter,
+                    failures = failures,
+                    bufferedEdges = bufferedEdges,
+                    verticesCreated = verticesCreated,
+                    onVertexRead = onVertexRead,
+                    onVertexCreated = onVertexCreated,
+                    onVertexSkipped = onVertexSkipped,
+                    onEdgeRead = onEdgeRead,
+                )
+            } ?: GraphIoStatus.FAILED
+        }
+        return nextStatus
+    }
+
+    private suspend fun drainBufferedEdges(
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        idMap: GraphIoExternalIdMap,
+        options: GraphImportOptions,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        currentStatus: GraphIoStatus,
+        onEdgesCreated: (Int) -> Unit,
+        onEdgeSkipped: () -> Unit,
+    ): GraphIoStatus {
+        var status = currentStatus
+        for (edge in bufferedEdges) {
+            if (status != GraphIoStatus.FAILED) {
+                status = drainBufferedEdge(
+                    edge = edge,
+                    idMap = idMap,
+                    options = options,
+                    batchWriter = batchWriter,
+                    failures = failures,
+                    currentStatus = status,
+                    onEdgesCreated = onEdgesCreated,
+                    onEdgeSkipped = onEdgeSkipped,
+                )
+            }
+        }
+        return status
+    }
+
+    private suspend fun drainBufferedEdge(
+        edge: GraphIoEdgeRecord,
+        idMap: GraphIoExternalIdMap,
+        options: GraphImportOptions,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        currentStatus: GraphIoStatus,
+        onEdgesCreated: (Int) -> Unit,
+        onEdgeSkipped: () -> Unit,
+    ): GraphIoStatus {
+        val from = idMap.resolve(edge.fromExternalId)
+        val to = idMap.resolve(edge.toExternalId)
+        return if (from == null || to == null) {
+            handleMissingEndpoint(edge, options, batchWriter, failures, onEdgesCreated, onEdgeSkipped)
+        } else {
+            val props = edge.externalId?.let { eid ->
+                options.preserveExternalIdProperty?.let { key -> edge.properties + (key to eid) } ?: edge.properties
+            } ?: edge.properties
+            onEdgesCreated(batchWriter.addEdge(edge.label, from, to, props))
+            currentStatus
+        }
+    }
+
+    private suspend fun handleMissingEndpoint(
+        edge: GraphIoEdgeRecord,
+        options: GraphImportOptions,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        onEdgesCreated: (Int) -> Unit,
+        onEdgeSkipped: () -> Unit,
+    ): GraphIoStatus =
+        when (options.onMissingEdgeEndpoint) {
+            MissingEndpointPolicy.FAIL -> {
+                onEdgesCreated(batchWriter.flushEdges())
+                failures += GraphIoFailure(
+                    phase = GraphIoPhase.READ_EDGE,
+                    fileRole = GraphIoFileRole.UNIFIED,
+                    recordId = edge.externalId,
+                    message = "Unresolved endpoint from=${edge.fromExternalId} to=${edge.toExternalId}",
+                )
+                GraphIoStatus.FAILED
+            }
+            MissingEndpointPolicy.SKIP_EDGE -> {
+                onEdgeSkipped()
+                failures += GraphIoFailure(
+                    phase = GraphIoPhase.READ_EDGE,
+                    severity = GraphIoFailureSeverity.WARN,
+                    fileRole = GraphIoFileRole.UNIFIED,
+                    recordId = edge.externalId,
+                    message = "Missing endpoint skipped from=${edge.fromExternalId} to=${edge.toExternalId}",
+                )
+                GraphIoStatus.PARTIAL
+            }
+        }
+
+    private suspend fun importEnvelope(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        idMap: GraphIoExternalIdMap,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        verticesCreated: () -> Long,
+        onVertexRead: () -> Unit,
+        onVertexCreated: (Int) -> Unit,
+        onVertexSkipped: () -> Unit,
+        onEdgeRead: () -> Unit,
+    ): GraphIoStatus =
+        when (env.type) {
+            NdJsonEnvelope.TYPE_VERTEX -> importVertexEnvelope(
+                env,
+                lineNo,
+                currentStatus,
+                options,
+                idMap,
+                batchWriter,
+                failures,
+                onVertexRead,
+                onVertexCreated,
+                onVertexSkipped,
+            )
+            NdJsonEnvelope.TYPE_EDGE -> importEdgeEnvelope(
+                env,
+                lineNo,
+                currentStatus,
+                options,
+                failures,
+                bufferedEdges,
+                verticesCreated,
+                onEdgeRead,
+            )
+            else -> {
+                failures += GraphIoFailure(
+                    phase = GraphIoPhase.READ_VERTEX,
+                    severity = GraphIoFailureSeverity.WARN,
+                    fileRole = GraphIoFileRole.UNIFIED,
+                    location = "line:$lineNo",
+                    message = "Unknown envelope type=${env.type}",
+                )
+                GraphIoStatus.PARTIAL
+            }
+        }
+
+    private suspend fun importVertexEnvelope(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        idMap: GraphIoExternalIdMap,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        onVertexRead: () -> Unit,
+        onVertexCreated: (Int) -> Unit,
+        onVertexSkipped: () -> Unit,
+    ): GraphIoStatus {
+        val rec = toVertexRecord(env, lineNo, options, failures) ?: return GraphIoStatus.FAILED
+        onVertexRead()
+        val props = options.preserveExternalIdProperty
+            ?.let { key -> rec.properties + (key to rec.externalId) } ?: rec.properties
+        return when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
+            GraphIoExternalIdMap.PutResult.CREATED -> {
+                onVertexCreated(batchWriter.addVertex(rec.externalId, rec.label, props, idMap))
+                currentStatus
+            }
+            GraphIoExternalIdMap.PutResult.SKIPPED -> {
+                onVertexSkipped()
+                GraphIoStatus.PARTIAL
+            }
+        }
+    }
+
+    private fun importEdgeEnvelope(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        failures: MutableList<GraphIoFailure>,
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        verticesCreated: () -> Long,
+        onEdgeRead: () -> Unit,
+    ): GraphIoStatus {
+        val rec = toEdgeRecord(env, lineNo, options, failures) ?: return GraphIoStatus.FAILED
+        onEdgeRead()
+        bufferedEdges += rec
+        return if (bufferedEdges.size > options.maxEdgeBufferSize) {
+            val maxSize = options.maxEdgeBufferSize
+            failures += GraphIoFailure(
+                phase = GraphIoPhase.READ_EDGE,
+                fileRole = GraphIoFileRole.UNIFIED,
+                location = "line:$lineNo",
+                message = "Edge buffer exceeded maxEdgeBufferSize=$maxSize; " +
+                    "verticesCreated=${verticesCreated()} remain in graph as partial state",
+            )
+            GraphIoStatus.FAILED
+        } else {
+            currentStatus
+        }
+    }
+
+    private fun parseEnvelope(
+        line: String,
+        lineNo: Int,
+        failures: MutableList<GraphIoFailure>,
+    ): NdJsonEnvelope? =
+        try {
+            codec.parseLine(line)
+        } catch (e: JsonProcessingException) {
+            log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
+            failures += GraphIoFailure(
+                phase = GraphIoPhase.READ_VERTEX,
+                fileRole = GraphIoFileRole.UNIFIED,
+                location = "line:$lineNo",
+                message = "Malformed JSON: ${e.message}",
+            )
+            null
+        }
+
+    private fun toVertexRecord(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        options: GraphImportOptions,
+        failures: MutableList<GraphIoFailure>,
+    ) = try {
+        codec.toVertex(env, options.defaultVertexLabel)
+    } catch (e: IllegalArgumentException) {
+        failures += GraphIoFailure(
+            phase = GraphIoPhase.READ_VERTEX,
+            fileRole = GraphIoFileRole.UNIFIED,
+            location = "line:$lineNo",
+            message = "Invalid vertex envelope: ${e.message}",
+        )
+        null
+    }
+
+    private fun toEdgeRecord(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        options: GraphImportOptions,
+        failures: MutableList<GraphIoFailure>,
+    ) = try {
+        codec.toEdge(env, options.defaultEdgeLabel)
+    } catch (e: IllegalArgumentException) {
+        failures += GraphIoFailure(
+            phase = GraphIoPhase.READ_EDGE,
+            fileRole = GraphIoFileRole.UNIFIED,
+            location = "line:$lineNo",
+            message = "Invalid edge envelope: ${e.message}",
+        )
+        null
     }
 
     companion object : KLoggingChannel()

--- a/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
+++ b/graph-io/jackson3/src/main/kotlin/io/bluetape4k/graph/io/jackson3/SuspendJackson3NdJsonBulkImporter.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
-import java.util.concurrent.CancellationException
+import tools.jackson.core.JacksonException
 
 /**
  * Coroutine NDJSON bulk importer backed by Jackson 3.
@@ -71,90 +71,29 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         val reader = withContext(Dispatchers.IO) { GraphIoPaths.openReader(source) }
         try {
             var lineNo = 0
-            while (status != GraphIoStatus.FAILED) {
+            var keepReading = true
+            while (keepReading && status != GraphIoStatus.FAILED) {
                 coroutineContext.ensureActive()
-                val raw = withContext(Dispatchers.IO) { reader.readLine() } ?: break
-                lineNo++
-                val line = raw.trim().ifBlank { continue }
-                val env = try {
-                    codec.parseLine(line)
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
-                    log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
-                    failures += GraphIoFailure(
-                        phase = GraphIoPhase.READ_VERTEX,
-                        fileRole = GraphIoFileRole.UNIFIED,
-                        location = "line:$lineNo",
-                        message = "Malformed JSON: ${e.message}",
+                val raw = withContext(Dispatchers.IO) { reader.readLine() }
+                if (raw == null) {
+                    keepReading = false
+                } else {
+                    lineNo++
+                    status = importLine(
+                        raw = raw,
+                        lineNo = lineNo,
+                        currentStatus = status,
+                        options = options,
+                        idMap = idMap,
+                        batchWriter = batchWriter,
+                        failures = failures,
+                        bufferedEdges = bufferedEdges,
+                        verticesCreated = { vc },
+                        onVertexRead = { vr++ },
+                        onVertexCreated = { created -> vc += created },
+                        onVertexSkipped = { sv++ },
+                        onEdgeRead = { er++ },
                     )
-                    status = GraphIoStatus.FAILED
-                    break
-                }
-                when (env.type) {
-                    NdJsonEnvelope.TYPE_VERTEX -> {
-                        val rec = try {
-                            codec.toVertex(env, options.defaultVertexLabel)
-                        } catch (e: Exception) {
-                            if (e is CancellationException) throw e
-                            failures += GraphIoFailure(
-                                phase = GraphIoPhase.READ_VERTEX,
-                                fileRole = GraphIoFileRole.UNIFIED,
-                                location = "line:$lineNo",
-                                message = "Invalid vertex envelope: ${e.message}",
-                            )
-                            status = GraphIoStatus.FAILED
-                            break
-                        }
-                        vr++
-                        val props = options.preserveExternalIdProperty
-                            ?.let { rec.properties + (it to rec.externalId) } ?: rec.properties
-                        when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
-                            GraphIoExternalIdMap.PutResult.CREATED -> {
-                                vc += batchWriter.addVertex(rec.externalId, rec.label, props, idMap)
-                            }
-                            GraphIoExternalIdMap.PutResult.SKIPPED -> {
-                                sv++
-                                status = GraphIoStatus.PARTIAL
-                            }
-                        }
-                    }
-                    NdJsonEnvelope.TYPE_EDGE -> {
-                        val rec = try {
-                            codec.toEdge(env, options.defaultEdgeLabel)
-                        } catch (e: Exception) {
-                            if (e is CancellationException) throw e
-                            failures += GraphIoFailure(
-                                phase = GraphIoPhase.READ_EDGE,
-                                fileRole = GraphIoFileRole.UNIFIED,
-                                location = "line:$lineNo",
-                                message = "Invalid edge envelope: ${e.message}",
-                            )
-                            status = GraphIoStatus.FAILED
-                            break
-                        }
-                        er++
-                        bufferedEdges += rec
-                        if (bufferedEdges.size > options.maxEdgeBufferSize) {
-                            failures += GraphIoFailure(
-                                phase = GraphIoPhase.READ_EDGE,
-                                fileRole = GraphIoFileRole.UNIFIED,
-                                location = "line:$lineNo",
-                                message = "Edge buffer exceeded maxEdgeBufferSize=${options.maxEdgeBufferSize}; " +
-                                    "verticesCreated=$vc remain in graph as partial state",
-                            )
-                            status = GraphIoStatus.FAILED
-                        }
-                    }
-                    else -> {
-                        failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_VERTEX,
-                            severity = GraphIoFailureSeverity.WARN,
-                            fileRole = GraphIoFileRole.UNIFIED,
-                            location = "line:$lineNo",
-                            message = "Unknown envelope type=${env.type}",
-                        )
-                        status = GraphIoStatus.PARTIAL
-                    }
                 }
             }
         } finally {
@@ -170,41 +109,16 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
             )
         }
 
-        for (e in bufferedEdges) {
-            val from = idMap.resolve(e.fromExternalId)
-            val to = idMap.resolve(e.toExternalId)
-            if (from == null || to == null) {
-                when (options.onMissingEdgeEndpoint) {
-                    MissingEndpointPolicy.FAIL -> {
-                        ec += batchWriter.flushEdges()
-                        failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
-                            fileRole = GraphIoFileRole.UNIFIED,
-                            recordId = e.externalId,
-                            message = "Unresolved endpoint from=${e.fromExternalId} to=${e.toExternalId}",
-                        )
-                        status = GraphIoStatus.FAILED
-                        break
-                    }
-                    MissingEndpointPolicy.SKIP_EDGE -> {
-                        se++
-                        status = GraphIoStatus.PARTIAL
-                        failures += GraphIoFailure(
-                            phase = GraphIoPhase.READ_EDGE,
-                            severity = GraphIoFailureSeverity.WARN,
-                            fileRole = GraphIoFileRole.UNIFIED,
-                            recordId = e.externalId,
-                            message = "Missing endpoint skipped from=${e.fromExternalId} to=${e.toExternalId}",
-                        )
-                        continue
-                    }
-                }
-            }
-            val props = e.externalId?.let { eid ->
-                options.preserveExternalIdProperty?.let { key -> e.properties + (key to eid) } ?: e.properties
-            } ?: e.properties
-            ec += batchWriter.addEdge(e.label, from, to, props)
-        }
+        status = drainBufferedEdges(
+            bufferedEdges = bufferedEdges,
+            idMap = idMap,
+            options = options,
+            batchWriter = batchWriter,
+            failures = failures,
+            currentStatus = status,
+            onEdgesCreated = { created -> ec += created },
+            onEdgeSkipped = { se++ },
+        )
 
         if (status != GraphIoStatus.FAILED) {
             ec += batchWriter.flushEdges()
@@ -213,6 +127,287 @@ class SuspendJackson3NdJsonBulkImporter : GraphSuspendBulkImporter<GraphImportSo
         return GraphImportReport(status, GraphIoFormat.NDJSON_JACKSON3, vr, vc, er, ec, sv, se, watch.elapsed(), failures).also {
             log.debug { "NDJSON_JACKSON3 import (suspend) completed: vertices=$vc/$vr, edges=$ec/$er, skipped=$sv/$se, status=$status, elapsed=${watch.elapsed()}" }
         }
+    }
+
+    private suspend fun importLine(
+        raw: String,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        idMap: GraphIoExternalIdMap,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        verticesCreated: () -> Long,
+        onVertexRead: () -> Unit,
+        onVertexCreated: (Int) -> Unit,
+        onVertexSkipped: () -> Unit,
+        onEdgeRead: () -> Unit,
+    ): GraphIoStatus {
+        var nextStatus = currentStatus
+        val line = raw.trim()
+        if (line.isNotBlank()) {
+            val env = parseEnvelope(line, lineNo, failures)
+            nextStatus = env?.let {
+                importEnvelope(
+                    env = it,
+                    lineNo = lineNo,
+                    currentStatus = currentStatus,
+                    options = options,
+                    idMap = idMap,
+                    batchWriter = batchWriter,
+                    failures = failures,
+                    bufferedEdges = bufferedEdges,
+                    verticesCreated = verticesCreated,
+                    onVertexRead = onVertexRead,
+                    onVertexCreated = onVertexCreated,
+                    onVertexSkipped = onVertexSkipped,
+                    onEdgeRead = onEdgeRead,
+                )
+            } ?: GraphIoStatus.FAILED
+        }
+        return nextStatus
+    }
+
+    private suspend fun drainBufferedEdges(
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        idMap: GraphIoExternalIdMap,
+        options: GraphImportOptions,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        currentStatus: GraphIoStatus,
+        onEdgesCreated: (Int) -> Unit,
+        onEdgeSkipped: () -> Unit,
+    ): GraphIoStatus {
+        var status = currentStatus
+        for (edge in bufferedEdges) {
+            if (status != GraphIoStatus.FAILED) {
+                status = drainBufferedEdge(
+                    edge = edge,
+                    idMap = idMap,
+                    options = options,
+                    batchWriter = batchWriter,
+                    failures = failures,
+                    currentStatus = status,
+                    onEdgesCreated = onEdgesCreated,
+                    onEdgeSkipped = onEdgeSkipped,
+                )
+            }
+        }
+        return status
+    }
+
+    private suspend fun drainBufferedEdge(
+        edge: GraphIoEdgeRecord,
+        idMap: GraphIoExternalIdMap,
+        options: GraphImportOptions,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        currentStatus: GraphIoStatus,
+        onEdgesCreated: (Int) -> Unit,
+        onEdgeSkipped: () -> Unit,
+    ): GraphIoStatus {
+        val from = idMap.resolve(edge.fromExternalId)
+        val to = idMap.resolve(edge.toExternalId)
+        return if (from == null || to == null) {
+            handleMissingEndpoint(edge, options, batchWriter, failures, onEdgesCreated, onEdgeSkipped)
+        } else {
+            val props = edge.externalId?.let { eid ->
+                options.preserveExternalIdProperty?.let { key -> edge.properties + (key to eid) } ?: edge.properties
+            } ?: edge.properties
+            onEdgesCreated(batchWriter.addEdge(edge.label, from, to, props))
+            currentStatus
+        }
+    }
+
+    private suspend fun handleMissingEndpoint(
+        edge: GraphIoEdgeRecord,
+        options: GraphImportOptions,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        onEdgesCreated: (Int) -> Unit,
+        onEdgeSkipped: () -> Unit,
+    ): GraphIoStatus =
+        when (options.onMissingEdgeEndpoint) {
+            MissingEndpointPolicy.FAIL -> {
+                onEdgesCreated(batchWriter.flushEdges())
+                failures += GraphIoFailure(
+                    phase = GraphIoPhase.READ_EDGE,
+                    fileRole = GraphIoFileRole.UNIFIED,
+                    recordId = edge.externalId,
+                    message = "Unresolved endpoint from=${edge.fromExternalId} to=${edge.toExternalId}",
+                )
+                GraphIoStatus.FAILED
+            }
+            MissingEndpointPolicy.SKIP_EDGE -> {
+                onEdgeSkipped()
+                failures += GraphIoFailure(
+                    phase = GraphIoPhase.READ_EDGE,
+                    severity = GraphIoFailureSeverity.WARN,
+                    fileRole = GraphIoFileRole.UNIFIED,
+                    recordId = edge.externalId,
+                    message = "Missing endpoint skipped from=${edge.fromExternalId} to=${edge.toExternalId}",
+                )
+                GraphIoStatus.PARTIAL
+            }
+        }
+
+    private suspend fun importEnvelope(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        idMap: GraphIoExternalIdMap,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        verticesCreated: () -> Long,
+        onVertexRead: () -> Unit,
+        onVertexCreated: (Int) -> Unit,
+        onVertexSkipped: () -> Unit,
+        onEdgeRead: () -> Unit,
+    ): GraphIoStatus =
+        when (env.type) {
+            NdJsonEnvelope.TYPE_VERTEX -> importVertexEnvelope(
+                env,
+                lineNo,
+                currentStatus,
+                options,
+                idMap,
+                batchWriter,
+                failures,
+                onVertexRead,
+                onVertexCreated,
+                onVertexSkipped,
+            )
+            NdJsonEnvelope.TYPE_EDGE -> importEdgeEnvelope(
+                env,
+                lineNo,
+                currentStatus,
+                options,
+                failures,
+                bufferedEdges,
+                verticesCreated,
+                onEdgeRead,
+            )
+            else -> {
+                failures += GraphIoFailure(
+                    phase = GraphIoPhase.READ_VERTEX,
+                    severity = GraphIoFailureSeverity.WARN,
+                    fileRole = GraphIoFileRole.UNIFIED,
+                    location = "line:$lineNo",
+                    message = "Unknown envelope type=${env.type}",
+                )
+                GraphIoStatus.PARTIAL
+            }
+        }
+
+    private suspend fun importVertexEnvelope(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        idMap: GraphIoExternalIdMap,
+        batchWriter: SuspendGraphIoBatchWriter,
+        failures: MutableList<GraphIoFailure>,
+        onVertexRead: () -> Unit,
+        onVertexCreated: (Int) -> Unit,
+        onVertexSkipped: () -> Unit,
+    ): GraphIoStatus {
+        val rec = toVertexRecord(env, lineNo, options, failures) ?: return GraphIoStatus.FAILED
+        onVertexRead()
+        val props = options.preserveExternalIdProperty
+            ?.let { key -> rec.properties + (key to rec.externalId) } ?: rec.properties
+        return when (idMap.putFirstOrFail(rec.externalId, GraphElementId(rec.externalId))) {
+            GraphIoExternalIdMap.PutResult.CREATED -> {
+                onVertexCreated(batchWriter.addVertex(rec.externalId, rec.label, props, idMap))
+                currentStatus
+            }
+            GraphIoExternalIdMap.PutResult.SKIPPED -> {
+                onVertexSkipped()
+                GraphIoStatus.PARTIAL
+            }
+        }
+    }
+
+    private fun importEdgeEnvelope(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        currentStatus: GraphIoStatus,
+        options: GraphImportOptions,
+        failures: MutableList<GraphIoFailure>,
+        bufferedEdges: ArrayDeque<GraphIoEdgeRecord>,
+        verticesCreated: () -> Long,
+        onEdgeRead: () -> Unit,
+    ): GraphIoStatus {
+        val rec = toEdgeRecord(env, lineNo, options, failures) ?: return GraphIoStatus.FAILED
+        onEdgeRead()
+        bufferedEdges += rec
+        return if (bufferedEdges.size > options.maxEdgeBufferSize) {
+            val maxSize = options.maxEdgeBufferSize
+            failures += GraphIoFailure(
+                phase = GraphIoPhase.READ_EDGE,
+                fileRole = GraphIoFileRole.UNIFIED,
+                location = "line:$lineNo",
+                message = "Edge buffer exceeded maxEdgeBufferSize=$maxSize; " +
+                    "verticesCreated=${verticesCreated()} remain in graph as partial state",
+            )
+            GraphIoStatus.FAILED
+        } else {
+            currentStatus
+        }
+    }
+
+    private fun parseEnvelope(
+        line: String,
+        lineNo: Int,
+        failures: MutableList<GraphIoFailure>,
+    ): NdJsonEnvelope? =
+        try {
+            codec.parseLine(line)
+        } catch (e: JacksonException) {
+            log.warn(e) { "Malformed JSON at line $lineNo: ${e.message}" }
+            failures += GraphIoFailure(
+                phase = GraphIoPhase.READ_VERTEX,
+                fileRole = GraphIoFileRole.UNIFIED,
+                location = "line:$lineNo",
+                message = "Malformed JSON: ${e.message}",
+            )
+            null
+        }
+
+    private fun toVertexRecord(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        options: GraphImportOptions,
+        failures: MutableList<GraphIoFailure>,
+    ) = try {
+        codec.toVertex(env, options.defaultVertexLabel)
+    } catch (e: IllegalArgumentException) {
+        failures += GraphIoFailure(
+            phase = GraphIoPhase.READ_VERTEX,
+            fileRole = GraphIoFileRole.UNIFIED,
+            location = "line:$lineNo",
+            message = "Invalid vertex envelope: ${e.message}",
+        )
+        null
+    }
+
+    private fun toEdgeRecord(
+        env: NdJsonEnvelope,
+        lineNo: Int,
+        options: GraphImportOptions,
+        failures: MutableList<GraphIoFailure>,
+    ) = try {
+        codec.toEdge(env, options.defaultEdgeLabel)
+    } catch (e: IllegalArgumentException) {
+        failures += GraphIoFailure(
+            phase = GraphIoPhase.READ_EDGE,
+            fileRole = GraphIoFileRole.UNIFIED,
+            location = "line:$lineNo",
+            message = "Invalid edge envelope: ${e.message}",
+        )
+        null
     }
 
     companion object : KLoggingChannel()

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphComponent.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphComponent.kt
@@ -7,7 +7,8 @@ import java.io.Serializable
  *
  * Represents vertices that share the same [componentId].
  *
- * @property componentId Component identifier. The value is implementation-defined; vertices in the same component share it.
+ * @property componentId Component identifier. The value is implementation-defined;
+ * vertices in the same component share it.
  * @property vertices Vertices in the component.
  *
  * ### Usage

--- a/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
+++ b/graph/graph-core/src/main/kotlin/io/bluetape4k/graph/model/GraphTraversalOptions.kt
@@ -73,7 +73,8 @@ data class NeighborOptions(
  * @param weightProperty Edge weight property key. `null` uses unweighted traversal.
  * @param missingWeightPolicy Policy for edges missing [weightProperty]. Defaults to [MissingWeightPolicy.Fail].
  * @param direction Traversal direction. Applies only when [weightProperty] is set. Defaults to [Direction.OUTGOING].
- * @param maxVisited Maximum visited vertices during weighted traversal. Protects against unbounded graphs. Defaults to `100_000`.
+ * @param maxVisited Maximum visited vertices during weighted traversal.
+ * Protects against unbounded graphs. Defaults to `100_000`.
  */
 data class PathOptions(
     val edgeLabel: String? = null,

--- a/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
+++ b/graph/graph-memgraph/src/main/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperations.kt
@@ -100,6 +100,9 @@ class MemgraphGraphSuspendOperations(
             SessionConfig.builder().withDatabase(database).build(),
         )
 
+    private fun failGraphExists(e: Exception, name: String): Nothing =
+        throw e.asGraphExistsFailure("Memgraph", name)
+
     override fun schemaManager(): GraphSuspendSchemaManager =
         MemgraphGraphSchemaManager(driver, database).asSuspendSchemaManager()
 
@@ -274,9 +277,9 @@ class MemgraphGraphSuspendOperations(
         } catch (e: CancellationException) {
             throw e
         } catch (e: org.neo4j.driver.exceptions.DatabaseException) {
-            if (e.isMissingDatabaseFailure()) false else throw e.asGraphExistsFailure("Memgraph", name)
+            if (e.isMissingDatabaseFailure()) false else failGraphExists(e, name)
         } catch (e: Exception) {
-            throw e.asGraphExistsFailure("Memgraph", name)
+            failGraphExists(e, name)
         } finally {
             s?.let { session ->
                 withContext(NonCancellable) { session.close<Void>().awaitFirstOrNull() }


### PR DESCRIPTION
## Summary
- Refactor suspend Jackson2/Jackson3 NDJSON importers to avoid unbaselined detekt failures after the review stack merge.
- Wrap graph-io report/record assertions and graph model KDoc lines that were newly rejected by detekt.
- Move Memgraph graphExists failure throwing behind a helper so the override stays under ThrowsCount.

## Validation
- `./gradlew detekt --no-daemon --continue --no-configuration-cache`
- `./gradlew :bluetape4k-graph-io-core:test :bluetape4k-graph-io-jackson2:test :bluetape4k-graph-io-jackson3:test :bluetape4k-graph-core:compileKotlin :bluetape4k-graph-memgraph:compileKotlin --no-daemon --continue --no-configuration-cache`
- `./gradlew build -x test --no-daemon --continue --no-configuration-cache`
- `./gradlew test --no-daemon --continue --no-configuration-cache`

## DoD Status
| Step | Status | Evidence |
| --- | --- | --- |
| Reproduce CI failure | PASS | Develop CI Build & Detekt failed on detekt after #343-#366 merge. |
| Fix detekt root causes | PASS | Removed broad catch/jump statements, reduced nesting, wrapped long lines, and preserved cancellation behavior. |
| Local detekt | PASS | `detekt` exit 0 / BUILD SUCCESSFUL in 8s. |
| Targeted tests | PASS | graph-io core/jackson2/jackson3 tests plus graph-core/memgraph compile exit 0 / BUILD SUCCESSFUL in 19s. |
| CI-like build | PASS | `build -x test` exit 0 / BUILD SUCCESSFUL in 16s. |
| Full repo tests | PASS | `test` log shows BUILD SUCCESSFUL in 5m 59s; no failure markers. |