### PR TITLE
ci: pin Kotlin for CodeQL analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,7 +708,15 @@ jobs:
       - test-graph-memgraph
       - test-graph-age
       - test-graph-falkordb
-    if: always()
+    if: >
+      always() &&
+      (needs.test-core.result == 'success' ||
+       needs.test-spring-starters.result == 'success' ||
+       needs.test-graph-ktor.result == 'success' ||
+       needs.test-graph-neo4j.result == 'success' ||
+       needs.test-graph-memgraph.result == 'success' ||
+       needs.test-graph-age.result == 'success' ||
+       needs.test-graph-falkordb.result == 'success')
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
+      - name: Pin Kotlin for CodeQL extractor
+        if: matrix.language == 'java-kotlin'
+        run: |
+          perl -0pi -e 's/kotlin = "2\.4\.0"/kotlin = "2.3.21"/' gradle/libs.versions.toml
+          grep -n 'kotlin = "2.3.21"' gradle/libs.versions.toml
+
       - name: Setup JDK 21
         if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary

- Pin Kotlin to 2.3.21 only inside the CodeQL java-kotlin analysis job.
- Keep the repository Gradle version catalog on Kotlin 2.4.0 for normal builds.
- Skip coverage aggregation when a workflow-only PR skips every test job and therefore produces no Kover XML artifacts.

## Rationale

CodeQL Java/Kotlin extractor support can lag Kotlin 2.4.x. This keeps project builds on Kotlin 2.4.0 while allowing CodeQL analysis to build with the latest known supported Kotlin line.

The initial PR CI also exposed an existing workflow-only path issue: all test jobs were skipped, but the coverage aggregation job still required Kover XML artifacts. The coverage job now runs only when at least one test job succeeds, while real test runs remain strict about missing coverage reports.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
- `git diff --check`

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| Scope | PASS | Changed ` .github/workflows/codeql.yml` and workflow-only CI coverage gating in `.github/workflows/ci.yml` |
| CodeQL Kotlin pin | PASS | `java-kotlin` job rewrites `kotlin = "2.4.0"` to `2.3.21` in the runner workspace |
| Repository Kotlin version | PASS | Source catalog remains Kotlin 2.4.0 outside the workflow job |
| Workflow-only coverage path | PASS | Coverage aggregation is skipped unless at least one test job succeeds |
| Workflow lint | PASS | `actionlint .github/workflows/codeql.yml`; `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml` |
| Whitespace check | PASS | `git diff --check` |
