### PR TITLE
test(graph-core): raise model coverage above average

### DIFF
--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphAlgorithmOptionsTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphAlgorithmOptionsTest.kt
@@ -1,0 +1,150 @@
+package io.bluetape4k.graph.model
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldContain
+import org.junit.jupiter.api.Test
+
+class GraphAlgorithmOptionsTest {
+
+    @Test
+    fun `PageRankOptions 기본값은 전체 정점과 간선을 대상으로 한다`() {
+        val opts = PageRankOptions()
+
+        opts.vertexLabel.shouldBeNull()
+        opts.edgeLabel.shouldBeNull()
+        opts.iterations shouldBeEqualTo 20
+        opts.dampingFactor shouldBeEqualTo 0.85
+        opts.tolerance shouldBeEqualTo 1e-4
+        opts.topK shouldBeEqualTo Int.MAX_VALUE
+    }
+
+    @Test
+    fun `PageRankOptions Default 상수는 기본 생성자와 동일하다`() {
+        PageRankOptions.Default shouldBeEqualTo PageRankOptions()
+    }
+
+    @Test
+    fun `PageRankOptions는 모든 필드를 명시해서 생성할 수 있다`() {
+        val opts = PageRankOptions(
+            vertexLabel = "Account",
+            edgeLabel = "TRANSFERRED_TO",
+            iterations = 50,
+            dampingFactor = 0.9,
+            tolerance = 1e-6,
+            topK = 25,
+        )
+
+        opts.vertexLabel shouldBeEqualTo "Account"
+        opts.edgeLabel shouldBeEqualTo "TRANSFERRED_TO"
+        opts.iterations shouldBeEqualTo 50
+        opts.dampingFactor shouldBeEqualTo 0.9
+        opts.tolerance shouldBeEqualTo 1e-6
+        opts.topK shouldBeEqualTo 25
+    }
+
+    @Test
+    fun `PageRankOptions copy로 일부 필드만 변경한다`() {
+        val base = PageRankOptions(vertexLabel = "Person", topK = 10)
+        val updated = base.copy(edgeLabel = "KNOWS", iterations = 30)
+
+        updated.vertexLabel shouldBeEqualTo "Person"
+        updated.edgeLabel shouldBeEqualTo "KNOWS"
+        updated.iterations shouldBeEqualTo 30
+        updated.topK shouldBeEqualTo 10
+    }
+
+    @Test
+    fun `PageRankOptions는 0 이하 iterations를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            PageRankOptions(iterations = 0)
+        }
+
+        ex.message shouldContain "iterations"
+    }
+
+    @Test
+    fun `PageRankOptions는 0 이하 topK를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            PageRankOptions(topK = 0)
+        }
+
+        ex.message shouldContain "topK"
+    }
+
+    @Test
+    fun `PageRankOptions는 범위를 벗어난 dampingFactor를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            PageRankOptions(dampingFactor = 1.1)
+        }
+
+        ex.message shouldContain "dampingFactor"
+    }
+
+    @Test
+    fun `DegreeOptions 기본값은 모든 간선과 양방향이다`() {
+        val opts = DegreeOptions()
+
+        opts.edgeLabel.shouldBeNull()
+        opts.direction shouldBeEqualTo Direction.BOTH
+    }
+
+    @Test
+    fun `DegreeOptions Default 상수는 기본 생성자와 동일하다`() {
+        DegreeOptions.Default shouldBeEqualTo DegreeOptions()
+    }
+
+    @Test
+    fun `DegreeOptions는 모든 필드를 명시해서 생성할 수 있다`() {
+        val opts = DegreeOptions(edgeLabel = "KNOWS", direction = Direction.OUTGOING)
+
+        opts.edgeLabel shouldBeEqualTo "KNOWS"
+        opts.direction shouldBeEqualTo Direction.OUTGOING
+    }
+
+    @Test
+    fun `ComponentOptions 기본값은 weak component 전체 반환이다`() {
+        val opts = ComponentOptions()
+
+        opts.vertexLabel.shouldBeNull()
+        opts.edgeLabel.shouldBeNull()
+        opts.weakly shouldBeEqualTo true
+        opts.minSize shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `ComponentOptions Default 상수는 기본 생성자와 동일하다`() {
+        ComponentOptions.Default shouldBeEqualTo ComponentOptions()
+    }
+
+    @Test
+    fun `ComponentOptions는 모든 필드를 명시해서 생성할 수 있다`() {
+        val opts = ComponentOptions(
+            vertexLabel = "Account",
+            edgeLabel = "TRANSFERRED_TO",
+            weakly = false,
+            minSize = 3,
+        )
+
+        opts.vertexLabel shouldBeEqualTo "Account"
+        opts.edgeLabel shouldBeEqualTo "TRANSFERRED_TO"
+        opts.weakly shouldBeEqualTo false
+        opts.minSize shouldBeEqualTo 3
+    }
+
+    @Test
+    fun `algorithm option들은 sealed base type이며 Serializable이다`() {
+        val pageRank: GraphAlgorithmOptions = PageRankOptions()
+        val degree: GraphAlgorithmOptions = DegreeOptions()
+        val component: GraphAlgorithmOptions = ComponentOptions()
+
+        pageRank shouldBeInstanceOf PageRankOptions::class
+        degree shouldBeInstanceOf DegreeOptions::class
+        component shouldBeInstanceOf ComponentOptions::class
+        pageRank shouldBeInstanceOf java.io.Serializable::class
+        degree shouldBeInstanceOf java.io.Serializable::class
+        component shouldBeInstanceOf java.io.Serializable::class
+    }
+}

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphAlgorithmResultsTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphAlgorithmResultsTest.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.graph.model
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class GraphAlgorithmResultsTest {
+
+    @Test
+    fun `DegreeResult total은 inDegree와 outDegree의 합이다`() {
+        val result = DegreeResult(GraphElementId("v-1"), inDegree = 2, outDegree = 3)
+
+        result.vertexId shouldBeEqualTo GraphElementId("v-1")
+        result.inDegree shouldBeEqualTo 2
+        result.outDegree shouldBeEqualTo 3
+        result.total shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `DegreeResult copy로 degree 값을 변경한다`() {
+        val base = DegreeResult(GraphElementId("v-1"), inDegree = 1, outDegree = 4)
+        val updated = base.copy(outDegree = 7)
+
+        updated.vertexId shouldBeEqualTo GraphElementId("v-1")
+        updated.inDegree shouldBeEqualTo 1
+        updated.outDegree shouldBeEqualTo 7
+        updated.total shouldBeEqualTo 8
+    }
+
+    @Test
+    fun `PageRankScore는 vertex와 score를 보존한다`() {
+        val vertex = GraphVertex(GraphElementId("account-1"), "Account", mapOf("risk" to "high"))
+        val score = PageRankScore(vertex, score = 0.42)
+
+        score.vertex shouldBeEqualTo vertex
+        score.score shouldBeEqualTo 0.42
+    }
+
+    @Test
+    fun `PageRankScore copy로 score만 변경한다`() {
+        val vertex = GraphVertex(GraphElementId("account-1"), "Account")
+        val score = PageRankScore(vertex, score = 0.42)
+        val updated = score.copy(score = 0.51)
+
+        updated.vertex shouldBeEqualTo vertex
+        updated.score shouldBeEqualTo 0.51
+    }
+
+    @Test
+    fun `GraphComponent size는 vertex 개수이다`() {
+        val vertices = listOf(
+            GraphVertex(GraphElementId("a"), "Account"),
+            GraphVertex(GraphElementId("b"), "Account"),
+        )
+        val component = GraphComponent("component-1", vertices)
+
+        component.componentId shouldBeEqualTo "component-1"
+        component.vertices shouldBeEqualTo vertices
+        component.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `GraphComponent copy로 vertices만 변경한다`() {
+        val component = GraphComponent("component-1", listOf(GraphVertex(GraphElementId("a"), "Account")))
+        val updated = component.copy(
+            vertices = component.vertices + GraphVertex(GraphElementId("b"), "Account")
+        )
+
+        updated.componentId shouldBeEqualTo "component-1"
+        updated.size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `algorithm result model들은 Serializable이다`() {
+        val degree: java.io.Serializable = DegreeResult(GraphElementId("v-1"), inDegree = 1, outDegree = 2)
+        val score: java.io.Serializable = PageRankScore(GraphVertex(GraphElementId("v-1"), "Person"), score = 0.7)
+        val component: java.io.Serializable = GraphComponent("component-1", emptyList())
+
+        degree shouldBeInstanceOf java.io.Serializable::class
+        score shouldBeInstanceOf java.io.Serializable::class
+        component shouldBeInstanceOf java.io.Serializable::class
+    }
+}

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphSchemaModelsTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphSchemaModelsTest.kt
@@ -1,0 +1,129 @@
+package io.bluetape4k.graph.model
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+
+class GraphSchemaModelsTest {
+
+    @Test
+    fun `GraphSchemaEntityType은 vertex edge unknown을 가진다`() {
+        GraphSchemaEntityType.entries shouldBeEqualTo listOf(
+            GraphSchemaEntityType.VERTEX,
+            GraphSchemaEntityType.EDGE,
+            GraphSchemaEntityType.UNKNOWN,
+        )
+    }
+
+    @Test
+    fun `GraphConstraintType은 unique exists unknown을 가진다`() {
+        GraphConstraintType.entries shouldBeEqualTo listOf(
+            GraphConstraintType.UNIQUE,
+            GraphConstraintType.EXISTS,
+            GraphConstraintType.UNKNOWN,
+        )
+    }
+
+    @Test
+    fun `GraphIndex 기본 entityType은 vertex이며 unique는 false이다`() {
+        val index = GraphIndex(name = "bt4k_idx_Person_email", label = "Person", property = "email")
+
+        index.name shouldBeEqualTo "bt4k_idx_Person_email"
+        index.label shouldBeEqualTo "Person"
+        index.property shouldBeEqualTo "email"
+        index.entityType shouldBeEqualTo GraphSchemaEntityType.VERTEX
+        index.unique shouldBeEqualTo false
+    }
+
+    @Test
+    fun `GraphIndex는 edge schema와 property 없는 index를 표현한다`() {
+        val index = GraphIndex(
+            name = "bt4k_idx_KNOWS",
+            label = "KNOWS",
+            property = null,
+            entityType = GraphSchemaEntityType.EDGE,
+            unique = true,
+        )
+
+        index.property.shouldBeNull()
+        index.entityType shouldBeEqualTo GraphSchemaEntityType.EDGE
+        index.unique shouldBeEqualTo true
+    }
+
+    @Test
+    fun `GraphIndex copy로 일부 필드만 변경한다`() {
+        val base = GraphIndex(name = "bt4k_idx_Person_email", label = "Person", property = "email")
+        val updated = base.copy(name = "bt4k_idx_Account_email", label = "Account")
+
+        updated.name shouldBeEqualTo "bt4k_idx_Account_email"
+        updated.label shouldBeEqualTo "Account"
+        updated.property shouldBeEqualTo "email"
+        updated.entityType shouldBeEqualTo GraphSchemaEntityType.VERTEX
+        updated.unique shouldBeEqualTo false
+    }
+
+    @Test
+    fun `GraphConstraint 기본 entityType은 vertex이다`() {
+        val constraint = GraphConstraint(
+            name = "bt4k_uc_Person_email",
+            label = "Person",
+            property = "email",
+            type = GraphConstraintType.UNIQUE,
+        )
+
+        constraint.name shouldBeEqualTo "bt4k_uc_Person_email"
+        constraint.label shouldBeEqualTo "Person"
+        constraint.property shouldBeEqualTo "email"
+        constraint.type shouldBeEqualTo GraphConstraintType.UNIQUE
+        constraint.entityType shouldBeEqualTo GraphSchemaEntityType.VERTEX
+    }
+
+    @Test
+    fun `GraphConstraint는 edge constraint도 표현한다`() {
+        val constraint = GraphConstraint(
+            name = "bt4k_exists_KNOWS_since",
+            label = "KNOWS",
+            property = "since",
+            type = GraphConstraintType.EXISTS,
+            entityType = GraphSchemaEntityType.EDGE,
+        )
+
+        constraint.type shouldBeEqualTo GraphConstraintType.EXISTS
+        constraint.entityType shouldBeEqualTo GraphSchemaEntityType.EDGE
+    }
+
+    @Test
+    fun `GraphConstraint copy로 type만 변경한다`() {
+        val base = GraphConstraint(
+            name = "bt4k_constraint_unknown",
+            label = "Account",
+            property = "risk",
+            type = GraphConstraintType.UNKNOWN,
+        )
+        val updated = base.copy(type = GraphConstraintType.EXISTS)
+
+        updated.name shouldBeEqualTo "bt4k_constraint_unknown"
+        updated.label shouldBeEqualTo "Account"
+        updated.property shouldBeEqualTo "risk"
+        updated.type shouldBeEqualTo GraphConstraintType.EXISTS
+    }
+
+    @Test
+    fun `schema metadata model들은 Serializable이다`() {
+        val index: java.io.Serializable = GraphIndex(
+            name = "bt4k_idx_Person_email",
+            label = "Person",
+            property = "email",
+        )
+        val constraint: java.io.Serializable = GraphConstraint(
+            name = "bt4k_uc_Person_email",
+            label = "Person",
+            property = "email",
+            type = GraphConstraintType.UNIQUE,
+        )
+
+        index shouldBeInstanceOf java.io.Serializable::class
+        constraint shouldBeInstanceOf java.io.Serializable::class
+    }
+}

--- a/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphTraversalOptionsTest.kt
+++ b/graph/graph-core/src/test/kotlin/io/bluetape4k/graph/model/GraphTraversalOptionsTest.kt
@@ -1,8 +1,10 @@
 package io.bluetape4k.graph.model
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldContain
 import org.junit.jupiter.api.Test
 
 class GraphTraversalOptionsTest {
@@ -102,5 +104,112 @@ class GraphTraversalOptionsTest {
 
         neighbor shouldBeInstanceOf java.io.Serializable::class
         path shouldBeInstanceOf java.io.Serializable::class
+    }
+
+    @Test
+    fun `BfsDfsOptions 기본값은 OUTGOING-depth 5-maxVertices 10000이다`() {
+        val opts = BfsDfsOptions()
+
+        opts.edgeLabel.shouldBeNull()
+        opts.direction shouldBeEqualTo Direction.OUTGOING
+        opts.maxDepth shouldBeEqualTo 5
+        opts.maxVertices shouldBeEqualTo 10_000
+    }
+
+    @Test
+    fun `BfsDfsOptions Default 상수는 기본 생성자와 동일하다`() {
+        BfsDfsOptions.Default shouldBeEqualTo BfsDfsOptions()
+    }
+
+    @Test
+    fun `BfsDfsOptions는 모든 필드를 명시해서 생성할 수 있다`() {
+        val opts = BfsDfsOptions(
+            edgeLabel = "TRANSFERRED_TO",
+            direction = Direction.BOTH,
+            maxDepth = 7,
+            maxVertices = 250,
+        )
+
+        opts.edgeLabel shouldBeEqualTo "TRANSFERRED_TO"
+        opts.direction shouldBeEqualTo Direction.BOTH
+        opts.maxDepth shouldBeEqualTo 7
+        opts.maxVertices shouldBeEqualTo 250
+    }
+
+    @Test
+    fun `BfsDfsOptions는 음수 maxDepth를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            BfsDfsOptions(maxDepth = -1)
+        }
+
+        ex.message shouldContain "maxDepth"
+    }
+
+    @Test
+    fun `BfsDfsOptions는 0 이하 maxVertices를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            BfsDfsOptions(maxVertices = 0)
+        }
+
+        ex.message shouldContain "maxVertices"
+    }
+
+    @Test
+    fun `CycleOptions 기본값은 depth 10-maxCycles 100이다`() {
+        val opts = CycleOptions()
+
+        opts.vertexLabel.shouldBeNull()
+        opts.edgeLabel.shouldBeNull()
+        opts.maxDepth shouldBeEqualTo 10
+        opts.maxCycles shouldBeEqualTo 100
+    }
+
+    @Test
+    fun `CycleOptions Default 상수는 기본 생성자와 동일하다`() {
+        CycleOptions.Default shouldBeEqualTo CycleOptions()
+    }
+
+    @Test
+    fun `CycleOptions는 모든 필드를 명시해서 생성할 수 있다`() {
+        val opts = CycleOptions(
+            vertexLabel = "Account",
+            edgeLabel = "TRANSFERRED_TO",
+            maxDepth = 4,
+            maxCycles = 12,
+        )
+
+        opts.vertexLabel shouldBeEqualTo "Account"
+        opts.edgeLabel shouldBeEqualTo "TRANSFERRED_TO"
+        opts.maxDepth shouldBeEqualTo 4
+        opts.maxCycles shouldBeEqualTo 12
+    }
+
+    @Test
+    fun `CycleOptions는 음수 maxDepth를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            CycleOptions(maxDepth = -1)
+        }
+
+        ex.message shouldContain "maxDepth"
+    }
+
+    @Test
+    fun `CycleOptions는 0 이하 maxCycles를 거부한다`() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            CycleOptions(maxCycles = 0)
+        }
+
+        ex.message shouldContain "maxCycles"
+    }
+
+    @Test
+    fun `BfsDfsOptions와 CycleOptions는 GraphTraversalOptions의 하위 타입이며 Serializable이다`() {
+        val bfsDfs: GraphTraversalOptions = BfsDfsOptions()
+        val cycle: GraphTraversalOptions = CycleOptions()
+
+        bfsDfs shouldBeInstanceOf BfsDfsOptions::class
+        cycle shouldBeInstanceOf CycleOptions::class
+        bfsDfs shouldBeInstanceOf java.io.Serializable::class
+        cycle shouldBeInstanceOf java.io.Serializable::class
     }
 }


### PR DESCRIPTION
## Summary

- Adds focused `graph-core` model tests for algorithm options, traversal options, schema metadata, and algorithm result DTOs.
- Raises `graph-core` Kover instruction coverage above the current graph module average targeted by #371.
- Keeps production code unchanged.

## Coverage

- Before: `4090/5688 = 71.91%` instruction coverage.
- After: `4574/5688 = 80.41%` instruction coverage.
- Target average from #371: `78.88%`.

## Verification

```bash
./gradlew :bluetape4k-graph-core:test :bluetape4k-graph-core:koverXmlReport --no-daemon --no-configuration-cache
```

Result: `324 passing`; Kover XML generated successfully.

Fixes #371

## DoD Status

- [x] `graph-core` coverage is above the issue target average.
- [x] Targeted tests pass locally.
- [x] Kover XML report generated locally.
- [x] Production code unchanged.
