### PR TITLE
test(graph-io-core): raise suspend writer coverage

### DIFF
--- a/docs/review/2026-07-05-issue-370-graph-io-core-coverage-review.md
+++ b/docs/review/2026-07-05-issue-370-graph-io-core-coverage-review.md
@@ -1,0 +1,26 @@
+# Issue 370 Graph IO Core Coverage Review
+
+## Scope
+
+- Module: `graph-io/core`
+- Issue: #370
+- Change: Add suspend batch writer tests mirroring existing blocking writer coverage.
+
+## Tier 4: Implementation Review
+
+- PASS: Production code is unchanged.
+- PASS: Tests exercise `SuspendGraphIoBatchWriter` vertex buffering, edge buffering, explicit flush, and empty-buffer no-op paths.
+- PASS: The tests reuse existing module dependencies and `bluetape4k` assertion style.
+- PASS: Coroutine tests use `runSuspendIO`; no ad hoc thread or sleep-based concurrency is introduced.
+
+## Tier 5: Regression Review
+
+- PASS: Targeted verification passed:
+  `./gradlew :bluetape4k-graph-io-core:detekt :bluetape4k-graph-io-core:test :bluetape4k-graph-io-core:koverXmlReport --no-daemon --no-configuration-cache`
+- PASS: `graph-io-core` instruction coverage increased from `74.72%` to `92.43%`, above the `78.88%` target.
+- PASS: `git diff --check` passed.
+
+## Findings
+
+- P0: 0
+- P1: 0

--- a/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoBatchWriterTest.kt
+++ b/graph-io/core/src/test/kotlin/io/bluetape4k/graph/io/support/GraphIoBatchWriterTest.kt
@@ -5,6 +5,11 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.graph.io.options.DuplicateVertexPolicy
 import io.bluetape4k.graph.io.testsupport.FakeGraphOperations
+import io.bluetape4k.graph.repository.GraphSuspendOperations
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
 import io.bluetape4k.graph.model.BatchEdge
 import io.bluetape4k.graph.model.GraphEdge
 import io.bluetape4k.graph.model.GraphElementId
@@ -88,5 +93,83 @@ class GraphIoBatchWriterTest {
         writer.flushVertices(idMap) shouldBeEqualTo 0
         writer.flushEdges() shouldBeEqualTo 0
         idMap.resolve("missing").shouldBeNull()
+    }
+
+    @Test
+    fun `suspend vertex writer flushes by label and maps returned ids in input order`() = runSuspendIO {
+        val operations = mockk<GraphSuspendOperations>()
+        val calls = mutableListOf<List<Map<String, Any?>>>()
+        var sequence = 0
+        coEvery { operations.createVertices("Person", any()) } coAnswers {
+            val rows = secondArg<List<Map<String, Any?>>>()
+            calls += rows
+            rows.map { properties ->
+                sequence++
+                GraphVertex(GraphElementId.of("sv$sequence"), "Person", properties)
+            }
+        }
+        val idMap = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+        val writer = SuspendGraphIoBatchWriter(operations, batchSize = 2)
+
+        listOf("a", "b", "c").forEach { id ->
+            idMap.putFirstOrFail(id, GraphElementId.of(id))
+            writer.addVertex(id, "Person", mapOf("name" to id.uppercase()), idMap)
+        }
+
+        calls.shouldHaveSize(1)
+        calls.single().map { it["name"] } shouldBeEqualTo listOf("A", "B")
+        idMap.resolve("a") shouldBeEqualTo GraphElementId.of("sv1")
+        idMap.resolve("b") shouldBeEqualTo GraphElementId.of("sv2")
+        idMap.resolve("c") shouldBeEqualTo GraphElementId.of("c")
+
+        writer.flushVertices(idMap) shouldBeEqualTo 1
+        calls.shouldHaveSize(2)
+        calls.last().map { it["name"] } shouldBeEqualTo listOf("C")
+        idMap.resolve("c") shouldBeEqualTo GraphElementId.of("sv3")
+        coVerify(exactly = 2) { operations.createVertices("Person", any()) }
+    }
+
+    @Test
+    fun `suspend edge writer flushes by label and batch size`() = runSuspendIO {
+        val operations = mockk<GraphSuspendOperations>()
+        val calls = mutableListOf<List<BatchEdge>>()
+        var sequence = 0
+        coEvery { operations.createEdges("KNOWS", any()) } coAnswers {
+            val edges = secondArg<List<BatchEdge>>()
+            calls += edges
+            edges.map { edge ->
+                sequence++
+                GraphEdge(GraphElementId.of("se$sequence"), "KNOWS", edge.fromId, edge.toId, edge.properties)
+            }
+        }
+        val writer = SuspendGraphIoBatchWriter(operations, batchSize = 2)
+        val a = GraphElementId.of("a")
+        val b = GraphElementId.of("b")
+        val c = GraphElementId.of("c")
+
+        writer.addEdge("KNOWS", a, b, mapOf("rank" to 1))
+        writer.addEdge("KNOWS", b, c, mapOf("rank" to 2))
+        writer.addEdge("KNOWS", c, a, mapOf("rank" to 3))
+
+        calls.shouldHaveSize(1)
+        calls.single().map { it.properties["rank"] } shouldBeEqualTo listOf(1, 2)
+
+        writer.flushEdges() shouldBeEqualTo 1
+        calls.shouldHaveSize(2)
+        calls.last().map { it.properties["rank"] } shouldBeEqualTo listOf(3)
+        coVerify(exactly = 2) { operations.createEdges("KNOWS", any()) }
+    }
+
+    @Test
+    fun `suspend flush on empty buffers is a no-op`() = runSuspendIO {
+        val operations = mockk<GraphSuspendOperations>()
+        val writer = SuspendGraphIoBatchWriter(operations, batchSize = 2)
+        val idMap = GraphIoExternalIdMap(DuplicateVertexPolicy.FAIL)
+
+        writer.flushVertices(idMap) shouldBeEqualTo 0
+        writer.flushEdges() shouldBeEqualTo 0
+        idMap.resolve("missing").shouldBeNull()
+        coVerify(exactly = 0) { operations.createVertices(any(), any()) }
+        coVerify(exactly = 0) { operations.createEdges(any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary

- Adds suspend batch writer tests for `graph-io-core`.
- Mirrors existing blocking writer coverage for vertex batching, edge batching, explicit flush, and empty-buffer no-op paths.
- Raises `graph-io-core` Kover instruction coverage above the current graph module average targeted by #370.
- Keeps production code unchanged.

## Coverage

- Before: `1708/2286 = 74.72%` instruction coverage.
- After: `2113/2286 = 92.43%` instruction coverage.
- Target average from #370: `78.88%`.

## Verification

```bash
./gradlew :bluetape4k-graph-io-core:detekt :bluetape4k-graph-io-core:test :bluetape4k-graph-io-core:koverXmlReport --no-daemon --no-configuration-cache
```

Result: `82 passing`; detekt passed; Kover XML generated successfully.

Fixes #370

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Worktree | PASS | `test/issue-370-graph-io-core-coverage` worktree branch. |
| Implementation | PASS | Added focused `SuspendGraphIoBatchWriter` tests; production code unchanged. |
| Coverage | PASS | `graph-io-core` instruction coverage is `92.43%`, above `78.88%`. |
| Verification | PASS | `:bluetape4k-graph-io-core:detekt`, `:test`, and `:koverXmlReport` passed locally. |
| Review | PASS | `docs/review/2026-07-05-issue-370-graph-io-core-coverage-review.md`; P0/P1 = 0. |
