### PR TITLE
test(graph-spring-boot): raise health coverage

### DIFF
--- a/docs/review/2026-07-05-issue-375-graph-spring-boot-coverage-review.md
+++ b/docs/review/2026-07-05-issue-375-graph-spring-boot-coverage-review.md
@@ -1,0 +1,31 @@
+# Issue 375 Graph Spring Boot Coverage Review
+
+## Scope
+
+- GitHub issue: #375
+- Module: `bluetape4k-graph-spring-boot`
+- Change type: test-only coverage improvement
+
+## Findings
+
+- P0: none
+- P1: none
+
+## Coverage
+
+- Baseline instruction coverage: `547/733 = 74.62%`
+- Updated instruction coverage: `627/733 = 85.54%`
+- Repository average target from coverage audit: `78.88%`
+
+## Review Notes
+
+- Added focused health indicator tests for AGE, Memgraph, Neo4j, and TinkerGraph auto-configurations.
+- Kept production auto-configuration behavior unchanged.
+- Used mocks for health indicator branches so the new coverage does not add external service dependency.
+
+## Verification
+
+```bash
+./gradlew :bluetape4k-graph-spring-boot:detekt :bluetape4k-graph-spring-boot:test :bluetape4k-graph-spring-boot:koverXmlReport --no-daemon --no-configuration-cache
+git diff --check
+```

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphAgeAutoConfigurationTest.kt
@@ -2,12 +2,16 @@ package io.bluetape4k.graph.spring.boot.autoconfigure
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
-import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.testcontainers.graphdb.PostgreSQLAgeServer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -16,6 +20,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.sql.Connection
+import java.sql.Statement
 import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -83,5 +89,42 @@ class GraphAgeAutoConfigurationTest {
             assertThatThrownBy { ctx.getBean(GraphVirtualThreadOperations::class.java) }
                 .isInstanceOf(NoSuchBeanDefinitionException::class.java)
         }
+    }
+
+    @Test
+    fun `AGE health indicator reports UP when validation query succeeds`() {
+        val dataSource = mockk<DataSource>()
+        val connection = mockk<Connection>(relaxed = true)
+        val statement = mockk<Statement>(relaxed = true)
+
+        every { dataSource.connection } returns connection
+        every { connection.createStatement() } returns statement
+        every { statement.execute("SELECT 1") } returns true
+
+        val health = GraphAgeAutoConfiguration.HealthConfig()
+            .ageHealthIndicator(dataSource)
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "UP"
+        health.details["backend"] shouldBeEqualTo "age"
+        verify {
+            statement.execute("SELECT 1")
+            connection.close()
+        }
+    }
+
+    @Test
+    fun `AGE health indicator reports DOWN when validation query fails`() {
+        val dataSource = mockk<DataSource>()
+
+        every { dataSource.connection } throws IllegalStateException("age is unavailable")
+
+        val health = GraphAgeAutoConfiguration.HealthConfig()
+            .ageHealthIndicator(dataSource)
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "DOWN"
     }
 }

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphMemgraphAutoConfigurationTest.kt
@@ -1,12 +1,15 @@
 package io.bluetape4k.graph.spring.boot.autoconfigure
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
-import io.bluetape4k.testcontainers.graphdb.MemgraphServer
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.testcontainers.graphdb.MemgraphServer
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.neo4j.driver.Driver
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -86,5 +89,36 @@ class GraphMemgraphAutoConfigurationTest {
             assertThatThrownBy { ctx.getBean(GraphVirtualThreadOperations::class.java) }
                 .isInstanceOf(NoSuchBeanDefinitionException::class.java)
         }
+    }
+
+    @Test
+    fun `Memgraph health indicator reports UP when connectivity succeeds`() {
+        val driver = mockk<Driver>()
+
+        every { driver.verifyConnectivity() } returns Unit
+
+        val health = GraphMemgraphAutoConfiguration.HealthConfig()
+            .memgraphHealthIndicator(driver)
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "UP"
+        health.details["backend"] shouldBeEqualTo "memgraph"
+        verify { driver.verifyConnectivity() }
+    }
+
+    @Test
+    fun `Memgraph health indicator reports DOWN when connectivity fails`() {
+        val driver = mockk<Driver>()
+
+        every { driver.verifyConnectivity() } throws IllegalStateException("memgraph is unavailable")
+
+        val health = GraphMemgraphAutoConfiguration.HealthConfig()
+            .memgraphHealthIndicator(driver)
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "DOWN"
+        verify { driver.verifyConnectivity() }
     }
 }

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphNeo4jAutoConfigurationTest.kt
@@ -1,11 +1,16 @@
 package io.bluetape4k.graph.spring.boot.autoconfigure
 
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
-import io.bluetape4k.testcontainers.graphdb.Neo4jServer
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.neo4j.driver.Driver
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -63,5 +68,36 @@ class GraphNeo4jAutoConfigurationTest {
             assertThatThrownBy { ctx.getBean(GraphVirtualThreadOperations::class.java) }
                 .isInstanceOf(NoSuchBeanDefinitionException::class.java)
         }
+    }
+
+    @Test
+    fun `Neo4j health indicator reports UP when connectivity succeeds`() {
+        val driver = mockk<Driver>()
+
+        every { driver.verifyConnectivity() } returns Unit
+
+        val health = GraphNeo4jAutoConfiguration.HealthConfig()
+            .neo4jHealthIndicator(driver)
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "UP"
+        health.details["backend"] shouldBeEqualTo "neo4j"
+        verify { driver.verifyConnectivity() }
+    }
+
+    @Test
+    fun `Neo4j health indicator reports DOWN when connectivity fails`() {
+        val driver = mockk<Driver>()
+
+        every { driver.verifyConnectivity() } throws IllegalStateException("neo4j is unavailable")
+
+        val health = GraphNeo4jAutoConfiguration.HealthConfig()
+            .neo4jHealthIndicator(driver)
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "DOWN"
+        verify { driver.verifyConnectivity() }
     }
 }

--- a/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfigurationTest.kt
+++ b/spring-boot/graph-spring-boot/src/test/kotlin/io/bluetape4k/graph/spring/boot/autoconfigure/GraphTinkerGraphAutoConfigurationTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.graph.spring.boot.autoconfigure
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.graph.repository.GraphOperations
 import io.bluetape4k.graph.repository.GraphSuspendOperations
 import io.bluetape4k.graph.repository.GraphVirtualThreadOperations
@@ -69,5 +70,16 @@ class GraphTinkerGraphAutoConfigurationTest {
             assertThatThrownBy { ctx.getBean(GraphVirtualThreadOperations::class.java) }
                 .isInstanceOf(NoSuchBeanDefinitionException::class.java)
         }
+    }
+
+    @Test
+    fun `TinkerGraph health indicator reports UP`() {
+        val health = GraphTinkerGraphAutoConfiguration.HealthConfig()
+            .tinkerGraphHealthIndicator()
+            .health()
+            .shouldNotBeNull()
+
+        health.status.code shouldBeEqualTo "UP"
+        health.details["backend"] shouldBeEqualTo "tinkergraph"
     }
 }


### PR DESCRIPTION
## Summary

- Closes #375
- Add focused health indicator branch tests for graph Spring Boot auto-configurations.
- Raise `bluetape4k-graph-spring-boot` instruction coverage above the repository average target.

## Coverage

- Baseline: `547/733 = 74.62%`
- Updated: `627/733 = 85.54%`
- Target from coverage audit: `78.88%`

## Verification

- `./gradlew :bluetape4k-graph-spring-boot:detekt :bluetape4k-graph-spring-boot:test :bluetape4k-graph-spring-boot:koverXmlReport --no-daemon --no-configuration-cache`
- `git diff --check`

## DoD Status

- [x] Issue metadata mirrored: assignee `debop`, labels `test`, `ci`, milestone `0.6.0`
- [x] Test-only production behavior preserved
- [x] Targeted module tests pass
- [x] Kover XML regenerated and coverage is above target
