### PR TITLE
test(graph-tinkerpop): raise suspend adapter coverage

### DIFF
--- a/docs/review/2026-07-05-issue-372-graph-tinkerpop-coverage-review.md
+++ b/docs/review/2026-07-05-issue-372-graph-tinkerpop-coverage-review.md
@@ -1,0 +1,31 @@
+# Issue 372 Graph TinkerPop Coverage Review
+
+## Scope
+
+- GitHub issue: #372
+- Module: `bluetape4k-graph-tinkerpop`
+- Change type: test-only coverage improvement
+
+## Findings
+
+- P0: none
+- P1: none
+
+## Coverage
+
+- Baseline instruction coverage: `4569/5906 = 77.36%`
+- Updated instruction coverage: `4834/5906 = 81.85%`
+- Repository average target from coverage audit: `78.88%`
+
+## Review Notes
+
+- Added focused suspend algorithm adapter tests for degree centrality, connected components, DFS, and cycle detection.
+- Kept production TinkerGraph behavior unchanged.
+- Covered adapter paths that were previously unexecuted without adding external infrastructure.
+
+## Verification
+
+```bash
+./gradlew :bluetape4k-graph-tinkerpop:detekt :bluetape4k-graph-tinkerpop:test :bluetape4k-graph-tinkerpop:koverXmlReport --no-daemon --no-configuration-cache
+git diff --check
+```

--- a/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphAlgorithmSuspendTest.kt
+++ b/graph/graph-tinkerpop/src/test/kotlin/io/bluetape4k/graph/tinkerpop/TinkerGraphAlgorithmSuspendTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.graph.tinkerpop
 
 import io.bluetape4k.graph.model.BfsDfsOptions
+import io.bluetape4k.graph.model.ComponentOptions
+import io.bluetape4k.graph.model.CycleOptions
+import io.bluetape4k.graph.model.DegreeOptions
 import io.bluetape4k.graph.model.PageRankOptions
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -51,5 +54,61 @@ class TinkerGraphAlgorithmSuspendTest {
         val visits = ops.bfs(a.id, BfsDfsOptions(edgeLabel = "E", maxDepth = 2)).toList()
         visits.first().depth shouldBeEqualTo 0
         visits.size shouldBeGreaterOrEqualTo 2
+    }
+
+    @Test
+    fun `degreeCentrality delegates through suspend adapter`() = runSuspendIO {
+        val a = ops.createVertex("Person", mapOf("name" to "A"))
+        val b = ops.createVertex("Person", mapOf("name" to "B"))
+        val c = ops.createVertex("Person", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "KNOWS")
+        ops.createEdge(c.id, a.id, "KNOWS")
+
+        val degree = ops.degreeCentrality(a.id, DegreeOptions(edgeLabel = "KNOWS"))
+
+        degree.inDegree shouldBeEqualTo 1
+        degree.outDegree shouldBeEqualTo 1
+        degree.total shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `connectedComponents Flow emits component groups`() = runSuspendIO {
+        val a1 = ops.createVertex("Person", mapOf("group" to "A"))
+        val a2 = ops.createVertex("Person", mapOf("group" to "A"))
+        val b1 = ops.createVertex("Person", mapOf("group" to "B"))
+        val b2 = ops.createVertex("Person", mapOf("group" to "B"))
+        ops.createEdge(a1.id, a2.id, "REL")
+        ops.createEdge(b1.id, b2.id, "REL")
+
+        val components = ops.connectedComponents(ComponentOptions(vertexLabel = "Person", edgeLabel = "REL")).toList()
+
+        components.size shouldBeGreaterOrEqualTo 2
+    }
+
+    @Test
+    fun `dfs Flow starts from the requested vertex`() = runSuspendIO {
+        val a = ops.createVertex("Node", emptyMap())
+        val b = ops.createVertex("Node", emptyMap())
+        ops.createEdge(a.id, b.id, "E")
+
+        val visits = ops.dfs(a.id, BfsDfsOptions(edgeLabel = "E", maxDepth = 3)).toList()
+
+        visits.first().vertex.id shouldBeEqualTo a.id
+        visits.size shouldBeGreaterOrEqualTo 2
+    }
+
+    @Test
+    fun `detectCycles Flow emits triangle cycles`() = runSuspendIO {
+        val a = ops.createVertex("Node", emptyMap())
+        val b = ops.createVertex("Node", emptyMap())
+        val c = ops.createVertex("Node", emptyMap())
+        ops.createEdge(a.id, b.id, "E")
+        ops.createEdge(b.id, c.id, "E")
+        ops.createEdge(c.id, a.id, "E")
+
+        val cycles = ops.detectCycles(CycleOptions(maxDepth = 5)).toList()
+
+        cycles.shouldNotBeEmpty()
+        cycles.first().path.vertices.first().id shouldBeEqualTo cycles.first().path.vertices.last().id
     }
 }


### PR DESCRIPTION
## Summary

- Closes #372
- Add focused suspend algorithm adapter tests for TinkerGraph.
- Raise `bluetape4k-graph-tinkerpop` instruction coverage above the repository average target.

## Coverage

- Baseline: `4569/5906 = 77.36%`
- Updated: `4834/5906 = 81.85%`
- Target from coverage audit: `78.88%`

## Verification

- `./gradlew :bluetape4k-graph-tinkerpop:detekt :bluetape4k-graph-tinkerpop:test :bluetape4k-graph-tinkerpop:koverXmlReport --no-daemon --no-configuration-cache`
- `git diff --check`

## DoD Status

- [x] Issue metadata mirrored: assignee `debop`, labels `test`, `ci`, milestone `0.6.0`
- [x] Test-only production behavior preserved
- [x] Targeted module tests pass
- [x] Kover XML regenerated and coverage is above target
