### PR TITLE
test(graph-memgraph): raise suspend coverage

### DIFF
--- a/docs/review/2026-07-05-issue-373-graph-memgraph-coverage-review.md
+++ b/docs/review/2026-07-05-issue-373-graph-memgraph-coverage-review.md
@@ -1,0 +1,31 @@
+# Issue 373 Graph Memgraph Coverage Review
+
+## Scope
+
+- GitHub issue: #373
+- Module: `bluetape4k-graph-memgraph`
+- Change type: test-only coverage improvement
+
+## Findings
+
+- P0: none
+- P1: none
+
+## Coverage
+
+- Baseline instruction coverage: `6508/8881 = 73.28%`
+- Updated instruction coverage: `7465/8881 = 84.06%`
+- Repository average target from coverage audit: `78.88%`
+
+## Review Notes
+
+- Added focused Memgraph suspend algorithm Flow tests.
+- Added a successful `suspendTransaction` scoped CRUD test to cover reactive transaction scope behavior.
+- Kept production Memgraph implementation unchanged.
+
+## Verification
+
+```bash
+./gradlew :bluetape4k-graph-memgraph:detekt :bluetape4k-graph-memgraph:test :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache
+git diff --check
+```

--- a/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperationsTest.kt
+++ b/graph/graph-memgraph/src/test/kotlin/io/bluetape4k/graph/memgraph/MemgraphGraphSuspendOperationsTest.kt
@@ -2,9 +2,14 @@ package io.bluetape4k.graph.memgraph
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.graph.GraphQueryException
+import io.bluetape4k.graph.model.BfsDfsOptions
+import io.bluetape4k.graph.model.ComponentOptions
+import io.bluetape4k.graph.model.CycleOptions
+import io.bluetape4k.graph.model.DegreeOptions
 import io.bluetape4k.graph.model.Direction
 import io.bluetape4k.graph.model.GraphElementId
 import io.bluetape4k.graph.model.NeighborOptions
+import io.bluetape4k.graph.model.PageRankOptions
 import io.bluetape4k.graph.model.PathOptions
 import io.bluetape4k.graph.repository.suspendTransaction
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -421,5 +426,113 @@ class MemgraphGraphSuspendOperationsTest {
         val paths = ops.allPaths(a.id, c.id, PathOptions(edgeLabel = "KNOWS")).toList()
         paths.shouldNotBeEmpty()
         paths.size shouldBeGreaterOrEqualTo 2
+    }
+
+    @Test
+    @Order(59)
+    fun `suspendTransaction success path supports scoped CRUD operations`() = runSuspendIO {
+        val remaining = ops.suspendTransaction {
+            val alice = createVertex("Person", mapOf("name" to "Alice", "city" to "Seoul"))
+            val bob = createVertex("Person", mapOf("name" to "Bob", "city" to "Seoul"))
+
+            findVertexById("Person", alice.id)?.properties?.get("name") shouldBeEqualTo "Alice"
+            findVertexById(bob.id)?.properties?.get("name") shouldBeEqualTo "Bob"
+            findVerticesByLabel("Person", mapOf("city" to "Seoul")).toList().shouldHaveSize(2)
+
+            updateVertex("Person", alice.id, mapOf("city" to "Busan"))
+                ?.properties?.get("city") shouldBeEqualTo "Busan"
+            countVertices("Person") shouldBeEqualTo 2L
+
+            val edge = createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2024L))
+            findEdgesByLabel("KNOWS", mapOf("since" to 2024L)).toList().shouldHaveSize(1)
+            findEdgesByStartId(alice.id, "KNOWS").toList().shouldHaveSize(1)
+            findEdgesByEndId(bob.id, null).toList().shouldHaveSize(1)
+
+            deleteEdge("KNOWS", edge.id).shouldBeTrue()
+            deleteVertex("Person", bob.id).shouldBeTrue()
+
+            countVertices("Person")
+        }
+
+        remaining shouldBeEqualTo 1L
+    }
+
+    @Test
+    @Order(60)
+    fun `suspend degreeCentrality counts both directions`() = runSuspendIO {
+        val a = ops.createVertex("Person", mapOf("name" to "A"))
+        val b = ops.createVertex("Person", mapOf("name" to "B"))
+        val c = ops.createVertex("Person", mapOf("name" to "C"))
+        ops.createEdge(a.id, b.id, "KNOWS")
+        ops.createEdge(c.id, a.id, "KNOWS")
+
+        val degree = ops.degreeCentrality(a.id, DegreeOptions(edgeLabel = "KNOWS"))
+
+        degree.outDegree shouldBeEqualTo 1
+        degree.inDegree shouldBeEqualTo 1
+        degree.total shouldBeEqualTo 2
+    }
+
+    @Test
+    @Order(61)
+    fun `suspend pageRank Flow emits scores`() = runSuspendIO {
+        val hub = ops.createVertex("Person", mapOf("name" to "Hub"))
+        repeat(3) { i ->
+            val leaf = ops.createVertex("Person", mapOf("name" to "L$i"))
+            ops.createEdge(leaf.id, hub.id, "FOLLOWS")
+        }
+
+        val scores = ops.pageRank(PageRankOptions(vertexLabel = "Person", iterations = 30)).toList()
+
+        scores.shouldNotBeEmpty()
+        scores.first().vertex.properties["name"] shouldBeEqualTo "Hub"
+    }
+
+    @Test
+    @Order(62)
+    fun `suspend connectedComponents Flow emits linked groups`() = runSuspendIO {
+        val a1 = ops.createVertex("Person", mapOf("group" to "A"))
+        val a2 = ops.createVertex("Person", mapOf("group" to "A"))
+        val b1 = ops.createVertex("Person", mapOf("group" to "B"))
+        val b2 = ops.createVertex("Person", mapOf("group" to "B"))
+        ops.createEdge(a1.id, a2.id, "REL")
+        ops.createEdge(b1.id, b2.id, "REL")
+
+        val components = ops.connectedComponents(ComponentOptions(vertexLabel = "Person", edgeLabel = "REL")).toList()
+
+        components.size shouldBeGreaterOrEqualTo 2
+    }
+
+    @Test
+    @Order(63)
+    fun `suspend bfs and dfs Flows emit visits`() = runSuspendIO {
+        val a = ops.createVertex("Node", emptyMap())
+        val b = ops.createVertex("Node", emptyMap())
+        val c = ops.createVertex("Node", emptyMap())
+        ops.createEdge(a.id, b.id, "E")
+        ops.createEdge(b.id, c.id, "E")
+
+        val bfsVisits = ops.bfs(a.id, BfsDfsOptions(edgeLabel = "E", maxDepth = 2)).toList()
+        val dfsVisits = ops.dfs(a.id, BfsDfsOptions(edgeLabel = "E", maxDepth = 2)).toList()
+
+        bfsVisits.first().vertex.id shouldBeEqualTo a.id
+        bfsVisits.size shouldBeGreaterOrEqualTo 3
+        dfsVisits.first().vertex.id shouldBeEqualTo a.id
+        dfsVisits.size shouldBeGreaterOrEqualTo 2
+    }
+
+    @Test
+    @Order(64)
+    fun `suspend detectCycles Flow emits triangle cycles`() = runSuspendIO {
+        val a = ops.createVertex("Node", emptyMap())
+        val b = ops.createVertex("Node", emptyMap())
+        val c = ops.createVertex("Node", emptyMap())
+        ops.createEdge(a.id, b.id, "E")
+        ops.createEdge(b.id, c.id, "E")
+        ops.createEdge(c.id, a.id, "E")
+
+        val cycles = ops.detectCycles(CycleOptions(edgeLabel = "E", maxDepth = 5)).toList()
+
+        cycles.shouldNotBeEmpty()
     }
 }


### PR DESCRIPTION
## Summary

- Closes #373
- Add Memgraph suspend algorithm Flow coverage.
- Add successful reactive transaction scope CRUD coverage.
- Raise `bluetape4k-graph-memgraph` instruction coverage above the repository average target.

## Coverage

- Baseline: `6508/8881 = 73.28%`
- Updated: `7465/8881 = 84.06%`
- Target from coverage audit: `78.88%`

## Verification

- `./gradlew :bluetape4k-graph-memgraph:detekt :bluetape4k-graph-memgraph:test :bluetape4k-graph-memgraph:koverXmlReport --no-daemon --no-configuration-cache`
- `git diff --check`

## DoD Status

- [x] Issue metadata mirrored: assignee `debop`, labels `test`, `ci`, milestone `0.6.0`
- [x] Test-only production behavior preserved
- [x] Targeted module tests pass
- [x] Kover XML regenerated and coverage is above target
