### PR TITLE
test(graph-neo4j): raise suspend coverage

### DIFF
--- a/docs/review/2026-07-05-issue-374-graph-neo4j-coverage-review.md
+++ b/docs/review/2026-07-05-issue-374-graph-neo4j-coverage-review.md
@@ -1,0 +1,17 @@
+# Issue 374 Graph Neo4j Coverage Review
+
+## Scope
+
+- Added `Neo4jCoroutineSessionTest` to cover reactive read/write/query session wrappers.
+- Expanded `Neo4jGraphSuspendOperationsTest` to cover successful scoped transaction CRUD and cancellation rollback.
+
+## Coverage
+
+- Baseline: `6946 / 9133 = 76.05%`
+- Updated: `7831 / 9133 = 85.74%`
+- Main improvement: `Neo4jCoroutineSession` and `Neo4jReactiveGraphSuspendTransactionScope` execution paths.
+
+## Verification
+
+- `./gradlew :bluetape4k-graph-neo4j:detekt :bluetape4k-graph-neo4j:test :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache`
+- Result: `BUILD SUCCESSFUL`

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jCoroutineSessionTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jCoroutineSessionTest.kt
@@ -1,0 +1,101 @@
+package io.bluetape4k.graph.neo4j
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.awaitSingle
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.neo4j.driver.AuthTokens
+import org.neo4j.driver.GraphDatabase
+import org.neo4j.driver.Query
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Neo4jCoroutineSessionTest {
+
+    private val driver = GraphDatabase.driver(Neo4jServer.Launcher.neo4j.boltUrl, AuthTokens.none())
+    private val session = Neo4jCoroutineSession(driver)
+
+    @AfterAll
+    fun teardown() {
+        session.close()
+        driver.close()
+    }
+
+    @BeforeEach
+    fun clearGraph() = runSuspendIO {
+        session.runWriteQuery("MATCH (n) DETACH DELETE n")
+    }
+
+    @Test
+    fun `write materializes reactive records and closes the session`() = runSuspendIO {
+        val names = session.write { s ->
+            s.run(Query("CREATE (n:Person {name: 'Alice'}) RETURN n.name AS name"))
+                .awaitSingle()
+                .records()
+                .asFlow()
+                .map { it["name"].asString() }
+        }
+
+        names shouldBeEqualTo listOf("Alice")
+    }
+
+    @Test
+    fun `read materializes reactive records with query parameters`() = runSuspendIO {
+        session.runWriteQuery(
+            "CREATE (:Person {name: \$name})",
+            mapOf("name" to "Bob"),
+        )
+
+        val names = session.read { s ->
+            s.run(
+                Query(
+                    "MATCH (n:Person {name: \$name}) RETURN n.name AS name",
+                    mapOf("name" to "Bob"),
+                ),
+            )
+                .awaitSingle()
+                .records()
+                .asFlow()
+                .map { it["name"].asString() }
+        }
+
+        names shouldBeEqualTo listOf("Bob")
+    }
+
+    @Test
+    fun `runReadQuery and runWriteQuery return materialized records`() = runSuspendIO {
+        val created = session.runWriteQuery(
+            "CREATE (n:Person {name: \$name}) RETURN n.name AS name",
+            mapOf("name" to "Carol"),
+        )
+
+        created.shouldHaveSize(1)
+        created.single()["name"].asString() shouldBeEqualTo "Carol"
+
+        val found = session.runReadQuery(
+            "MATCH (n:Person {name: \$name}) RETURN n.name AS name",
+            mapOf("name" to "Carol"),
+        )
+
+        found.shouldHaveSize(1)
+        found.single()["name"].asString() shouldBeEqualTo "Carol"
+    }
+
+    @Test
+    fun `blank cypher is rejected before opening a session`() = runSuspendIO {
+        assertFailsWith<IllegalArgumentException> {
+            session.runReadQuery(" ")
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            session.runWriteQuery(" ")
+        }
+    }
+}

--- a/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSuspendOperationsTest.kt
+++ b/graph/graph-neo4j/src/test/kotlin/io/bluetape4k/graph/neo4j/Neo4jGraphSuspendOperationsTest.kt
@@ -13,7 +13,10 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.testcontainers.graphdb.Neo4jServer
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
@@ -204,6 +207,52 @@ class Neo4jGraphSuspendOperationsTest {
 
     @Test
     @Order(31)
+    fun `suspendTransaction은 scoped vertex와 edge CRUD를 지원한다`() = runSuspendIO {
+        val result = ops.suspendTransaction {
+            val alice = createVertex("Person", mapOf("name" to "Alice"))
+            val bob = createVertex("Person", mapOf("name" to "Bob"))
+
+            findVertexById("Person", alice.id)?.properties?.get("name") shouldBeEqualTo "Alice"
+            findVertexById(bob.id)?.properties?.get("name") shouldBeEqualTo "Bob"
+            countVertices("Person") shouldBeEqualTo 2L
+
+            updateVertex("Person", alice.id, mapOf("age" to 30L))?.properties?.get("age") shouldBeEqualTo 30L
+
+            val edge = createEdge(alice.id, bob.id, "KNOWS", mapOf("since" to 2026L))
+            findEdgesByLabel("KNOWS", mapOf("since" to 2026L)).toList().shouldHaveSize(1)
+            findEdgesByStartId(alice.id, "KNOWS").toList().shouldHaveSize(1)
+            findEdgesByEndId(bob.id).toList().shouldHaveSize(1)
+
+            deleteEdge("KNOWS", edge.id).shouldBeTrue()
+            deleteVertex("Person", bob.id).shouldBeTrue()
+
+            countVertices("Person")
+        }
+
+        result shouldBeEqualTo 1L
+        ops.countVertices("Person") shouldBeEqualTo 1L
+    }
+
+    @Test
+    @Order(32)
+    fun `suspendTransaction은 취소 시 빠르게 반환하고 rollback한다`() = runSuspendIO {
+        val existing = ops.createVertex("Person", mapOf("name" to "Existing"))
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(500) {
+                ops.suspendTransaction {
+                    createVertex("Person", mapOf("name" to "Cancelled"))
+                    awaitCancellation()
+                }
+            }
+        }
+
+        ops.findVertexById("Person", existing.id)?.properties?.get("name") shouldBeEqualTo "Existing"
+        ops.countVertices("Person") shouldBeEqualTo 1L
+    }
+
+    @Test
+    @Order(33)
     fun `unsafe Cypher identifiers are rejected before query execution`() = runSuspendIO {
         assertFailsWith<IllegalArgumentException> {
             ops.findVerticesByLabel("Person", mapOf("name) RETURN n MATCH (m" to "Alice")).toList()
@@ -216,7 +265,7 @@ class Neo4jGraphSuspendOperationsTest {
     // ----- 간선(Edge) CRUD -----
 
     @Test
-    @Order(32)
+    @Order(34)
     fun `createEdge로 간선을 생성한다`() = runSuspendIO {
         val alice = ops.createVertex("Person", mapOf("name" to "Alice"))
         val bob = ops.createVertex("Person", mapOf("name" to "Bob"))


### PR DESCRIPTION
## Summary

- Add live Neo4j coverage for `Neo4jCoroutineSession` read/write/query wrappers.
- Expand suspend transaction coverage for scoped vertex/edge CRUD and cancellation rollback.
- Record coverage evidence in `docs/review/2026-07-05-issue-374-graph-neo4j-coverage-review.md`.

Fixes #374

## Coverage

- Baseline: `6946 / 9133 = 76.05%`
- Updated: `7831 / 9133 = 85.74%`

## Verification

- `./gradlew :bluetape4k-graph-neo4j:detekt :bluetape4k-graph-neo4j:test :bluetape4k-graph-neo4j:koverXmlReport --no-daemon --no-configuration-cache`
- `git diff --check`

## DoD Status

- [x] Issue milestone and labels mirrored from #374.
- [x] `graph-neo4j` coverage is above the graph repository average.
- [x] Targeted module verification passed.
