### PR TITLE
build: sync managed catalog versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,13 +19,13 @@ neo4j-java-driver = "6.1.0"  # https://mvnrepository.com/artifact/org.neo4j.driv
 neo4j-bolt-connection = "11.0.2"  # https://mvnrepository.com/artifact/org.neo4j.bolt/neo4j-bolt-connection-bom
 
 # Local Exposed aliases keep modules that are not exposed by the bt4k catalog.
-exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-core
+exposed = "1.3.1"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-core
 
 # Local Okio/Jackson aliases keep graph-io-specific companion modules.
 okio = "3.17.0"  # https://mvnrepository.com/artifact/com.squareup.okio/okio-fakefilesystem
 okhttp3 = "5.3.2"  # https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom
 
-jackson = "2.22.0"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
+jackson = "2.22.1"  # https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom
 jackson3 = "3.2.0"  # https://mvnrepository.com/artifact/tools.jackson/jackson-bom
 
 feign = "13.12"  # https://mvnrepository.com/artifact/io.github.openfeign/feign-bom
@@ -51,7 +51,7 @@ detekt = "2.0.0-alpha.3"  # https://plugins.gradle.org/plugin/dev.detekt
 # Local Kover/Shadow/Gatling plugin aliases are not exposed by the bt4k catalog.
 kover = "0.9.8"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kover-gradle-plugin
 test-logger = "4.0.0"  # https://mvnrepository.com/artifact/com.adarshr/gradle-test-logger-plugin
-shadow = "9.4.2"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
+shadow = "9.5.1"  # https://mvnrepository.com/artifact/com.gradleup.shadow/shadow-gradle-plugin
 gatling = "3.15.1"  # https://mvnrepository.com/artifact/io.gatling/gatling-app
 
 [plugins]
@@ -207,7 +207,7 @@ micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micro
 # Micrometer Tracing
 micrometer-tracing-bom = { module = "io.micrometer:micrometer-tracing-bom", version.ref = "micrometer-tracing" }
 
-hikaricp = { module = "com.zaxxer:HikariCP", version = "7.0.2" }  # https://mvnrepository.com/artifact/com.zaxxer/HikariCP
+hikaricp = { module = "com.zaxxer:HikariCP", version = "7.1.0" }  # https://mvnrepository.com/artifact/com.zaxxer/HikariCP
 
 postgresql-driver = { module = "org.postgresql:postgresql" }  # version from bt4k catalog
 


### PR DESCRIPTION
## Summary
- Materializes the refreshed `bluetape4k-dependencies` shared version catalog into this repository.
- Keeps the change scoped to `gradle/libs.versions.toml`.
- `bluetape4k-experimental` is intentionally excluded from this propagation wave.

## Validation
- `git diff --check`
- `./gradlew help --no-configuration-cache --console=plain`

## DoD Status
| Step | Status | Evidence |
|---|---|---|
| Catalog sync | PASS | `scripts/sync-shared-versions.py --write --check --summary` generated this repo's catalog update from the central source. |
| Scope guard | PASS | Only `gradle/libs.versions.toml` changed. |
| Smoke validation | PASS | `git diff --check` and Gradle `help` completed successfully. |
