### PR TITLE
build: consume catalog 2026-07-08-00

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-06-25-05")
+    .orElse("catalog/2026-07-08-00")
     .get()
 val bluetape4kDependenciesCatalogCacheKey = bluetape4kDependenciesCatalogRef.replace(Regex("[^A-Za-z0-9._-]"), "_")
 


### PR DESCRIPTION
## Summary
- Updates the default `bluetape4kDependenciesCatalogRef` to `catalog/2026-07-08-00`.
- Keeps the change scoped to `settings.gradle.kts`.
- Uses the date-formatted catalog git tag, not a `bluetape4k-dependencies` artifact version.

## Validation
- `git diff --check`
- `./gradlew help --no-configuration-cache --console=plain`

## DoD Status
| Step | Status | Evidence |
|---|---|---|
| Catalog ref sync | PASS | Default catalog ref points to `catalog/2026-07-08-00`. |
| Scope guard | PASS | Only `settings.gradle.kts` changed. |
| Smoke validation | PASS | `git diff --check` and Gradle `help` completed successfully. |
