### PR TITLE
test: isolate Testcontainers reuse from graph benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       graph-memgraph: ${{ steps.filter.outputs.graph-memgraph }}
       graph-age: ${{ steps.filter.outputs.graph-age }}
       graph-falkordb: ${{ steps.filter.outputs.graph-falkordb }}
+      graph-benchmark: ${{ steps.filter.outputs.graph-benchmark }}
       graph-spring-boot: ${{ steps.filter.outputs.graph-spring-boot }}
       graph-ktor: ${{ steps.filter.outputs.graph-ktor }}
       common: ${{ steps.filter.outputs.common }}
@@ -109,6 +110,8 @@ jobs:
               - 'graph/graph-age/**'
             graph-falkordb:
               - 'graph/graph-falkordb/**'
+            graph-benchmark:
+              - 'benchmark/graph-benchmark/**'
             graph-spring-boot:
               - 'spring-boot/**'
             graph-ktor:
@@ -695,7 +698,64 @@ jobs:
           path: '**/build/reports/kover/report.xml'
           retention-days: 7
 
-  # ── 11. 커버리지 집계 ─────────────────────────────────────────────────────
+  # ── 11. Graph benchmark lifecycle (serial Testcontainers scope) ──────────
+  test-graph-benchmark:
+    name: Test / Graph Benchmark Lifecycle (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [build, changes]
+    if: >
+      needs.changes.outputs['graph-benchmark'] == 'true' ||
+      needs.changes.outputs.common == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+
+      - name: Restore Testcontainers image cache
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: restore
+          cache-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-${{ hashFiles('.github/testcontainers-images.txt') }}
+          restore-key: ${{ runner.os }}-testcontainers-images-v1-${{ github.job }}-
+
+      - name: Test graph benchmark lifecycle
+        run: |
+          ./gradlew :graph-benchmark:test \
+            --tests 'io.bluetape4k.graph.benchmark.BenchmarkContainerLifecycleContractTest' \
+            --no-daemon --no-configuration-cache
+          ./gradlew :bluetape4k-graph-falkordb:test \
+            --tests 'io.bluetape4k.graph.falkordb.FalkorDBGraphOperationsTest' \
+            --no-daemon --no-configuration-cache
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+
+      - name: Save Testcontainers image cache
+        if: always()
+        uses: ./.github/actions/testcontainers-image-cache
+        with:
+          mode: save
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-graph-benchmark
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
+  # ── 12. 커버리지 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
@@ -753,7 +813,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 14
 
-  # ── 12. 결과 집계 ──────────────────────────────────────────────────────────
+  # ── 13. 결과 집계 ──────────────────────────────────────────────────────────
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
@@ -769,6 +829,7 @@ jobs:
       - test-graph-memgraph
       - test-graph-age
       - test-graph-falkordb
+      - test-graph-benchmark
       - coverage-report
     if: always()
     steps:

--- a/benchmark/graph-benchmark/README.ko.md
+++ b/benchmark/graph-benchmark/README.ko.md
@@ -38,6 +38,15 @@
 
 컨테이너 기반 backend benchmark는 bluetape4k Testcontainers launcher 또는 wrapper를 사용합니다. 순차 실행해야 하며 초기 기동 시간이 더 깁니다.
 
+CI를 포함한 기본 실행에서는 컨테이너 재사용을 비활성화합니다. 개발자가 로컬 benchmark에서만 재사용하려면 로컬 Testcontainers 설정에서 reusable container를 활성화하고 다음 환경 변수를 명시적으로 지정합니다.
+
+```bash
+BLUETAPE4K_TESTCONTAINERS_REUSE=true \
+  ./gradlew :graph-benchmark:mainGraphDbSmallBenchmark
+```
+
+`CI` 또는 `GITHUB_ACTIONS`가 존재하면 benchmark가 이 opt-in을 무시합니다. 테스트와 예제는 컨테이너 재사용을 암묵적으로 활성화하지 않습니다.
+
 ## 실행
 
 ```bash

--- a/benchmark/graph-benchmark/README.md
+++ b/benchmark/graph-benchmark/README.md
@@ -38,6 +38,15 @@ kotlinx-benchmark module for graph performance comparison. It now contains nine 
 
 Container-backed backend benchmarks use bluetape4k Testcontainers launchers or wrappers. Run them serially and expect longer startup time.
 
+Container reuse is disabled by default, including in CI. A developer may opt in only for a local benchmark run by setting the environment variable below and enabling reusable containers in the local Testcontainers configuration:
+
+```bash
+BLUETAPE4K_TESTCONTAINERS_REUSE=true \
+  ./gradlew :graph-benchmark:mainGraphDbSmallBenchmark
+```
+
+The benchmark ignores this opt-in whenever `CI` or `GITHUB_ACTIONS` is present. Tests and examples never enable reuse implicitly.
+
 ## Running
 
 ```bash

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerReuse.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerReuse.kt
@@ -9,3 +9,18 @@ internal object BenchmarkContainerReuse {
     private fun isCi(environment: Map<String, String>): Boolean =
         !environment["CI"].isNullOrBlank() || !environment["GITHUB_ACTIONS"].isNullOrBlank()
 }
+
+internal object BenchmarkFalkorLifecycle {
+    fun close(
+        reusableServer: Boolean,
+        closeOperations: () -> Unit,
+        closeDriver: () -> Unit,
+        closeServer: () -> Unit,
+    ) {
+        runCatching(closeOperations)
+        runCatching(closeDriver)
+        if (!reusableServer) {
+            runCatching(closeServer)
+        }
+    }
+}

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerReuse.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerReuse.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.graph.benchmark
+
+internal object BenchmarkContainerReuse {
+    const val ENV_NAME: String = "BLUETAPE4K_TESTCONTAINERS_REUSE"
+
+    fun isEnabled(environment: Map<String, String> = System.getenv()): Boolean =
+        environment[ENV_NAME].toBoolean() && !isCi(environment)
+
+    private fun isCi(environment: Map<String, String>): Boolean =
+        !environment["CI"].isNullOrBlank() || !environment["GITHUB_ACTIONS"].isNullOrBlank()
+}

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerReuse.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerReuse.kt
@@ -7,7 +7,7 @@ internal object BenchmarkContainerReuse {
         environment[ENV_NAME].toBoolean() && !isCi(environment)
 
     private fun isCi(environment: Map<String, String>): Boolean =
-        !environment["CI"].isNullOrBlank() || !environment["GITHUB_ACTIONS"].isNullOrBlank()
+        "CI" in environment || "GITHUB_ACTIONS" in environment
 }
 
 internal object BenchmarkFalkorLifecycle {

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphDbComparisonBenchmark.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphDbComparisonBenchmark.kt
@@ -106,6 +106,7 @@ open class GraphDbComparisonState {
     private var neo4jDriver: Driver? = null
     private var falkorDriver: com.falkordb.Driver? = null
     private var falkorServer: FalkorDBServer? = null
+    private var falkorServerReusable: Boolean = false
 
     @Setup(Level.Trial)
     fun setupBackend() {
@@ -133,7 +134,8 @@ open class GraphDbComparisonState {
                 AgeGraphOperations(GRAPH_NAME)
             }
             "falkordb" -> {
-                val server = FalkorDBServer(reuse = BenchmarkContainerReuse.isEnabled()).apply {
+                falkorServerReusable = BenchmarkContainerReuse.isEnabled()
+                val server = FalkorDBServer(reuse = falkorServerReusable).apply {
                     withEnv("FALKORDB_ARGS", "MAX_QUEUED_QUERIES 25 TIMEOUT 60000 RESULTSET_SIZE 100000")
                     start()
                 }
@@ -182,10 +184,13 @@ open class GraphDbComparisonState {
     @TearDown(Level.Trial)
     fun teardownBackend() {
         runCatching { ops.dropGraph(GRAPH_NAME) }
-        runCatching { ops.close() }
         runCatching { neo4jDriver?.close() }
-        runCatching { falkorDriver?.close() }
-        runCatching { falkorServer?.close() }
+        BenchmarkFalkorLifecycle.close(
+            reusableServer = falkorServerReusable,
+            closeOperations = { ops.close() },
+            closeDriver = { falkorDriver?.close() },
+            closeServer = { falkorServer?.close() },
+        )
         runCatching { dataSource?.close() }
     }
 }

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphDbComparisonBenchmark.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphDbComparisonBenchmark.kt
@@ -133,7 +133,7 @@ open class GraphDbComparisonState {
                 AgeGraphOperations(GRAPH_NAME)
             }
             "falkordb" -> {
-                val server = FalkorDBServer(reuse = true).apply {
+                val server = FalkorDBServer(reuse = BenchmarkContainerReuse.isEnabled()).apply {
                     withEnv("FALKORDB_ARGS", "MAX_QUEUED_QUERIES 25 TIMEOUT 60000 RESULTSET_SIZE 100000")
                     start()
                 }

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphWriteIngestionBenchmark.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphWriteIngestionBenchmark.kt
@@ -136,6 +136,7 @@ open class GraphWriteIngestionState {
     private var neo4jDriver: Driver? = null
     private var falkorDriver: com.falkordb.Driver? = null
     private var falkorServer: FalkorDBServer? = null
+    private var falkorServerReusable: Boolean = false
 
     @Setup(Level.Trial)
     fun setupBackend() {
@@ -166,7 +167,8 @@ open class GraphWriteIngestionState {
                 AgeGraphOperations(GRAPH_NAME)
             }
             "falkordb" -> {
-                val server = FalkorDBServer(reuse = BenchmarkContainerReuse.isEnabled()).apply {
+                falkorServerReusable = BenchmarkContainerReuse.isEnabled()
+                val server = FalkorDBServer(reuse = falkorServerReusable).apply {
                     withEnv("FALKORDB_ARGS", "MAX_QUEUED_QUERIES 25 TIMEOUT 60000 RESULTSET_SIZE 100000")
                     start()
                 }
@@ -194,10 +196,13 @@ open class GraphWriteIngestionState {
     @TearDown(Level.Trial)
     fun teardownBackend() {
         runCatching { ops.dropGraph(GRAPH_NAME) }
-        runCatching { ops.close() }
         runCatching { neo4jDriver?.close() }
-        runCatching { falkorDriver?.close() }
-        runCatching { falkorServer?.close() }
+        BenchmarkFalkorLifecycle.close(
+            reusableServer = falkorServerReusable,
+            closeOperations = { ops.close() },
+            closeDriver = { falkorDriver?.close() },
+            closeServer = { falkorServer?.close() },
+        )
         runCatching { dataSource?.close() }
     }
 

--- a/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphWriteIngestionBenchmark.kt
+++ b/benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark/GraphWriteIngestionBenchmark.kt
@@ -166,7 +166,7 @@ open class GraphWriteIngestionState {
                 AgeGraphOperations(GRAPH_NAME)
             }
             "falkordb" -> {
-                val server = FalkorDBServer(reuse = true).apply {
+                val server = FalkorDBServer(reuse = BenchmarkContainerReuse.isEnabled()).apply {
                     withEnv("FALKORDB_ARGS", "MAX_QUEUED_QUERIES 25 TIMEOUT 60000 RESULTSET_SIZE 100000")
                     start()
                 }

--- a/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerLifecycleContractTest.kt
+++ b/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerLifecycleContractTest.kt
@@ -47,6 +47,20 @@ class BenchmarkContainerLifecycleContractTest {
     }
 
     @Test
+    fun `empty CI marker still disables container reuse`() {
+        BenchmarkContainerReuse.isEnabled(
+            environment = mapOf(BenchmarkContainerReuse.ENV_NAME to "true", "CI" to ""),
+        ).shouldBeFalse()
+    }
+
+    @Test
+    fun `empty GitHub Actions marker still disables container reuse`() {
+        BenchmarkContainerReuse.isEnabled(
+            environment = mapOf(BenchmarkContainerReuse.ENV_NAME to "true", "GITHUB_ACTIONS" to ""),
+        ).shouldBeFalse()
+    }
+
+    @Test
     fun `reusable FalkorDB servers survive trial teardown while clients close`() {
         var operationsCloseCount = 0
         var driverCloseCount = 0

--- a/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerLifecycleContractTest.kt
+++ b/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerLifecycleContractTest.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.graph.benchmark
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotContain
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+class BenchmarkContainerLifecycleContractTest {
+
+    @Test
+    fun `benchmark startup paths do not enable container reuse implicitly`() {
+        val benchmarkSources = listOf(
+            "GraphDbComparisonBenchmark.kt",
+            "GraphWriteIngestionBenchmark.kt",
+        )
+
+        benchmarkSources.forEach { sourceName ->
+            benchmarkSource(sourceName).readText() shouldNotContain "reuse = true"
+        }
+    }
+
+    @Test
+    fun `container reuse is disabled by default`() {
+        BenchmarkContainerReuse.isEnabled(environment = emptyMap()).shouldBeFalse()
+    }
+
+    @Test
+    fun `developer can explicitly enable container reuse locally`() {
+        BenchmarkContainerReuse.isEnabled(
+            environment = mapOf(BenchmarkContainerReuse.ENV_NAME to "true"),
+        ).shouldBeTrue()
+    }
+
+    @Test
+    fun `CI cannot enable container reuse`() {
+        BenchmarkContainerReuse.isEnabled(
+            environment = mapOf(BenchmarkContainerReuse.ENV_NAME to "true", "CI" to "1"),
+        ).shouldBeFalse()
+        BenchmarkContainerReuse.isEnabled(
+            environment = mapOf(BenchmarkContainerReuse.ENV_NAME to "true", "GITHUB_ACTIONS" to "true"),
+        ).shouldBeFalse()
+    }
+
+    private fun benchmarkSource(name: String): Path =
+        repoRoot()
+            .resolve("benchmark/graph-benchmark/src/main/kotlin/io/bluetape4k/graph/benchmark")
+            .resolve(name)
+
+    private fun repoRoot(): Path {
+        var current = Path.of(System.getProperty("user.dir"))
+        while (!current.resolve("settings.gradle.kts").exists()) {
+            current = current.parent ?: error("Repository root not found")
+        }
+        return current
+    }
+}

--- a/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerLifecycleContractTest.kt
+++ b/benchmark/graph-benchmark/src/test/kotlin/io/bluetape4k/graph/benchmark/BenchmarkContainerLifecycleContractTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.graph.benchmark
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotContain
 import org.junit.jupiter.api.Test
 import java.nio.file.Path
@@ -42,6 +44,68 @@ class BenchmarkContainerLifecycleContractTest {
         BenchmarkContainerReuse.isEnabled(
             environment = mapOf(BenchmarkContainerReuse.ENV_NAME to "true", "GITHUB_ACTIONS" to "true"),
         ).shouldBeFalse()
+    }
+
+    @Test
+    fun `reusable FalkorDB servers survive trial teardown while clients close`() {
+        var operationsCloseCount = 0
+        var driverCloseCount = 0
+        var serverCloseCount = 0
+
+        BenchmarkFalkorLifecycle.close(
+            reusableServer = true,
+            closeOperations = {
+                operationsCloseCount++
+                error("operations close failure must not block remaining cleanup")
+            },
+            closeDriver = { driverCloseCount++ },
+            closeServer = { serverCloseCount++ },
+        )
+
+        operationsCloseCount shouldBeEqualTo 1
+        driverCloseCount shouldBeEqualTo 1
+        serverCloseCount shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `non-reusable FalkorDB server closes after clients`() {
+        val closeOrder = mutableListOf<String>()
+
+        BenchmarkFalkorLifecycle.close(
+            reusableServer = false,
+            closeOperations = { closeOrder += "operations" },
+            closeDriver = { closeOrder += "driver" },
+            closeServer = { closeOrder += "server" },
+        )
+
+        closeOrder shouldBeEqualTo listOf("operations", "driver", "server")
+    }
+
+    @Test
+    fun `benchmark states delegate FalkorDB teardown to lifecycle policy`() {
+        val benchmarkSources = listOf(
+            "GraphDbComparisonBenchmark.kt",
+            "GraphWriteIngestionBenchmark.kt",
+        )
+
+        benchmarkSources.forEach { sourceName ->
+            val source = benchmarkSource(sourceName).readText()
+            source shouldContain "BenchmarkFalkorLifecycle.close("
+            source shouldContain "closeOperations = { ops.close() }"
+            source shouldContain "closeDriver = { falkorDriver?.close() }"
+            source shouldContain "closeServer = { falkorServer?.close() }"
+        }
+    }
+
+    @Test
+    fun `PR CI detects graph benchmark changes and runs lifecycle tests`() {
+        val workflow = repoRoot().resolve(".github/workflows/ci.yml").readText()
+
+        workflow shouldContain "graph-benchmark:"
+        workflow shouldContain "- 'benchmark/graph-benchmark/**'"
+        workflow shouldContain "test-graph-benchmark:"
+        workflow shouldContain ":graph-benchmark:test"
+        workflow shouldContain "- test-graph-benchmark"
     }
 
     private fun benchmarkSource(name: String): Path =


### PR DESCRIPTION
## Summary

Closes #385

Make graph benchmark Testcontainers non-reusable by default while retaining an explicit developer-local reuse mode whose server survives JMH Trial teardown. PR CI now detects `benchmark/graph-benchmark/**` changes and runs the lifecycle contract plus a serial FalkorDB container-backed proof.

## Background

The original correction guarded reusable startup, but Trial teardown still closed the reusable FalkorDB server. The existing CI path filter also ignored graph benchmark changes, so every affected test job was skipped.

## Work Done

- Added default-off, CI-denied benchmark container reuse policy.
- Aligned CI detection with the ecosystem convention: `CI` and `GITHUB_ACTIONS` disable reuse by key presence, including explicitly empty marker values.
- Added `BenchmarkFalkorLifecycle`: operations and driver clients always close independently; the server closes only when it is not reusable.
- Applied the lifecycle policy to both direct FalkorDB benchmark states.
- Added lifecycle regression tests for reusable/non-reusable teardown, independent client cleanup, benchmark-state delegation, and CI wiring.
- Added a `graph-benchmark` path-filter output and a dedicated serial `Test / Graph Benchmark Lifecycle (Testcontainers)` job.
- The CI job runs the changed lifecycle contract first, then `FalkorDBGraphOperationsTest` in a separate Gradle process, and is included in the final `CI Status` rollup.
- Preserved the root worker/mutex policy unchanged.
- Kept English and Korean benchmark reuse documentation aligned.

## Review Findings Resolved

- P1: reusable FalkorDB server was stopped by `Trial` teardown while client resources needed unconditional cleanup — resolved with explicit lifecycle ownership and regression coverage.
- P1: PR CI ignored `benchmark/graph-benchmark/**`, skipped the changed lifecycle tests, and omitted the missing job from rollup dependencies — resolved with path detection, a serial container-backed job, and `ci-status.needs` wiring.
- Ecosystem consistency: empty `CI` or `GITHUB_ACTIONS` markers previously permitted reuse — resolved with key-presence detection and dedicated tests for both markers.
- Current P0/P1: 0; no live reviews or review threads remain after the pushed correction.

## Validation

- RED: `BenchmarkContainerLifecycleContractTest` failed 2 tests before the correction (unconditional server close; missing CI path/job/rollup).
- RED: empty `CI` and `GITHUB_ACTIONS` marker tests both failed before key-presence detection.
- `./gradlew :graph-benchmark:test --no-daemon --no-build-cache`: PASS (26 tests, including 10 lifecycle contract tests).
- `./gradlew :bluetape4k-graph-falkordb:cleanTest :bluetape4k-graph-falkordb:test --tests 'io.bluetape4k.graph.falkordb.FalkorDBGraphOperationsTest' --no-daemon --no-build-cache --no-configuration-cache`: PASS (23 fresh container-backed tests).
- `./gradlew detekt --no-daemon --no-build-cache`: PASS.
- `actionlint .github/workflows/ci.yml`: PASS.
- `git diff --check`: PASS.
- [CI run #29144128371](https://github.com/bluetape4k/bluetape4k-graph/actions/runs/29144128371): PASS, including `Test / Graph Benchmark Lifecycle (Testcontainers)` and final `CI Status`.
- [CI run #29144439868](https://github.com/bluetape4k/bluetape4k-graph/actions/runs/29144439868): PASS for commit `d69c687`, including the updated lifecycle contract and final `CI Status`.

## Metadata

- Issue: #385, milestone `backlog`, assignee `debop`.
- PR: #386, milestone `backlog`, assignee `debop`; issue labels mirrored.
- Merge: explicitly out of scope for this correction wave.

## DoD Status

Required checks: 33/33; N/A: 5; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF/C-01..05 | Reproduced review and consistency findings, locked RED, fixed, and proved GREEN | PASS | prior 2 RED failures plus 2 empty-marker RED failures; 26 benchmark tests and 23 fresh FalkorDB tests pass | none |
| CG-01..08 | Read authority, protected the existing worktree, reused project lifecycle patterns, serialized container proof | PASS | scoped 5-file correction commit `54f5f1f`; sequential Gradle processes | none |
| KT-01..05 | Applied Kotlin testing/resource-ownership guidance and reviewed the final diff | PASS | client cleanup remains independent; reusable server survives; compile through tests | none |
| CI-MARKERS | Treat CI markers as present regardless of value | PASS | `CI=""` and `GITHUB_ACTIONS=""` tests both pass with key-presence detection | none |
| CI-P1 | Detect benchmark changes and execute lifecycle/container proof | PASS | run #29144128371 executed `Test / Graph Benchmark Lifecycle (Testcontainers)` successfully | none |
| CI-ROLLUP | Include the lifecycle job in final status | PASS | run #29144128371 final `CI Status` succeeded | none |
| CG-09 | Mirror and verify issue metadata on PR | PASS | issue/PR assigned to `debop`, labels mirrored, milestone `backlog` | none |
| CG-10/C-07 | Verify final body, reviews, and required CI | PASS | final H2 is `DoD Status`; run #29144439868 green; no reviews or threads | none |
| CG-11 | Respect merge boundary | PASS | user explicitly requested no merge | none |

Final status: final consistency correction is pushed and verified; merge remains explicitly out of scope.

Unchecked required items: none.
