### PR TITLE
Align the Graph manual manifest with the site snapshot contract

### DIFF
--- a/docs/manual/generated/manifest.json
+++ b/docs/manual/generated/manifest.json
@@ -2,14 +2,13 @@
   "modules": [
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-age",
+      "en": "en/modules/bluetape4k-graph-age.md",
       "gradlePath": ":bluetape4k-graph-age",
+      "group": "backends",
       "id": "bluetape4k-graph-age",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-age.md",
       "projectName": "bluetape4k-graph-age",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-age.md",
-        "ko": "ko/modules/bluetape4k-graph-age.md"
-      },
       "sourceDir": "graph/graph-age",
       "sourcePaths": [
         "graph/graph-age"
@@ -18,14 +17,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-bom",
+      "en": "en/modules/bluetape4k-graph-bom.md",
       "gradlePath": ":bluetape4k-graph-bom",
+      "group": "foundation",
       "id": "bluetape4k-graph-bom",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-bom.md",
       "projectName": "bluetape4k-graph-bom",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-bom.md",
-        "ko": "ko/modules/bluetape4k-graph-bom.md"
-      },
       "sourceDir": "bom",
       "sourcePaths": [
         "bom"
@@ -34,14 +32,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-core",
+      "en": "en/modules/bluetape4k-graph-core.md",
       "gradlePath": ":bluetape4k-graph-core",
+      "group": "foundation",
       "id": "bluetape4k-graph-core",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-core.md",
       "projectName": "bluetape4k-graph-core",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-core.md",
-        "ko": "ko/modules/bluetape4k-graph-core.md"
-      },
       "sourceDir": "graph/graph-core",
       "sourcePaths": [
         "graph/graph-core"
@@ -50,14 +47,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-falkordb",
+      "en": "en/modules/bluetape4k-graph-falkordb.md",
       "gradlePath": ":bluetape4k-graph-falkordb",
+      "group": "backends",
       "id": "bluetape4k-graph-falkordb",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-falkordb.md",
       "projectName": "bluetape4k-graph-falkordb",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-falkordb.md",
-        "ko": "ko/modules/bluetape4k-graph-falkordb.md"
-      },
       "sourceDir": "graph/graph-falkordb",
       "sourcePaths": [
         "graph/graph-falkordb"
@@ -66,14 +62,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-io-core",
+      "en": "en/modules/bluetape4k-graph-io-core.md",
       "gradlePath": ":bluetape4k-graph-io-core",
+      "group": "graph-io",
       "id": "bluetape4k-graph-io-core",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-io-core.md",
       "projectName": "bluetape4k-graph-io-core",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-io-core.md",
-        "ko": "ko/modules/bluetape4k-graph-io-core.md"
-      },
       "sourceDir": "graph-io/core",
       "sourcePaths": [
         "graph-io/core"
@@ -82,14 +77,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-io-csv",
+      "en": "en/modules/bluetape4k-graph-io-csv.md",
       "gradlePath": ":bluetape4k-graph-io-csv",
+      "group": "graph-io",
       "id": "bluetape4k-graph-io-csv",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-io-csv.md",
       "projectName": "bluetape4k-graph-io-csv",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-io-csv.md",
-        "ko": "ko/modules/bluetape4k-graph-io-csv.md"
-      },
       "sourceDir": "graph-io/csv",
       "sourcePaths": [
         "graph-io/csv"
@@ -98,14 +92,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-io-graphml",
+      "en": "en/modules/bluetape4k-graph-io-graphml.md",
       "gradlePath": ":bluetape4k-graph-io-graphml",
+      "group": "graph-io",
       "id": "bluetape4k-graph-io-graphml",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-io-graphml.md",
       "projectName": "bluetape4k-graph-io-graphml",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-io-graphml.md",
-        "ko": "ko/modules/bluetape4k-graph-io-graphml.md"
-      },
       "sourceDir": "graph-io/graphml",
       "sourcePaths": [
         "graph-io/graphml"
@@ -114,14 +107,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-io-jackson2",
+      "en": "en/modules/bluetape4k-graph-io-jackson2.md",
       "gradlePath": ":bluetape4k-graph-io-jackson2",
+      "group": "graph-io",
       "id": "bluetape4k-graph-io-jackson2",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-io-jackson2.md",
       "projectName": "bluetape4k-graph-io-jackson2",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-io-jackson2.md",
-        "ko": "ko/modules/bluetape4k-graph-io-jackson2.md"
-      },
       "sourceDir": "graph-io/jackson2",
       "sourcePaths": [
         "graph-io/jackson2"
@@ -130,14 +122,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-io-jackson3",
+      "en": "en/modules/bluetape4k-graph-io-jackson3.md",
       "gradlePath": ":bluetape4k-graph-io-jackson3",
+      "group": "graph-io",
       "id": "bluetape4k-graph-io-jackson3",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-io-jackson3.md",
       "projectName": "bluetape4k-graph-io-jackson3",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-io-jackson3.md",
-        "ko": "ko/modules/bluetape4k-graph-io-jackson3.md"
-      },
       "sourceDir": "graph-io/jackson3",
       "sourcePaths": [
         "graph-io/jackson3"
@@ -146,14 +137,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-ktor",
+      "en": "en/modules/bluetape4k-graph-ktor.md",
       "gradlePath": ":bluetape4k-graph-ktor",
+      "group": "frameworks",
       "id": "bluetape4k-graph-ktor",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-ktor.md",
       "projectName": "bluetape4k-graph-ktor",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-ktor.md",
-        "ko": "ko/modules/bluetape4k-graph-ktor.md"
-      },
       "sourceDir": "ktor/graph-ktor",
       "sourcePaths": [
         "ktor/graph-ktor"
@@ -162,14 +152,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-memgraph",
+      "en": "en/modules/bluetape4k-graph-memgraph.md",
       "gradlePath": ":bluetape4k-graph-memgraph",
+      "group": "backends",
       "id": "bluetape4k-graph-memgraph",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-memgraph.md",
       "projectName": "bluetape4k-graph-memgraph",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-memgraph.md",
-        "ko": "ko/modules/bluetape4k-graph-memgraph.md"
-      },
       "sourceDir": "graph/graph-memgraph",
       "sourcePaths": [
         "graph/graph-memgraph"
@@ -178,14 +167,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-neo4j",
+      "en": "en/modules/bluetape4k-graph-neo4j.md",
       "gradlePath": ":bluetape4k-graph-neo4j",
+      "group": "backends",
       "id": "bluetape4k-graph-neo4j",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-neo4j.md",
       "projectName": "bluetape4k-graph-neo4j",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-neo4j.md",
-        "ko": "ko/modules/bluetape4k-graph-neo4j.md"
-      },
       "sourceDir": "graph/graph-neo4j",
       "sourcePaths": [
         "graph/graph-neo4j"
@@ -194,14 +182,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-okio",
+      "en": "en/modules/graph-okio.md",
       "gradlePath": ":bluetape4k-graph-okio",
+      "group": "graph-io",
       "id": "bluetape4k-graph-okio",
       "kind": "library",
+      "ko": "ko/modules/graph-okio.md",
       "projectName": "bluetape4k-graph-okio",
-      "routes": {
-        "en": "en/modules/graph-okio.md",
-        "ko": "ko/modules/graph-okio.md"
-      },
       "sourceDir": "graph-io/okio",
       "sourcePaths": [
         "graph-io/okio"
@@ -210,14 +197,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-spring-boot",
+      "en": "en/modules/bluetape4k-graph-spring-boot.md",
       "gradlePath": ":bluetape4k-graph-spring-boot",
+      "group": "frameworks",
       "id": "bluetape4k-graph-spring-boot",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-spring-boot.md",
       "projectName": "bluetape4k-graph-spring-boot",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-spring-boot.md",
-        "ko": "ko/modules/bluetape4k-graph-spring-boot.md"
-      },
       "sourceDir": "spring-boot/graph-spring-boot",
       "sourcePaths": [
         "spring-boot/graph-spring-boot"
@@ -226,14 +212,13 @@
     },
     {
       "artifact": "io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop",
+      "en": "en/modules/bluetape4k-graph-tinkerpop.md",
       "gradlePath": ":bluetape4k-graph-tinkerpop",
+      "group": "backends",
       "id": "bluetape4k-graph-tinkerpop",
       "kind": "library",
+      "ko": "ko/modules/bluetape4k-graph-tinkerpop.md",
       "projectName": "bluetape4k-graph-tinkerpop",
-      "routes": {
-        "en": "en/modules/bluetape4k-graph-tinkerpop.md",
-        "ko": "ko/modules/bluetape4k-graph-tinkerpop.md"
-      },
       "sourceDir": "graph/graph-tinkerpop",
       "sourcePaths": [
         "graph/graph-tinkerpop"
@@ -242,14 +227,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/code-graph.md",
       "gradlePath": ":code-graph-examples",
+      "group": "examples",
       "id": "code-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/code-graph.md",
       "projectName": "code-graph-examples",
-      "routes": {
-        "en": "en/examples/code-graph.md",
-        "ko": "ko/examples/code-graph.md"
-      },
       "sourceDir": "examples/code-graph-examples",
       "sourcePaths": [
         "examples/code-graph-examples"
@@ -258,14 +242,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/data-lineage.md",
       "gradlePath": ":data-lineage-examples",
+      "group": "examples",
       "id": "data-lineage-examples",
       "kind": "example",
+      "ko": "ko/examples/data-lineage.md",
       "projectName": "data-lineage-examples",
-      "routes": {
-        "en": "en/examples/data-lineage.md",
-        "ko": "ko/examples/data-lineage.md"
-      },
       "sourceDir": "examples/data-lineage-examples",
       "sourcePaths": [
         "examples/data-lineage-examples"
@@ -274,14 +257,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/fraud-detection.md",
       "gradlePath": ":fraud-detection-examples",
+      "group": "examples",
       "id": "fraud-detection-examples",
       "kind": "example",
+      "ko": "ko/examples/fraud-detection.md",
       "projectName": "fraud-detection-examples",
-      "routes": {
-        "en": "en/examples/fraud-detection.md",
-        "ko": "ko/examples/fraud-detection.md"
-      },
       "sourceDir": "examples/fraud-detection-examples",
       "sourcePaths": [
         "examples/fraud-detection-examples"
@@ -290,14 +272,13 @@
     },
     {
       "artifact": null,
+      "en": "en/benchmarks/age-and-neo4j.md",
       "gradlePath": ":graph-age-benchmark",
+      "group": "benchmarks",
       "id": "graph-age-benchmark",
       "kind": "benchmark",
+      "ko": "ko/benchmarks/age-and-neo4j.md",
       "projectName": "graph-age-benchmark",
-      "routes": {
-        "en": "en/benchmarks/age-and-neo4j.md",
-        "ko": "ko/benchmarks/age-and-neo4j.md"
-      },
       "sourceDir": "benchmark/graph-age-benchmark",
       "sourcePaths": [
         "benchmark/graph-age-benchmark"
@@ -306,14 +287,13 @@
     },
     {
       "artifact": null,
+      "en": "en/benchmarks/graph-operations.md",
       "gradlePath": ":graph-benchmark",
+      "group": "benchmarks",
       "id": "graph-benchmark",
       "kind": "benchmark",
+      "ko": "ko/benchmarks/graph-operations.md",
       "projectName": "graph-benchmark",
-      "routes": {
-        "en": "en/benchmarks/graph-operations.md",
-        "ko": "ko/benchmarks/graph-operations.md"
-      },
       "sourceDir": "benchmark/graph-benchmark",
       "sourcePaths": [
         "benchmark/graph-benchmark"
@@ -322,14 +302,13 @@
     },
     {
       "artifact": null,
+      "en": "en/benchmarks/graph-io.md",
       "gradlePath": ":graph-io-benchmark",
+      "group": "benchmarks",
       "id": "graph-io-benchmark",
       "kind": "benchmark",
+      "ko": "ko/benchmarks/graph-io.md",
       "projectName": "graph-io-benchmark",
-      "routes": {
-        "en": "en/benchmarks/graph-io.md",
-        "ko": "ko/benchmarks/graph-io.md"
-      },
       "sourceDir": "benchmark/graph-io-benchmark",
       "sourcePaths": [
         "benchmark/graph-io-benchmark"
@@ -338,14 +317,13 @@
     },
     {
       "artifact": null,
+      "en": "en/benchmarks/age-and-neo4j.md",
       "gradlePath": ":graph-neo4j-benchmark",
+      "group": "benchmarks",
       "id": "graph-neo4j-benchmark",
       "kind": "benchmark",
+      "ko": "ko/benchmarks/age-and-neo4j.md",
       "projectName": "graph-neo4j-benchmark",
-      "routes": {
-        "en": "en/benchmarks/age-and-neo4j.md",
-        "ko": "ko/benchmarks/age-and-neo4j.md"
-      },
       "sourceDir": "benchmark/graph-neo4j-benchmark",
       "sourcePaths": [
         "benchmark/graph-neo4j-benchmark"
@@ -354,14 +332,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/iam-access-graph.md",
       "gradlePath": ":iam-access-graph-examples",
+      "group": "examples",
       "id": "iam-access-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/iam-access-graph.md",
       "projectName": "iam-access-graph-examples",
-      "routes": {
-        "en": "en/examples/iam-access-graph.md",
-        "ko": "ko/examples/iam-access-graph.md"
-      },
       "sourceDir": "examples/iam-access-graph-examples",
       "sourcePaths": [
         "examples/iam-access-graph-examples"
@@ -370,14 +347,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/knowledge-graph.md",
       "gradlePath": ":knowledge-graph-examples",
+      "group": "examples",
       "id": "knowledge-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/knowledge-graph.md",
       "projectName": "knowledge-graph-examples",
-      "routes": {
-        "en": "en/examples/knowledge-graph.md",
-        "ko": "ko/examples/knowledge-graph.md"
-      },
       "sourceDir": "examples/knowledge-graph-examples",
       "sourcePaths": [
         "examples/knowledge-graph-examples"
@@ -386,14 +362,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/ktor-graph.md",
       "gradlePath": ":ktor-graph-examples",
+      "group": "examples",
       "id": "ktor-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/ktor-graph.md",
       "projectName": "ktor-graph-examples",
-      "routes": {
-        "en": "en/examples/ktor-graph.md",
-        "ko": "ko/examples/ktor-graph.md"
-      },
       "sourceDir": "examples/ktor-graph-examples",
       "sourcePaths": [
         "examples/ktor-graph-examples"
@@ -402,14 +377,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/linkedin-graph.md",
       "gradlePath": ":linkedin-graph-examples",
+      "group": "examples",
       "id": "linkedin-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/linkedin-graph.md",
       "projectName": "linkedin-graph-examples",
-      "routes": {
-        "en": "en/examples/linkedin-graph.md",
-        "ko": "ko/examples/linkedin-graph.md"
-      },
       "sourceDir": "examples/linkedin-graph-examples",
       "sourcePaths": [
         "examples/linkedin-graph-examples"
@@ -418,14 +392,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/network-topology.md",
       "gradlePath": ":network-topology-examples",
+      "group": "examples",
       "id": "network-topology-examples",
       "kind": "example",
+      "ko": "ko/examples/network-topology.md",
       "projectName": "network-topology-examples",
-      "routes": {
-        "en": "en/examples/network-topology.md",
-        "ko": "ko/examples/network-topology.md"
-      },
       "sourceDir": "examples/network-topology-examples",
       "sourcePaths": [
         "examples/network-topology-examples"
@@ -434,14 +407,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/observability-graph.md",
       "gradlePath": ":observability-graph-examples",
+      "group": "examples",
       "id": "observability-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/observability-graph.md",
       "projectName": "observability-graph-examples",
-      "routes": {
-        "en": "en/examples/observability-graph.md",
-        "ko": "ko/examples/observability-graph.md"
-      },
       "sourceDir": "examples/observability-graph-examples",
       "sourcePaths": [
         "examples/observability-graph-examples"
@@ -450,14 +422,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/recommendation.md",
       "gradlePath": ":recommendation-examples",
+      "group": "examples",
       "id": "recommendation-examples",
       "kind": "example",
+      "ko": "ko/examples/recommendation.md",
       "projectName": "recommendation-examples",
-      "routes": {
-        "en": "en/examples/recommendation.md",
-        "ko": "ko/examples/recommendation.md"
-      },
       "sourceDir": "examples/recommendation-examples",
       "sourcePaths": [
         "examples/recommendation-examples"
@@ -466,14 +437,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/security-attack-path.md",
       "gradlePath": ":security-attack-path-examples",
+      "group": "examples",
       "id": "security-attack-path-examples",
       "kind": "example",
+      "ko": "ko/examples/security-attack-path.md",
       "projectName": "security-attack-path-examples",
-      "routes": {
-        "en": "en/examples/security-attack-path.md",
-        "ko": "ko/examples/security-attack-path.md"
-      },
       "sourceDir": "examples/security-attack-path-examples",
       "sourcePaths": [
         "examples/security-attack-path-examples"
@@ -482,14 +452,13 @@
     },
     {
       "artifact": null,
+      "en": "en/examples/supply-chain-graph.md",
       "gradlePath": ":supply-chain-graph-examples",
+      "group": "examples",
       "id": "supply-chain-graph-examples",
       "kind": "example",
+      "ko": "ko/examples/supply-chain-graph.md",
       "projectName": "supply-chain-graph-examples",
-      "routes": {
-        "en": "en/examples/supply-chain-graph.md",
-        "ko": "ko/examples/supply-chain-graph.md"
-      },
       "sourceDir": "examples/supply-chain-graph-examples",
       "sourcePaths": [
         "examples/supply-chain-graph-examples"

--- a/docs/manual/manifest.yaml
+++ b/docs/manual/manifest.yaml
@@ -78,370 +78,370 @@ modules:
   projectName: bluetape4k-graph-age
   sourceDir: graph/graph-age
   kind: library
+  group: backends
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-age
   status: stable
   sourcePaths:
   - graph/graph-age
-  routes:
-    en: en/modules/bluetape4k-graph-age.md
-    ko: ko/modules/bluetape4k-graph-age.md
+  en: en/modules/bluetape4k-graph-age.md
+  ko: ko/modules/bluetape4k-graph-age.md
 - id: bluetape4k-graph-bom
   gradlePath: ":bluetape4k-graph-bom"
   projectName: bluetape4k-graph-bom
   sourceDir: bom
   kind: library
+  group: foundation
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-bom
   status: stable
   sourcePaths:
   - bom
-  routes:
-    en: en/modules/bluetape4k-graph-bom.md
-    ko: ko/modules/bluetape4k-graph-bom.md
+  en: en/modules/bluetape4k-graph-bom.md
+  ko: ko/modules/bluetape4k-graph-bom.md
 - id: bluetape4k-graph-core
   gradlePath: ":bluetape4k-graph-core"
   projectName: bluetape4k-graph-core
   sourceDir: graph/graph-core
   kind: library
+  group: foundation
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-core
   status: stable
   sourcePaths:
   - graph/graph-core
-  routes:
-    en: en/modules/bluetape4k-graph-core.md
-    ko: ko/modules/bluetape4k-graph-core.md
+  en: en/modules/bluetape4k-graph-core.md
+  ko: ko/modules/bluetape4k-graph-core.md
 - id: bluetape4k-graph-falkordb
   gradlePath: ":bluetape4k-graph-falkordb"
   projectName: bluetape4k-graph-falkordb
   sourceDir: graph/graph-falkordb
   kind: library
+  group: backends
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-falkordb
   status: stable
   sourcePaths:
   - graph/graph-falkordb
-  routes:
-    en: en/modules/bluetape4k-graph-falkordb.md
-    ko: ko/modules/bluetape4k-graph-falkordb.md
+  en: en/modules/bluetape4k-graph-falkordb.md
+  ko: ko/modules/bluetape4k-graph-falkordb.md
 - id: bluetape4k-graph-io-core
   gradlePath: ":bluetape4k-graph-io-core"
   projectName: bluetape4k-graph-io-core
   sourceDir: graph-io/core
   kind: library
+  group: graph-io
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-io-core
   status: stable
   sourcePaths:
   - graph-io/core
-  routes:
-    en: en/modules/bluetape4k-graph-io-core.md
-    ko: ko/modules/bluetape4k-graph-io-core.md
+  en: en/modules/bluetape4k-graph-io-core.md
+  ko: ko/modules/bluetape4k-graph-io-core.md
 - id: bluetape4k-graph-io-csv
   gradlePath: ":bluetape4k-graph-io-csv"
   projectName: bluetape4k-graph-io-csv
   sourceDir: graph-io/csv
   kind: library
+  group: graph-io
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-io-csv
   status: stable
   sourcePaths:
   - graph-io/csv
-  routes:
-    en: en/modules/bluetape4k-graph-io-csv.md
-    ko: ko/modules/bluetape4k-graph-io-csv.md
+  en: en/modules/bluetape4k-graph-io-csv.md
+  ko: ko/modules/bluetape4k-graph-io-csv.md
 - id: bluetape4k-graph-io-graphml
   gradlePath: ":bluetape4k-graph-io-graphml"
   projectName: bluetape4k-graph-io-graphml
   sourceDir: graph-io/graphml
   kind: library
+  group: graph-io
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-io-graphml
   status: stable
   sourcePaths:
   - graph-io/graphml
-  routes:
-    en: en/modules/bluetape4k-graph-io-graphml.md
-    ko: ko/modules/bluetape4k-graph-io-graphml.md
+  en: en/modules/bluetape4k-graph-io-graphml.md
+  ko: ko/modules/bluetape4k-graph-io-graphml.md
 - id: bluetape4k-graph-io-jackson2
   gradlePath: ":bluetape4k-graph-io-jackson2"
   projectName: bluetape4k-graph-io-jackson2
   sourceDir: graph-io/jackson2
   kind: library
+  group: graph-io
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-io-jackson2
   status: stable
   sourcePaths:
   - graph-io/jackson2
-  routes:
-    en: en/modules/bluetape4k-graph-io-jackson2.md
-    ko: ko/modules/bluetape4k-graph-io-jackson2.md
+  en: en/modules/bluetape4k-graph-io-jackson2.md
+  ko: ko/modules/bluetape4k-graph-io-jackson2.md
 - id: bluetape4k-graph-io-jackson3
   gradlePath: ":bluetape4k-graph-io-jackson3"
   projectName: bluetape4k-graph-io-jackson3
   sourceDir: graph-io/jackson3
   kind: library
+  group: graph-io
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-io-jackson3
   status: stable
   sourcePaths:
   - graph-io/jackson3
-  routes:
-    en: en/modules/bluetape4k-graph-io-jackson3.md
-    ko: ko/modules/bluetape4k-graph-io-jackson3.md
+  en: en/modules/bluetape4k-graph-io-jackson3.md
+  ko: ko/modules/bluetape4k-graph-io-jackson3.md
 - id: bluetape4k-graph-ktor
   gradlePath: ":bluetape4k-graph-ktor"
   projectName: bluetape4k-graph-ktor
   sourceDir: ktor/graph-ktor
   kind: library
+  group: frameworks
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-ktor
   status: stable
   sourcePaths:
   - ktor/graph-ktor
-  routes:
-    en: en/modules/bluetape4k-graph-ktor.md
-    ko: ko/modules/bluetape4k-graph-ktor.md
+  en: en/modules/bluetape4k-graph-ktor.md
+  ko: ko/modules/bluetape4k-graph-ktor.md
 - id: bluetape4k-graph-memgraph
   gradlePath: ":bluetape4k-graph-memgraph"
   projectName: bluetape4k-graph-memgraph
   sourceDir: graph/graph-memgraph
   kind: library
+  group: backends
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-memgraph
   status: stable
   sourcePaths:
   - graph/graph-memgraph
-  routes:
-    en: en/modules/bluetape4k-graph-memgraph.md
-    ko: ko/modules/bluetape4k-graph-memgraph.md
+  en: en/modules/bluetape4k-graph-memgraph.md
+  ko: ko/modules/bluetape4k-graph-memgraph.md
 - id: bluetape4k-graph-neo4j
   gradlePath: ":bluetape4k-graph-neo4j"
   projectName: bluetape4k-graph-neo4j
   sourceDir: graph/graph-neo4j
   kind: library
+  group: backends
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-neo4j
   status: stable
   sourcePaths:
   - graph/graph-neo4j
-  routes:
-    en: en/modules/bluetape4k-graph-neo4j.md
-    ko: ko/modules/bluetape4k-graph-neo4j.md
+  en: en/modules/bluetape4k-graph-neo4j.md
+  ko: ko/modules/bluetape4k-graph-neo4j.md
 - id: bluetape4k-graph-okio
   gradlePath: ":bluetape4k-graph-okio"
   projectName: bluetape4k-graph-okio
   sourceDir: graph-io/okio
   kind: library
+  group: graph-io
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-okio
   status: stable
   sourcePaths:
   - graph-io/okio
-  routes:
-    en: en/modules/graph-okio.md
-    ko: ko/modules/graph-okio.md
+  en: en/modules/graph-okio.md
+  ko: ko/modules/graph-okio.md
 - id: bluetape4k-graph-spring-boot
   gradlePath: ":bluetape4k-graph-spring-boot"
   projectName: bluetape4k-graph-spring-boot
   sourceDir: spring-boot/graph-spring-boot
   kind: library
+  group: frameworks
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-spring-boot
   status: stable
   sourcePaths:
   - spring-boot/graph-spring-boot
-  routes:
-    en: en/modules/bluetape4k-graph-spring-boot.md
-    ko: ko/modules/bluetape4k-graph-spring-boot.md
+  en: en/modules/bluetape4k-graph-spring-boot.md
+  ko: ko/modules/bluetape4k-graph-spring-boot.md
 - id: bluetape4k-graph-tinkerpop
   gradlePath: ":bluetape4k-graph-tinkerpop"
   projectName: bluetape4k-graph-tinkerpop
   sourceDir: graph/graph-tinkerpop
   kind: library
+  group: backends
   artifact: io.github.bluetape4k.graph:bluetape4k-graph-tinkerpop
   status: stable
   sourcePaths:
   - graph/graph-tinkerpop
-  routes:
-    en: en/modules/bluetape4k-graph-tinkerpop.md
-    ko: ko/modules/bluetape4k-graph-tinkerpop.md
+  en: en/modules/bluetape4k-graph-tinkerpop.md
+  ko: ko/modules/bluetape4k-graph-tinkerpop.md
 - id: code-graph-examples
   gradlePath: ":code-graph-examples"
   projectName: code-graph-examples
   sourceDir: examples/code-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/code-graph-examples
-  routes:
-    en: en/examples/code-graph.md
-    ko: ko/examples/code-graph.md
+  en: en/examples/code-graph.md
+  ko: ko/examples/code-graph.md
 - id: data-lineage-examples
   gradlePath: ":data-lineage-examples"
   projectName: data-lineage-examples
   sourceDir: examples/data-lineage-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/data-lineage-examples
-  routes:
-    en: en/examples/data-lineage.md
-    ko: ko/examples/data-lineage.md
+  en: en/examples/data-lineage.md
+  ko: ko/examples/data-lineage.md
 - id: fraud-detection-examples
   gradlePath: ":fraud-detection-examples"
   projectName: fraud-detection-examples
   sourceDir: examples/fraud-detection-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/fraud-detection-examples
-  routes:
-    en: en/examples/fraud-detection.md
-    ko: ko/examples/fraud-detection.md
+  en: en/examples/fraud-detection.md
+  ko: ko/examples/fraud-detection.md
 - id: graph-age-benchmark
   gradlePath: ":graph-age-benchmark"
   projectName: graph-age-benchmark
   sourceDir: benchmark/graph-age-benchmark
   kind: benchmark
+  group: benchmarks
   artifact:
   status: stable
   sourcePaths:
   - benchmark/graph-age-benchmark
-  routes:
-    en: en/benchmarks/age-and-neo4j.md
-    ko: ko/benchmarks/age-and-neo4j.md
+  en: en/benchmarks/age-and-neo4j.md
+  ko: ko/benchmarks/age-and-neo4j.md
 - id: graph-benchmark
   gradlePath: ":graph-benchmark"
   projectName: graph-benchmark
   sourceDir: benchmark/graph-benchmark
   kind: benchmark
+  group: benchmarks
   artifact:
   status: stable
   sourcePaths:
   - benchmark/graph-benchmark
-  routes:
-    en: en/benchmarks/graph-operations.md
-    ko: ko/benchmarks/graph-operations.md
+  en: en/benchmarks/graph-operations.md
+  ko: ko/benchmarks/graph-operations.md
 - id: graph-io-benchmark
   gradlePath: ":graph-io-benchmark"
   projectName: graph-io-benchmark
   sourceDir: benchmark/graph-io-benchmark
   kind: benchmark
+  group: benchmarks
   artifact:
   status: stable
   sourcePaths:
   - benchmark/graph-io-benchmark
-  routes:
-    en: en/benchmarks/graph-io.md
-    ko: ko/benchmarks/graph-io.md
+  en: en/benchmarks/graph-io.md
+  ko: ko/benchmarks/graph-io.md
 - id: graph-neo4j-benchmark
   gradlePath: ":graph-neo4j-benchmark"
   projectName: graph-neo4j-benchmark
   sourceDir: benchmark/graph-neo4j-benchmark
   kind: benchmark
+  group: benchmarks
   artifact:
   status: stable
   sourcePaths:
   - benchmark/graph-neo4j-benchmark
-  routes:
-    en: en/benchmarks/age-and-neo4j.md
-    ko: ko/benchmarks/age-and-neo4j.md
+  en: en/benchmarks/age-and-neo4j.md
+  ko: ko/benchmarks/age-and-neo4j.md
 - id: iam-access-graph-examples
   gradlePath: ":iam-access-graph-examples"
   projectName: iam-access-graph-examples
   sourceDir: examples/iam-access-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/iam-access-graph-examples
-  routes:
-    en: en/examples/iam-access-graph.md
-    ko: ko/examples/iam-access-graph.md
+  en: en/examples/iam-access-graph.md
+  ko: ko/examples/iam-access-graph.md
 - id: knowledge-graph-examples
   gradlePath: ":knowledge-graph-examples"
   projectName: knowledge-graph-examples
   sourceDir: examples/knowledge-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/knowledge-graph-examples
-  routes:
-    en: en/examples/knowledge-graph.md
-    ko: ko/examples/knowledge-graph.md
+  en: en/examples/knowledge-graph.md
+  ko: ko/examples/knowledge-graph.md
 - id: ktor-graph-examples
   gradlePath: ":ktor-graph-examples"
   projectName: ktor-graph-examples
   sourceDir: examples/ktor-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/ktor-graph-examples
-  routes:
-    en: en/examples/ktor-graph.md
-    ko: ko/examples/ktor-graph.md
+  en: en/examples/ktor-graph.md
+  ko: ko/examples/ktor-graph.md
 - id: linkedin-graph-examples
   gradlePath: ":linkedin-graph-examples"
   projectName: linkedin-graph-examples
   sourceDir: examples/linkedin-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/linkedin-graph-examples
-  routes:
-    en: en/examples/linkedin-graph.md
-    ko: ko/examples/linkedin-graph.md
+  en: en/examples/linkedin-graph.md
+  ko: ko/examples/linkedin-graph.md
 - id: network-topology-examples
   gradlePath: ":network-topology-examples"
   projectName: network-topology-examples
   sourceDir: examples/network-topology-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/network-topology-examples
-  routes:
-    en: en/examples/network-topology.md
-    ko: ko/examples/network-topology.md
+  en: en/examples/network-topology.md
+  ko: ko/examples/network-topology.md
 - id: observability-graph-examples
   gradlePath: ":observability-graph-examples"
   projectName: observability-graph-examples
   sourceDir: examples/observability-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/observability-graph-examples
-  routes:
-    en: en/examples/observability-graph.md
-    ko: ko/examples/observability-graph.md
+  en: en/examples/observability-graph.md
+  ko: ko/examples/observability-graph.md
 - id: recommendation-examples
   gradlePath: ":recommendation-examples"
   projectName: recommendation-examples
   sourceDir: examples/recommendation-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/recommendation-examples
-  routes:
-    en: en/examples/recommendation.md
-    ko: ko/examples/recommendation.md
+  en: en/examples/recommendation.md
+  ko: ko/examples/recommendation.md
 - id: security-attack-path-examples
   gradlePath: ":security-attack-path-examples"
   projectName: security-attack-path-examples
   sourceDir: examples/security-attack-path-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/security-attack-path-examples
-  routes:
-    en: en/examples/security-attack-path.md
-    ko: ko/examples/security-attack-path.md
+  en: en/examples/security-attack-path.md
+  ko: ko/examples/security-attack-path.md
 - id: supply-chain-graph-examples
   gradlePath: ":supply-chain-graph-examples"
   projectName: supply-chain-graph-examples
   sourceDir: examples/supply-chain-graph-examples
   kind: example
+  group: examples
   artifact:
   status: stable
   sourcePaths:
   - examples/supply-chain-graph-examples
-  routes:
-    en: en/examples/supply-chain-graph.md
-    ko: ko/examples/supply-chain-graph.md
+  en: en/examples/supply-chain-graph.md
+  ko: ko/examples/supply-chain-graph.md

--- a/scripts/manual/build_graph_manifest.rb
+++ b/scripts/manual/build_graph_manifest.rb
@@ -66,6 +66,18 @@ def route_for(row, benchmark_routes)
   end
 end
 
+def group_for(row)
+  return "examples" if row.fetch("kind") == "example"
+  return "benchmarks" if row.fetch("kind") == "benchmark"
+
+  source_dir = row.fetch("sourceDir")
+  return "foundation" if ["bom", "graph/graph-core"].include?(source_dir)
+  return "graph-io" if source_dir.start_with?("graph-io/")
+  return "frameworks" if source_dir.start_with?("ktor/", "spring-boot/")
+
+  "backends"
+end
+
 modules = rows.map do |row|
   kind = row.fetch("kind")
   {
@@ -74,13 +86,12 @@ modules = rows.map do |row|
     "projectName" => row.fetch("projectName"),
     "sourceDir" => row.fetch("sourceDir"),
     "kind" => kind,
+    "group" => group_for(row),
     "artifact" => kind == "library" ? "io.github.bluetape4k.graph:#{row.fetch('projectName')}" : nil,
     "status" => "stable",
     "sourcePaths" => [row.fetch("sourceDir")],
-    "routes" => {
-      "en" => "en/#{route_for(row, benchmark_routes)}",
-      "ko" => "ko/#{route_for(row, benchmark_routes)}",
-    },
+    "en" => "en/#{route_for(row, benchmark_routes)}",
+    "ko" => "ko/#{route_for(row, benchmark_routes)}",
   }
 end.sort_by { |row| row.fetch("id") }
 

--- a/scripts/manual/build_graph_manifest_test.rb
+++ b/scripts/manual/build_graph_manifest_test.rb
@@ -1,0 +1,70 @@
+require "json"
+require "minitest/autorun"
+require "open3"
+require "tmpdir"
+require "yaml"
+
+class BuildGraphManifestTest < Minitest::Test
+  def test_exports_locale_routes_with_the_common_schema_v2_fields
+    Dir.mktmpdir do |root|
+      inventory = File.join(root, "inventory.json")
+      manifest = File.join(root, "manifest.yaml")
+      File.write(inventory, JSON.generate([
+        {
+          "gradlePath" => ":bluetape4k-graph-core",
+          "projectName" => "bluetape4k-graph-core",
+          "sourceDir" => "graph/graph-core",
+          "kind" => "library",
+        },
+      ]))
+
+      script = File.expand_path("build_graph_manifest.rb", __dir__)
+      _stdout, stderr, status = Open3.capture3("ruby", script, inventory, manifest)
+
+      assert status.success?, stderr
+      row = YAML.safe_load(File.read(manifest)).fetch("modules").first
+      assert_equal "foundation", row.fetch("group")
+      assert_equal "en/modules/bluetape4k-graph-core.md", row.fetch("en")
+      assert_equal "ko/modules/bluetape4k-graph-core.md", row.fetch("ko")
+      refute row.key?("routes")
+    end
+  end
+
+  def test_classifies_every_manual_navigation_group
+    Dir.mktmpdir do |root|
+      inventory = File.join(root, "inventory.json")
+      manifest = File.join(root, "manifest.yaml")
+      File.write(inventory, JSON.generate([
+        row(":bluetape4k-graph-core", "bluetape4k-graph-core", "graph/graph-core", "library"),
+        row(":bluetape4k-graph-neo4j", "bluetape4k-graph-neo4j", "graph/neo4j", "library"),
+        row(":bluetape4k-graph-io-core", "bluetape4k-graph-io-core", "graph-io/core", "library"),
+        row(":bluetape4k-graph-spring-boot", "bluetape4k-graph-spring-boot", "spring-boot/graph", "library"),
+        row(":graph-benchmark", "graph-benchmark", "benchmark/graph", "benchmark"),
+        row(":graph-examples", "graph-examples", "examples/graph", "example"),
+      ]))
+
+      script = File.expand_path("build_graph_manifest.rb", __dir__)
+      _stdout, stderr, status = Open3.capture3("ruby", script, inventory, manifest)
+
+      assert status.success?, stderr
+      groups = YAML.safe_load(File.read(manifest)).fetch("modules").to_h { |entry| [entry.fetch("id"), entry.fetch("group")] }
+      assert_equal "foundation", groups.fetch("bluetape4k-graph-core")
+      assert_equal "backends", groups.fetch("bluetape4k-graph-neo4j")
+      assert_equal "graph-io", groups.fetch("bluetape4k-graph-io-core")
+      assert_equal "frameworks", groups.fetch("bluetape4k-graph-spring-boot")
+      assert_equal "benchmarks", groups.fetch("graph-benchmark")
+      assert_equal "examples", groups.fetch("graph-examples")
+    end
+  end
+
+  private
+
+  def row(gradle_path, project_name, source_dir, kind)
+    {
+      "gradlePath" => gradle_path,
+      "projectName" => project_name,
+      "sourceDir" => source_dir,
+      "kind" => kind,
+    }
+  end
+end

--- a/scripts/manual/manual_contract.rb
+++ b/scripts/manual/manual_contract.rb
@@ -4,9 +4,10 @@ require "yaml"
 module ManualDocs
   SUPPORTED_SCHEMA_VERSION = 2
   VALID_KINDS = %w[library benchmark example].freeze
+  VALID_GROUPS = %w[foundation backends graph-io frameworks benchmarks examples].freeze
 
   class Validator
-    REQUIRED_FIELDS = %w[id gradlePath projectName sourceDir kind artifact status].freeze
+    REQUIRED_FIELDS = %w[id gradlePath projectName sourceDir kind group artifact status].freeze
     LOCALES = { "en" => "English", "ko" => "Korean" }.freeze
     attr_reader :errors
 
@@ -81,8 +82,12 @@ module ManualDocs
 
     def validate_entry(entry)
       errors = []
-      REQUIRED_FIELDS.each { |field| errors << "#{entry['id'] || 'module'}: missing manifest field #{field}" unless entry.key?(field) }
+      REQUIRED_FIELDS.each do |field|
+        missing = !entry.key?(field) || (field == "group" && entry[field].nil?)
+        errors << "#{entry['id'] || 'module'}: missing manifest field #{field}" if missing
+      end
       errors << "#{entry['id']}: invalid kind #{entry['kind'].inspect}" unless VALID_KINDS.include?(entry["kind"])
+      errors << "#{entry['id']}: invalid group #{entry['group'].inspect}" if !entry["group"].nil? && !VALID_GROUPS.include?(entry["group"])
       errors << "#{entry['id']}: library artifact must be present" if entry["kind"] == "library" && blank?(entry["artifact"])
       errors << "#{entry['id']}: #{entry['kind']} artifact must be null" if %w[benchmark example].include?(entry["kind"]) && !entry["artifact"].nil?
       errors << "#{entry['id']}: missing manifest field sourcePaths" if @strict && !entry.key?("sourcePaths")
@@ -90,7 +95,7 @@ module ManualDocs
         errors << "#{entry['id']}: sourcePaths must equal [sourceDir]"
       end
       errors.concat(validate_paths(entry, "sourcePaths")) if entry.key?("sourcePaths")
-      errors.concat(validate_routes(entry)) if entry.key?("routes") || @strict
+      errors.concat(validate_routes(entry)) if LOCALES.keys.any? { |locale| entry.key?(locale) } || @strict
       errors.concat(validate_assets(entry.fetch("assets", []), entry["id"]))
       errors
     end
@@ -139,7 +144,7 @@ module ManualDocs
     def validate_registered_documents(entries, locale_paths)
       manual_root = File.dirname(@manifest_path)
       LOCALES.keys.flat_map do |locale|
-        registered = Array(locale_paths[locale]) + entries.map { |entry| entry.dig("routes", locale) }.compact
+        registered = Array(locale_paths[locale]) + entries.map { |entry| entry[locale] }.compact
         actual = Dir.glob(File.join(manual_root, locale, "**/*.md")).map do |path|
           Pathname.new(path).relative_path_from(Pathname.new(manual_root)).to_s
         end
@@ -149,11 +154,9 @@ module ManualDocs
     end
 
     def validate_routes(entry)
-      routes = entry["routes"]
-      return ["#{entry['id']}: routes must be a mapping"] unless routes.is_a?(Hash)
       errors = []
       LOCALES.each do |locale, language|
-        path = routes[locale]
+        path = entry[locale]
         if blank?(path)
           errors << "#{entry['id']}: missing #{language} route"
           next
@@ -169,8 +172,8 @@ module ManualDocs
           errors.concat(validate_document_references(absolute, entry["id"]))
         end
       end
-      if routes["en"].is_a?(String) && routes["ko"].is_a?(String)
-        errors << "#{entry['id']}: English/Korean route differs" unless routes["en"].delete_prefix("en/") == routes["ko"].delete_prefix("ko/")
+      if entry["en"].is_a?(String) && entry["ko"].is_a?(String)
+        errors << "#{entry['id']}: English/Korean route differs" unless entry["en"].delete_prefix("en/") == entry["ko"].delete_prefix("ko/")
       end
       errors
     end

--- a/scripts/manual/manual_contract_test.rb
+++ b/scripts/manual/manual_contract_test.rb
@@ -14,7 +14,7 @@ class ManualContractTest < Minitest::Test
       FileUtils.mkdir_p(source)
       File.write(File.join(source, "build.gradle.kts"), "")
       row = { "id" => "core", "gradlePath" => ":core", "projectName" => "core", "sourceDir" => "graph/core",
-              "kind" => "library", "artifact" => "g:core", "status" => "stable" }.merge(module_overrides)
+              "kind" => "library", "group" => "foundation", "artifact" => "g:core", "status" => "stable" }.merge(module_overrides)
       manifest = { "schemaVersion" => 2, "repository" => "bluetape4k-graph", "releaseRef" => RELEASE["ref"],
                    "stableVersion" => RELEASE["ref"], "stableMinor" => "0.5", "releaseTag" => RELEASE["ref"],
                    "releaseCommit" => RELEASE["commit"], "publication" => { "manualVersion" => "0.5", "locales" => %w[en ko] },
@@ -32,7 +32,7 @@ class ManualContractTest < Minitest::Test
   end
 
   def test_rejects_missing_locale_route_when_routes_are_declared
-    validate("routes" => { "en" => "en/modules/core.md" }) { |validator| assert validator.errors.any? { |e| e.include?("missing Korean route") } }
+    validate("en" => "en/modules/core.md") { |validator| assert validator.errors.any? { |e| e.include?("missing Korean route") } }
   end
 
   def test_rejects_missing_source_file
@@ -41,6 +41,12 @@ class ManualContractTest < Minitest::Test
 
   def test_rejects_release_mismatch
     validate({}, "releaseRef" => "0.5.0") { |validator| assert validator.errors.any? { |e| e.include?("releaseRef must be 0.5.1") } }
+  end
+
+  def test_rejects_missing_blank_or_unknown_module_group
+    validate({ "group" => nil }) { |validator| assert validator.errors.any? { |e| e.include?("missing manifest field group") } }
+    validate({ "group" => "" }) { |validator| assert validator.errors.any? { |e| e.include?("invalid group") } }
+    validate({ "group" => "other" }) { |validator| assert validator.errors.any? { |e| e.include?("invalid group") } }
   end
 
   def test_rejects_missing_canonical_release_header
@@ -54,7 +60,8 @@ class ManualContractTest < Minitest::Test
 
   def test_strict_mode_requires_routes_and_source_paths
     validate({}, {}, strict: true) do |validator|
-      assert validator.errors.any? { |e| e.include?("routes must be a mapping") }
+      assert validator.errors.any? { |e| e.include?("missing English route") }
+      assert validator.errors.any? { |e| e.include?("missing Korean route") }
       assert validator.errors.any? { |e| e.include?("missing manifest field sourcePaths") }
     end
   end
@@ -90,7 +97,7 @@ class ManualContractTest < Minitest::Test
 
   def test_strict_mode_rejects_missing_declared_asset
     validate({
-      "routes" => { "en" => "en/modules/core.md", "ko" => "ko/modules/core.md" },
+      "en" => "en/modules/core.md", "ko" => "ko/modules/core.md",
       "sourcePaths" => ["graph/core/build.gradle.kts"],
       "assets" => ["assets/missing.svg"],
     }, {}, strict: true) do |validator|
@@ -101,7 +108,7 @@ class ManualContractTest < Minitest::Test
 
   def test_strict_mode_requires_complete_locale_matched_overview_documents
     validate({
-      "routes" => { "en" => "en/modules/core.md", "ko" => "ko/modules/core.md" },
+      "en" => "en/modules/core.md", "ko" => "ko/modules/core.md",
       "sourcePaths" => ["graph/core/build.gradle.kts"],
     }, {
       "overview" => { "documents" => { "en" => ["en/index.md"], "ko" => ["ko/getting-started.md"] }, "assets" => [] },
@@ -112,7 +119,7 @@ class ManualContractTest < Minitest::Test
 
   def test_strict_mode_rejects_unregistered_manual_document
     validate({
-      "routes" => { "en" => "en/modules/core.md", "ko" => "ko/modules/core.md" },
+      "en" => "en/modules/core.md", "ko" => "ko/modules/core.md",
       "sourcePaths" => ["graph/core/build.gradle.kts"],
     }, {
       "overview" => { "documents" => { "en" => ["en/index.md"], "ko" => ["ko/index.md"] }, "assets" => [] },
@@ -143,14 +150,13 @@ class ManualContractTest < Minitest::Test
         File.write(File.join(manual_root, locale, "benchmarks/age-and-neo4j.md"), "# comparison\n")
       end
       rows = [
-        { "id" => "age", "gradlePath" => ":age", "projectName" => "age", "sourceDir" => "benchmark/age", "kind" => "benchmark", "artifact" => nil, "status" => "stable" },
-        { "id" => "neo4j", "gradlePath" => ":neo4j", "projectName" => "neo4j", "sourceDir" => "benchmark/neo4j", "kind" => "benchmark", "artifact" => nil, "status" => "stable" },
+        { "id" => "age", "gradlePath" => ":age", "projectName" => "age", "sourceDir" => "benchmark/age", "kind" => "benchmark", "group" => "benchmarks", "artifact" => nil, "status" => "stable" },
+        { "id" => "neo4j", "gradlePath" => ":neo4j", "projectName" => "neo4j", "sourceDir" => "benchmark/neo4j", "kind" => "benchmark", "group" => "benchmarks", "artifact" => nil, "status" => "stable" },
       ]
       rows.each { |row| FileUtils.mkdir_p(File.join(root, row.fetch("sourceDir"))) }
       modules = rows.map do |row|
-        row.merge("sourcePaths" => [row.fetch("sourceDir")], "routes" => {
-          "en" => "en/benchmarks/age-and-neo4j.md", "ko" => "ko/benchmarks/age-and-neo4j.md",
-        })
+        row.merge("sourcePaths" => [row.fetch("sourceDir")],
+          "en" => "en/benchmarks/age-and-neo4j.md", "ko" => "ko/benchmarks/age-and-neo4j.md")
       end
       manifest = {
         "schemaVersion" => 2, "repository" => "bluetape4k-graph", "releaseRef" => RELEASE["ref"],


### PR DESCRIPTION
Fixes #390

Related publication work: bluetape4k/bluetape4k.github.io#221

## Why

The Graph manual source manifest used a nested locale route shape that the website snapshot pipeline could not consume. Graph also has one comparison guide intentionally shared by the AGE and Neo4j benchmark modules, so publication needs an explicit multi-owner document contract.

## What changed

- publish top-level en and ko route fields in the source manifest
- keep the generated JSON snapshot aligned with the YAML source
- classify Graph modules into six stable manual navigation groups
- require group and reject blank or unsupported values in the strict source validator
- regression-test every navigation group
- retain the source contract that permits multiple modules to share one comparison guide

The paired website change publishes a multi-owner document once as a neutral guide instead of assigning misleading ownership to either module.

## Regression evidence

- RED: build_graph_manifest_test rejected the missing top-level en field
- RED: manual_contract_test rejected an incomplete top-level locale pair
- RED: group contract test accepted missing, blank, and unsupported groups
- GREEN: all manual Ruby suites pass
- GREEN: strict 0.5.1 release validation passes with 31 source paths and 432 release links
- GREEN: the paired website snapshot sync completes for 104 documents, 10 assets, and 104 redirects

## Verification

- all scripts/manual/*_test.rb suites
- MANUAL_RELEASE_REF=0.5.1 MANUAL_RELEASE_COMMIT=3e0fa7cb9e3bc70c2743aeebda2487f3e45e4907 MANUAL_STRICT=1 ruby scripts/manual/validate_manuals.rb build/manual/release-module-inventory.json
- git diff --check
- GitHub CI run 29418744503

## DoD Status

- [x] Website-facing locale fields are explicit and regression-tested
- [x] Shared benchmark guide ownership is explicit across source and site contracts
- [x] Generated YAML and JSON manifests are aligned
- [x] Module groups are required, allowlisted, and fully classification-tested
- [x] Graph 0.5.1 release inventory passes strict validation
- [x] Paired local website snapshot sync succeeds
- [x] GitHub checks pass
- [x] PR is merged
