### PR TITLE
docs: lead the manual with core capabilities

### DIFF
--- a/docs/manual/en/index.md
+++ b/docs/manual/en/index.md
@@ -2,6 +2,15 @@
 
 This manual describes the stable `0.5.1` contract at commit `3e0fa7cb9e3bc70c2743aeebda2487f3e45e4907`. It covers the common model, paired synchronous/coroutine APIs, five supported backends, graph-io, and framework integration. Amazon Neptune is **not supported** in 0.5.1; backlog issues are not part of this contract.
 
+## Core capabilities
+
+- **Backend-independent graph model:** The [core model](architecture/core-model.md) gives every backend the same vertex, edge, path, and element-ID vocabulary.
+- **Synchronous and coroutine APIs:** [Paired APIs](architecture/paired-apis.md) keep repository, traversal, batch, merge, and transaction operations aligned across blocking and suspending execution.
+- **Five database backends:** The [backend selection guide](backends/selection-guide.md) compares Neo4j, Memgraph, Apache AGE, TinkerPop/TinkerGraph, and FalkorDB by query language, transaction behavior, and operational fit.
+- **Schema, traversal, and transactions:** [Schema and transactions](architecture/schema-and-transactions.md) explains labels, indexes, constraints, merge semantics, paths, and ownership boundaries.
+- **Graph import and export:** [graph-io formats](graph-io/formats.md), [execution models](graph-io/execution-model.md), and [OkIO security](graph-io/okio-security.md) cover CSV, NDJSON, GraphML, compression, and authenticated encryption.
+- **Application integration and examples:** [Spring Boot](frameworks/spring-boot.md), [Ktor](frameworks/ktor.md), and the [learning path](guides/learning-path.md) connect the common API to runnable domain examples and production checks.
+
 ## Start with a decision
 
 1. Follow [Getting started](getting-started.md) to import the ecosystem BOM and run one operation.

--- a/docs/manual/ko/index.md
+++ b/docs/manual/ko/index.md
@@ -2,6 +2,15 @@
 
 이 매뉴얼은 커밋 `3e0fa7cb9e3bc70c2743aeebda2487f3e45e4907`에서 출시한 안정 버전 `0.5.1`을 설명한다. 공통 모델, 동기·코루틴 API, 지원 백엔드 다섯 개, graph-io, 프레임워크 연동이 범위다. Amazon Neptune은 0.5.1에서 **지원하지 않는다**. 백로그 이슈도 현재 기능으로 다루지 않는다.
 
+## 핵심 기능
+
+- **백엔드 독립 그래프 모델:** [핵심 모델](architecture/core-model.md)에서 모든 백엔드가 같은 vertex, edge, path, element ID 규칙을 사용합니다.
+- **동기·코루틴 API:** [대응 API](architecture/paired-apis.md)가 저장소, 순회, 배치, merge, 트랜잭션 연산을 블로킹 실행과 일시 중단 실행에서 같은 구조로 제공합니다.
+- **다섯 가지 데이터베이스 백엔드:** [백엔드 선택 가이드](backends/selection-guide.md)에서 Neo4j, Memgraph, Apache AGE, TinkerPop/TinkerGraph, FalkorDB를 쿼리 언어, 트랜잭션 동작, 운영 조건으로 비교합니다.
+- **스키마·순회·트랜잭션:** [스키마와 트랜잭션](architecture/schema-and-transactions.md)에서 label, index, constraint, merge, path, 소유권 경계를 설명합니다.
+- **그래프 가져오기와 내보내기:** [graph-io 형식](graph-io/formats.md), [실행 모델](graph-io/execution-model.md), [OkIO 보안](graph-io/okio-security.md)으로 CSV, NDJSON, GraphML, 압축, 인증 암호화를 다룹니다.
+- **애플리케이션 연동과 예제:** [Spring Boot](frameworks/spring-boot.md), [Ktor](frameworks/ktor.md), [학습 경로](guides/learning-path.md)가 공통 API를 실행 가능한 도메인 예제와 운영 검증으로 연결합니다.
+
 ## 무엇부터 결정할까
 
 1. [시작하기](getting-started.md)에서 생태계 BOM을 불러오고 첫 연산을 실행한다.


### PR DESCRIPTION
## Summary

- Add bilingual Core capabilities and 핵심 기능 sections to the manual Home.
- Link each capability to an existing guide, architecture page, module, or example.
- Keep the repository manual as the canonical source consumed by the website publisher.

## Why

Readers should understand what bluetape4k-graph provides before choosing a learning path or browsing individual modules.

## Validation

- export_manifest.rb --check
- Ruby manual suite: 39 runs, 109 assertions, 0 failures and 0 errors
- git diff --check

## DoD Status

- [x] English and Korean capability sets have conceptual parity.
- [x] Korean copy was edited for natural technical flow.
- [x] Capability links resolve inside docs/manual.
- [x] Only canonical manual documentation changed.