### PR TITLE
Prevent invalid Maven publication models from catalog aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,14 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+      - name: Validate publication POMs
+        run: |
+          ruby scripts/publication/publication_pom_audit_test.rb
+          ruby scripts/publication/publication_pom_integration_test.rb
+          ./gradlew generatePomFileForBluetapeGraphPublication -PsnapshotVersion=-SNAPSHOT \
+            --no-daemon --no-configuration-cache --no-build-cache
+          ruby scripts/publication/validate_poms.rb
+
       - name: Detekt static analysis
         run: |
           for attempt in 1 2 3 4 5; do

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           gradle-version: wrapper
           cache-read-only: true
+      - name: Validate publication POMs
+        run: |
+          ./gradlew generatePomFileForBluetapeGraphPublication -PsnapshotVersion=-SNAPSHOT \
+            --no-daemon --no-configuration-cache --no-build-cache
+          ruby scripts/publication/validate_poms.rb
+
       - name: Publish SNAPSHOT
         run: |
           ./gradlew publishAggregationToCentralSnapshots -PsnapshotVersion=-SNAPSHOT \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
             "bluetape4k-bom"
             "bluetape4k-exposed-bom"
             "exposed-plugin"
+            "spring-boot4-dependencies"
           )
 
           echo "Fetching bluetape4k-dependencies catalog: $catalog_url"
@@ -142,7 +143,7 @@ jobs:
           done
 
           echo "Verified catalog aliases from ${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}:"
-          grep -E '^[[:space:]]*(bluetape4k-bom|bluetape4k-exposed-bom|exposed-plugin)[[:space:]]*=' "$catalog_file"
+          grep -E '^[[:space:]]*(bluetape4k-bom|bluetape4k-exposed-bom|exposed-plugin|spring-boot4-dependencies)[[:space:]]*=' "$catalog_file"
 
       - name: Verify gradle.properties matches tag
         shell: bash
@@ -208,6 +209,12 @@ jobs:
           print(f"SIGNING_KEY source={source} normalized_length={len(normalized_key)}")
           print(f"SIGNING_KEY armored={'BEGIN PGP PRIVATE KEY BLOCK' in normalized_key}")
           PY
+
+      - name: Validate publication POMs
+        run: |
+          ./gradlew generatePomFileForBluetapeGraphPublication \
+            --no-daemon --no-configuration-cache --no-build-cache
+          ruby scripts/publication/validate_poms.rb
 
       - name: Publish to Central Portal
         run: >

--- a/docs/lessons/2026-05-17-central-release-pom-metadata.md
+++ b/docs/lessons/2026-05-17-central-release-pom-metadata.md
@@ -25,3 +25,12 @@ and no `SNAPSHOT` references.
 Release branches must not reference bluetape4k `-SNAPSHOT` coordinates in
 catalog versions, direct dependency versions, or generated POM dependency
 management.
+
+## 2026-07-17 Follow-up
+
+A repository-wide snapshot audit found that this rule must be executable rather
+than a manual release check. Published BOM imports now use versioned central
+`bt4k` aliases, and `scripts/publication/validate_poms.rb` checks every
+generated POM both structurally and through Maven effective-model construction.
+Regular dependencies may remain versionless only when Maven can resolve them
+through the same POM's dependency management or a versioned imported BOM.

--- a/scripts/publication/maven-settings.xml
+++ b/scripts/publication/maven-settings.xml
@@ -1,0 +1,24 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <profiles>
+    <profile>
+      <id>publication-pom-audit</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <releases><enabled>true</enabled></releases>
+          <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
+          <id>central-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <releases><enabled>false</enabled></releases>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>publication-pom-audit</activeProfile>
+  </activeProfiles>
+</settings>

--- a/scripts/publication/publication_pom_audit.rb
+++ b/scripts/publication/publication_pom_audit.rb
@@ -1,0 +1,67 @@
+require "rexml/document"
+require "set"
+
+module Publication
+  class PomAudit
+    Result = Struct.new(:errors, :file_count, :dependency_count, keyword_init: true)
+
+    def initialize(paths)
+      @paths = Array(paths).map { |path| File.expand_path(path) }.sort
+    end
+
+    def validate
+      return Result.new(errors: ["no publication POM files found"], file_count: 0, dependency_count: 0) if @paths.empty?
+
+      errors = []
+      dependency_count = 0
+
+      @paths.each do |path|
+        document = REXML::Document.new(File.read(path))
+        managed_dependencies = REXML::XPath.match(
+          document,
+          "/project/dependencyManagement/dependencies/dependency",
+        )
+        managed_versions = managed_dependencies.each_with_object(Set.new) do |dependency, result|
+          version = dependency.elements["version"]&.text.to_s.strip
+          result << coordinate(dependency) unless version.empty?
+        end
+        has_versioned_bom_import = managed_dependencies.any? do |dependency|
+          version = dependency.elements["version"]&.text.to_s.strip
+          type = dependency.elements["type"]&.text.to_s.strip
+          scope = dependency.elements["scope"]&.text.to_s.strip
+          !version.empty? && type == "pom" && scope == "import"
+        end
+
+        managed_dependencies.each do |dependency|
+          dependency_count += 1
+          next unless dependency.elements["version"]&.text.to_s.strip.empty?
+
+          errors << "#{path}: missing dependency version: #{coordinate(dependency)}"
+        end
+
+        REXML::XPath.each(document, "/project/dependencies/dependency") do |dependency|
+          dependency_count += 1
+          version = dependency.elements["version"]&.text.to_s.strip
+          dependency_coordinate = coordinate(dependency)
+          next unless version.empty?
+          next if managed_versions.include?(dependency_coordinate)
+          next if has_versioned_bom_import
+
+          errors << "#{path}: missing dependency version: #{dependency_coordinate}"
+        end
+      rescue REXML::ParseException => error
+        errors << "#{path}: invalid XML: #{error.message.lines.first.to_s.strip}"
+      end
+
+      Result.new(errors: errors.sort, file_count: @paths.length, dependency_count: dependency_count)
+    end
+
+    private
+
+    def coordinate(dependency)
+      group = dependency.elements["groupId"]&.text.to_s.strip
+      artifact = dependency.elements["artifactId"]&.text.to_s.strip
+      "#{group}:#{artifact}"
+    end
+  end
+end

--- a/scripts/publication/publication_pom_audit_test.rb
+++ b/scripts/publication/publication_pom_audit_test.rb
@@ -1,0 +1,85 @@
+require "fileutils"
+require "minitest/autorun"
+require "tmpdir"
+
+require_relative "publication_pom_audit"
+
+class PublicationPomAuditTest < Minitest::Test
+  def test_accepts_dependencies_with_explicit_versions
+    with_pom(<<~XML) do |path|
+      <project><dependencies><dependency>
+        <groupId>org.example</groupId><artifactId>example-core</artifactId><version>1.2.3</version>
+      </dependency></dependencies></project>
+    XML
+      result = Publication::PomAudit.new([path]).validate
+      assert_empty result.errors
+      assert_equal 1, result.file_count
+      assert_equal 1, result.dependency_count
+    end
+  end
+
+  def test_rejects_versionless_regular_and_managed_dependencies
+    with_pom(<<~XML) do |path|
+      <project>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-bom</artifactId>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      errors = Publication::PomAudit.new([path]).validate.errors
+      assert_equal 2, errors.length
+      assert errors.any? { |error| error.end_with?("missing dependency version: org.example:example-bom") }
+      assert errors.any? { |error| error.end_with?("missing dependency version: org.example:example-core") }
+    end
+  end
+
+  def test_accepts_a_versionless_dependency_managed_by_the_same_pom
+    with_pom(<<~XML) do |path|
+      <project>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId><version>1.2.3</version>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      assert_empty Publication::PomAudit.new([path]).validate.errors
+    end
+  end
+
+  def test_accepts_a_versionless_dependency_when_a_versioned_bom_is_imported
+    with_pom(<<~XML) do |path|
+      <project>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-bom</artifactId><version>1.2.3</version>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.example</groupId><artifactId>example-core</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      assert_empty Publication::PomAudit.new([path]).validate.errors
+    end
+  end
+
+  def test_fails_closed_when_no_publication_poms_exist
+    result = Publication::PomAudit.new([]).validate
+    assert_equal ["no publication POM files found"], result.errors
+  end
+
+  private
+
+  def with_pom(content)
+    Dir.mktmpdir("publication-pom-audit") do |root|
+      path = File.join(root, "pom-default.xml")
+      File.write(path, content)
+      yield path
+    end
+  end
+end

--- a/scripts/publication/publication_pom_integration_test.rb
+++ b/scripts/publication/publication_pom_integration_test.rb
@@ -1,0 +1,69 @@
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+class PublicationPomIntegrationTest < Minitest::Test
+  def test_maven_rejects_a_dependency_not_managed_by_the_imported_bom
+    with_pom(<<~XML) do |path|
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.example</groupId>
+        <artifactId>unmanaged-dependency</artifactId>
+        <version>1</version>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.junit</groupId><artifactId>junit-bom</artifactId><version>5.10.2</version>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      output, status = validate(path)
+      refute status.success?
+      assert_includes output, "'dependencies.dependency.version' for org.slf4j:slf4j-api:jar is missing"
+    end
+  end
+
+  def test_maven_accepts_a_dependency_managed_by_the_imported_bom
+    with_pom(<<~XML) do |path|
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.example</groupId>
+        <artifactId>managed-dependency</artifactId>
+        <version>1</version>
+        <dependencyManagement><dependencies><dependency>
+          <groupId>org.junit</groupId><artifactId>junit-bom</artifactId><version>5.10.2</version>
+          <type>pom</type><scope>import</scope>
+        </dependency></dependencies></dependencyManagement>
+        <dependencies><dependency>
+          <groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-api</artifactId>
+        </dependency></dependencies>
+      </project>
+    XML
+      output, status = validate(path)
+      assert status.success?, output
+      assert_includes output, "maven_models=1"
+    end
+  end
+
+  private
+
+  def validate(path)
+    stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby,
+      File.expand_path("validate_poms.rb", __dir__),
+      path,
+    )
+    [stdout + stderr, status]
+  end
+
+  def with_pom(content)
+    Dir.mktmpdir("publication-pom-integration") do |root|
+      path = File.join(root, "pom.xml")
+      File.write(path, content)
+      yield path
+    end
+  end
+end

--- a/scripts/publication/validate_poms.rb
+++ b/scripts/publication/validate_poms.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+require_relative "publication_pom_audit"
+
+paths = if ARGV.empty?
+          Dir.glob("**/build/publications/*/pom-default.xml")
+            .reject { |path| path.start_with?(".worktrees/") }
+        else
+          ARGV
+        end
+
+result = Publication::PomAudit.new(paths).validate
+unless result.errors.empty?
+  warn(result.errors.join("\n"))
+  abort("publication-poms: failures=#{result.errors.length} files=#{result.file_count} dependencies=#{result.dependency_count}")
+end
+
+settings = File.expand_path("maven-settings.xml", __dir__)
+
+Dir.mktmpdir("publication-pom-reactor") do |reactor|
+  modules = paths.sort.each_with_index.map do |path, index|
+    module_name = format("module-%03d", index + 1)
+    module_dir = File.join(reactor, module_name)
+    FileUtils.mkdir_p(module_dir)
+    FileUtils.cp(File.expand_path(path), File.join(module_dir, "pom.xml"))
+    module_name
+  end
+
+  File.write(
+    File.join(reactor, "pom.xml"),
+    <<~XML,
+      <project xmlns="http://maven.apache.org/POM/4.0.0">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>io.github.bluetape4k.validation</groupId>
+        <artifactId>publication-pom-reactor</artifactId>
+        <version>1</version>
+        <packaging>pom</packaging>
+        <modules>
+      #{modules.map { |name| "    <module>#{name}</module>" }.join("\n")}
+        </modules>
+      </project>
+    XML
+  )
+
+  command = [
+    ENV.fetch("MAVEN_COMMAND", "mvn"),
+    "-U", "-q", "-s", settings,
+    "-f", File.join(reactor, "pom.xml"),
+    "validate",
+  ]
+  stdout, stderr, status = Open3.capture3(*command)
+  unless status.success?
+    diagnostics = (stdout + stderr).lines.grep(/\[ERROR\]/).first(40)
+    warn(diagnostics.empty? ? stdout + stderr : diagnostics.join)
+    abort("publication-poms: Maven effective-model validation failed")
+  end
+rescue Errno::ENOENT => error
+  abort("publication-poms: Maven executable not found: #{error.message}")
+end
+
+puts "publication-poms: failures=0 files=#{result.file_count} dependencies=#{result.dependency_count} maven_models=#{result.file_count}"

--- a/spring-boot/graph-spring-boot/build.gradle.kts
+++ b/spring-boot/graph-spring-boot/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(platform(libs.spring.boot4.dependencies))
+    implementation(platform(bt4k.spring.boot4.dependencies))
 
     // graph-core는 api로 전이 노출 — GraphOperations 등 공개 API 타입이 전이 노출 필요
     api(project(":bluetape4k-graph-core"))


### PR DESCRIPTION
## Summary

This PR prevents catalog aliases from producing incomplete Maven publication metadata.

## Background

The Spring Boot 4 platform alias could configure in Gradle without guaranteeing a complete published Maven model.

## What This Solves

- Publication POM correctness is verified as a Maven consumer contract, not inferred from Gradle resolution.
- Snapshot, release, and CI paths fail closed when generated metadata is incomplete.

## Work Done

- Use the central Spring Boot 4 catalog version in the published graph module.
- Add structural POM auditing, Maven model validation, and CI/snapshot/release gates.

## Validation

- Ruby audit: 5 tests / 12 assertions: PASS
- Maven integration: 2 tests / 6 assertions: PASS
- Publication contract: 15 POMs, 1,705 dependency entries, 15 Maven models: PASS
- ./gradlew build -x test: PASS: PASS
- ./gradlew :bluetape4k-graph-spring-boot:test: PASS: PASS
- actionlint on changed workflows: PASS: PASS

## Review Notes

- P0/P1: 0
- P2/P3: fixed during local review; no open findings
- Review evidence: independent local review plus the complete cross-repository publication gate

## Metadata

- Issue: N/A - cross-repository defect correction requested directly
- PR: #394, head `ed1c3dbcca473baacca55abcb4b0177bc52075fd`, base `develop`, assignee `debop`
- CI: PENDING on the exact PR head

## DoD Status

Required checks: 18/18; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 to CG-10 | Scope, implement, review, and verify the branch | PASS | Clean Lore commit `ed1c3dbcca473baacca55abcb4b0177bc52075fd`; local validation above | none |
| CG-11 | Confirm PR authority and exact base/head | PASS | User requested PR delivery for every changed repo; base `develop` | none |
| CG-12 | Push and read back exact head | PASS | Local and remote head `ed1c3dbcca473baacca55abcb4b0177bc52075fd` | none |
| CG-13 | Create and verify PR metadata | PASS | https://github.com/bluetape4k/bluetape4k-graph/pull/394; head `ed1c3dbcca473baacca55abcb4b0177bc52075fd`; assignee `debop` | none |
| CG-14 | Pass CI and live review | PASS | 15 successful checks; mergeable; unresolved review threads 0 | none |
| CG-15 | Report exact-head merge readiness | PASS | PR #394 at `ed1c3dbcca473baacca55abcb4b0177bc52075fd`; checks/review evidence reported to user | none |
| CG-16 | Obtain fresh merge approval | PASS | User replied `승인` after the exact-head merge-ready report | none |
| CG-17 | Execute and verify squash merge | PASS | PR #394 merged as `500f16f21205e15b101a779c8087646324c097a9`; tested head `ed1c3dbcca473baacca55abcb4b0177bc52075fd` | none |
| CG-18 | Synchronize local develop | PASS | Local and `origin/develop` at `500f16f21205e15b101a779c8087646324c097a9`; merge tree equals tested head tree | Local feature branch preserved; no unrelated worktree cleanup |

Final status: DONE

Unchecked required items: none