### PR TITLE
build: adopt projects 1.12.0 snapshot catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '2646d2cd2d4ecc09654c2ac6ef11cfd6679f1086'
+  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '691e1794f7fd5744a14c39234d1230eee32a3b97'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ val baseProjectName = "bluetape4k"
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("2646d2cd2d4ecc09654c2ac6ef11cfd6679f1086")
+    .orElse("691e1794f7fd5744a14c39234d1230eee32a3b97")
     .get()
 require(bluetape4kDependenciesCatalogRef.matches(Regex("[0-9a-f]{40}|[0-9a-f]{64}"))) {
     "bluetape4k-dependencies catalog ref must be an immutable Git commit SHA: " +


### PR DESCRIPTION
## Summary

Pins this repository's central build catalog to immutable commit `691e1794f7fd5744a14c39234d1230eee32a3b97`, which selects the corrected public projects `1.12.0-SNAPSHOT`.

## Background

The previous catalog commit selected projects `1.11.1-SNAPSHOT`. Projects PR #1046 repaired the Gradle Module Metadata contract, and public build `1.12.0-20260718.030942-6` now exposes all 75 expected artifacts without versionless Jackson 3 API dependencies.

## What This Solves

- Aligns local settings and CI with the same immutable central catalog source.
- Moves this consumer to the verified projects `1.12.0-SNAPSHOT` metadata contract.
- Keeps dependency authority centralized instead of adding repo-local version overrides.

## Work Done

- Replaced the previous central catalog SHA in `settings.gradle.kts`.
- Replaced the same SHA in `.github/workflows/ci.yml`.
- Rebased the single scoped commit onto current `origin/develop`.

## Validation

- `./gradlew build -x test --refresh-dependencies --no-daemon --no-configuration-cache`: PASS (153 actionable tasks)
- no-override fresh-cache `./gradlew help --refresh-dependencies`: PASS against remote catalog commit `691e1794...`
- `actionlint`: PASS
- `git diff --check`: PASS
- central adoption guard: PASS
- cross-repository publication-POM gate: PASS (9 repositories, 175 POMs, 46,011 dependencies, 175 Maven models, failures=0)

## Review Notes

- P0/P1: 0
- P2/P3: none known
- Review evidence: exact two-file diff, full repository build, remote catalog resolution, and cross-repository Maven model validation

## Metadata

- Issue/milestone: N/A; this is an internal catalog-train consumer alignment with no linked issue
- PR: current PR, head `d91cc1a99a95e3ddcb1e1fd6e898bf4f63bf4be6`, base `develop`, assignee `debop`, label `dependencies`
- CI: exact-head checks PASS; live review/comment audit clean

## DoD Status

Required checks: 8/8; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| Central prerequisite | Verify corrected producer snapshot and catalog content | PASS | public build 6; raw catalog/checksum HTTP 200 | none |
| Scoped change | Keep settings and CI on one immutable SHA | PASS | exactly two files and two matching replacements | none |
| Local validation | Build the rebased exact head | PASS | full build, 153 actionable tasks | none |
| Remote catalog path | Resolve the declared SHA without a local override | PASS | fresh-cache Gradle help | none |
| Branch publication | Push and read back the exact head | PASS | local/remote `d91cc1a99a95e3ddcb1e1fd6e898bf4f63bf4be6` | none |
| PR metadata | Create and verify base/head/assignee/label/body | PASS | live read-back follows creation | repair before CI progression |
| CI/review | Pass exact-head checks and live review audit | PASS | exact-head checks pass; 0 reviews/comments | none |
| Merge | Merge this exact head | PASS | approved exact head; squash commit `22ce148ed7853d89315ad59ecea6178966c6d4b2` | none |
| Cleanup | Delete branch/worktree | N/A | cleanup is not authorized | preserve state |

Final status: COMPLETE

Unchecked required items: none
